### PR TITLE
Check if dest is src before strncpy in Q_strncpyz.

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -789,6 +789,10 @@ void Q_strncpyz( char *dest, const char *src, int destsize ) {
 		Com_Error(ERR_FATAL,"Q_strncpyz: destsize < 1" ); 
 	}
 
+        if (src == dest) {
+          return;
+        }
+    
 	strncpy( dest, src, destsize-1 );
   dest[destsize-1] = 0;
 }


### PR DESCRIPTION
I stumbled into this after updating MacOSX to 10.9 (Mavericks). IOQuake3, XreaL and ETLegacy where crashing after the update. This commit checks if we try to copy a string with same src and dest. More info here:
http://dev.etlegacy.com/issues/385
GDB output here (line 15):
http://pastebin.com/qGm4WvMM
