### PR TITLE
Misc fixes to renderer2 to correctly use sizeof(glIndex_t)

### DIFF
--- a/code/renderergl2/tr_shade.c
+++ b/code/renderergl2/tr_shade.c
@@ -44,9 +44,9 @@ R_DrawElements
 void R_DrawElementsVBO( int numIndexes, glIndex_t firstIndex, glIndex_t minIndex, glIndex_t maxIndex )
 {
 	if (glRefConfig.drawRangeElements)
-		qglDrawRangeElementsEXT(GL_TRIANGLES, minIndex, maxIndex, numIndexes, GL_INDEX_TYPE, BUFFER_OFFSET(firstIndex * sizeof(GL_INDEX_TYPE)));
+		qglDrawRangeElementsEXT(GL_TRIANGLES, minIndex, maxIndex, numIndexes, GL_INDEX_TYPE, BUFFER_OFFSET(firstIndex * sizeof(glIndex_t)));
 	else
-		qglDrawElements(GL_TRIANGLES, numIndexes, GL_INDEX_TYPE, BUFFER_OFFSET(firstIndex * sizeof(GL_INDEX_TYPE)));
+		qglDrawElements(GL_TRIANGLES, numIndexes, GL_INDEX_TYPE, BUFFER_OFFSET(firstIndex * sizeof(glIndex_t)));
 	
 }
 

--- a/code/renderergl2/tr_sky.c
+++ b/code/renderergl2/tr_sky.c
@@ -468,7 +468,7 @@ static void DrawSkySide( struct image_s *image, const int mins[2], const int max
 
 	R_DrawElementsVBO(tess.numIndexes - tess.firstIndex, tess.firstIndex, tess.minIndex, tess.maxIndex);
 
-	//qglDrawElements(GL_TRIANGLES, tess.numIndexes - tess.firstIndex, GL_INDEX_TYPE, BUFFER_OFFSET(tess.firstIndex * sizeof(GL_INDEX_TYPE)));
+	//qglDrawElements(GL_TRIANGLES, tess.numIndexes - tess.firstIndex, GL_INDEX_TYPE, BUFFER_OFFSET(tess.firstIndex * sizeof(glIndex_t)));
 	
 	//R_BindNullVBO();
 	//R_BindNullIBO();

--- a/code/renderergl2/tr_surface.c
+++ b/code/renderergl2/tr_surface.c
@@ -437,8 +437,8 @@ static qboolean RB_SurfaceVbo(VBO_t *vbo, IBO_t *ibo, int numVerts, int numIndex
 	// merge this into any existing multidraw primitives
 	mergeForward = -1;
 	mergeBack = -1;
-	firstIndexOffset = BUFFER_OFFSET(firstIndex * sizeof(GL_INDEX_TYPE));
-	lastIndexOffset  = BUFFER_OFFSET((firstIndex + numIndexes) * sizeof(GL_INDEX_TYPE));
+	firstIndexOffset = BUFFER_OFFSET(firstIndex * sizeof(glIndex_t));
+	lastIndexOffset  = BUFFER_OFFSET((firstIndex + numIndexes) * sizeof(glIndex_t));
 
 	if (r_mergeMultidraws->integer)
 	{

--- a/code/renderergl2/tr_vbo.c
+++ b/code/renderergl2/tr_vbo.c
@@ -506,12 +506,11 @@ IBO_t          *R_CreateIBO2(const char *name, int numTriangles, srfTriangle_t *
 	IBO_t          *ibo;
 	int             i, j;
 
-	byte           *indexes;
+	glIndex_t       *indexes;
 	int             indexesSize;
-	int             indexesOfs;
+	int             indexesCount;
 
 	srfTriangle_t  *tri;
-	glIndex_t       index;
 	int				glUsage;
 
 	switch (usage)
@@ -548,17 +547,15 @@ IBO_t          *R_CreateIBO2(const char *name, int numTriangles, srfTriangle_t *
 
 	Q_strncpyz(ibo->name, name, sizeof(ibo->name));
 
-	indexesSize = numTriangles * 3 * sizeof(int);
+	indexesSize = numTriangles * 3 * sizeof(glIndex_t);
 	indexes = ri.Hunk_AllocateTempMemory(indexesSize);
-	indexesOfs = 0;
+	indexesCount = 0;
 
 	for(i = 0, tri = triangles; i < numTriangles; i++, tri++)
 	{
 		for(j = 0; j < 3; j++)
 		{
-			index = tri->indexes[j];
-			memcpy(indexes + indexesOfs, &index, sizeof(glIndex_t));
-			indexesOfs += sizeof(glIndex_t);
+			indexes[indexesCount++] = tri->indexes[j];
 		}
 	}
 


### PR DESCRIPTION
While doing the WebGL port I had the need to use ushort index buffers and ran across this.
