### PR TITLE
Added support for IQM int/float encoded blend indices and weights. This makes it possible to import IQM files from Noesis.

### DIFF
--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -616,10 +616,21 @@ typedef struct {
 	float		*texcoords;
 	float		*normals;
 	float		*tangents;
-	byte		*blendIndexes;
-	byte		*blendWeights;
+	union {
+		int		*i;
+		byte	*b;
+	} blendIndexes;
+	union {
+		float	*f;
+		byte	*b;
+	} blendWeights;
 	byte		*colors;
-	int		*triangles;
+	int			*triangles;
+
+	// depending upon the exporter, blend indices and weights might be int/float
+	// as opposed to the recommended byte/byte, for example Noesis exports
+	// int/float whereas the official IQM tool exports byte/byte
+	qboolean	blendTypesIntFloat;
 
 	int		*jointParents;
 	float		*jointMats;

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1142,10 +1142,21 @@ typedef struct {
 	float		*texcoords;
 	float		*normals;
 	float		*tangents;
-	byte		*blendIndexes;
-	byte		*blendWeights;
+	union {
+		int		*i;
+		byte	*b;
+	} blendIndexes;
+	union {
+		float	*f;
+		byte	*b;
+	} blendWeights;
 	byte		*colors;
-	int		*triangles;
+	int			*triangles;
+
+	// depending upon the exporter, blend indices and weights might be int/float
+	// as opposed to the recommended byte/byte, for example Noesis exports
+	// int/float whereas the official IQM tool exports byte/byte
+	qboolean	blendTypesIntFloat;
 
 	int		*jointParents;
 	float		*jointMats;


### PR DESCRIPTION
I've updated both gl1 and gl2 renderers so they can import IQM files exported from Noesis.  Although the official IQM spec recommends indices and weights encoded as bytes, Noesis exports them as ints and floats (respectively).  This patch allows the IQM loader to account for both cases.
