### PR TITLE
MSVC/C89 Fix

### DIFF
--- a/code/renderergl2/tr_bsp.c
+++ b/code/renderergl2/tr_bsp.c
@@ -3361,7 +3361,7 @@ void RE_LoadWorldMap( const char *name ) {
 		int lightGridSize;
 		int i;
 
-        w = &s_worldData;
+		w = &s_worldData;
 
 		lightGridSize = w->lightGridBounds[0] * w->lightGridBounds[1] * w->lightGridBounds[2];
 		primaryLightGrid = ri.Malloc(lightGridSize * sizeof(*primaryLightGrid));


### PR DESCRIPTION
This fix allows tr_bsp.c to compile under a C89 compiler like MSVC.  Without this, you will receive the following error:

```
error C2275: 'uint8_t' : illegal use of this type as an expression
```
