### PR TITLE
workaround for undefined strncpy behavior when src and dest are the same

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -75,11 +75,18 @@ COM_StripExtension
 */
 void COM_StripExtension( const char *in, char *out, int destsize )
 {
-	const char *dot = strrchr(in, '.'), *slash;
-	if (dot && (!(slash = strrchr(in, '/')) || slash < dot))
-		Q_strncpyz(out, in, (destsize < dot-in+1 ? destsize : dot-in+1));
-	else
+	const char *dot;
+	const char *slash;
+
+	dot = strrchr(in, '.');
+
+	if (dot && (!(slash = strrchr(in, '/')) || slash < dot)) {
+		char temp[MAX_OSPATH];
+		Q_strncpyz(temp, in, (MAX_OSPATH < dot-in+1 ? MAX_OSPATH : dot-in+1));
+		Q_strncpyz(out, temp, destsize);
+	} else if (out != in) {
 		Q_strncpyz(out, in, destsize);
+	}
 }
 
 /*


### PR DESCRIPTION
Just tried building on Mac OSX 10.9 Mavericks and hit a crash while loading a map as Apple's libc implementation is now asserting if src == dest for strncpy.

It seems this has always been undefined behavior, but it worked I suppose.

I found another thread of someone else having the same issue:

http://postgresql.1045698.n5.nabble.com/OSX-doesn-t-accept-identical-source-target-for-strcpy-anymore-td5776101.html
