### PR TITLE
Fixed incorrectly referenced depth buffer image for SSAO shader.

### DIFF
--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -1196,7 +1196,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 			GLSL_BindProgram(&tr.ssaoShader);
 
-			GL_BindToTMU(tr.hdrDepthImage, TB_COLORMAP);
+			GL_BindToTMU(tr.renderDepthImage, TB_COLORMAP);
 
 			{
 				vec4_t viewInfo;


### PR DESCRIPTION
The wrong image is used for the SSAO shader.  The shader expects the screens depth buffer image, not the HDR depth image.  Without this fix, SSAO will not work.
