### PR TITLE
Add support for the GNU/Hurd architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ LIB=lib
 INSTALL=install
 MKDIR=mkdir
 
-ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu"))
+ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
 
   ifeq ($(ARCH),x86_64)
     LIB=lib64

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -169,14 +169,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 //================================================================= LINUX ===
 
-#if defined(__linux__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 
 #include <endian.h>
 
 #if defined(__linux__)
 #define OS_STRING "linux"
-#else
+#elif defined(__FreeBSD_kernel__)
 #define OS_STRING "kFreeBSD"
+#else
+#define OS_STRING "GNU"
 #endif
 
 #define ID_INLINE inline


### PR DESCRIPTION
[As with GNU/kFreeBSD, it's treated as "Linux": all three use the GNU libc
and runtime linker, which is mostly what matters for ioquake3. -smcv]

Bug-Debian: http://bugs.debian.org/679330
Reviewed-by: Simon McVittie <smcv@debian.org>