### PR TITLE
Don't forget to install the renderer2 binary if USE_RENDERER_DLOPEN=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2701,6 +2701,10 @@ ifneq ($(BUILD_CLIENT),0)
     ifneq ($(BUILD_RENDERER_OPENGL2),0)
 	$(INSTALL) $(STRIP_FLAG) -m 0755 $(BR)/renderer_opengl2_$(SHLIBNAME) $(COPYBINDIR)/renderer_opengl2_$(SHLIBNAME)
     endif
+  else
+    ifneq ($(BUILD_RENDERER_OPENGL2),0)
+	$(INSTALL) $(STRIP_FLAG) -m 0755 $(BR)/$(CLIENTBIN)_opengl2$(FULLBINEXT) $(COPYBINDIR)/$(CLIENTBIN)_opengl2$(FULLBINEXT)
+    endif
   endif
 endif
 


### PR DESCRIPTION
If BUILD_RENDERER_OPENGL2=1 and USE_RENDERER_DLOPEN=0, then "make copyfiles" does not install the second binary.
