### PR TITLE
Fix building using old MSYS installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1241,7 +1241,9 @@ endif
 	$(call print_wrapped, $(SERVER_CFLAGS))
 	@echo ""
 	@echo "  LDFLAGS:"
+ifneq ($(LDFLAGS),)
 	$(call print_wrapped, $(LDFLAGS))
+endif
 	@echo ""
 	@echo "  LIBS:"
 	$(call print_wrapped, $(LIBS))


### PR DESCRIPTION
Make errored about empty for loop in print_list and quit building.

```
/bin/sh.exe: -c: line 1: syntax error near unexpected token `;'
/bin/sh.exe: -c: line 1: `for i in  ; do echo "    $i"; done'
```

Might be better to fix print_list, but I don't know how.