### PR TITLE
validate framebuffers are in use before adjusting state

### DIFF
--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -501,7 +501,7 @@ void RB_BeginDrawingView (void) {
 	}
 
 	// clear to black for cube maps
-	if (backEnd.viewParms.targetFbo == tr.renderCubeFbo)
+	if (glRefConfig.framebufferObject && backEnd.viewParms.targetFbo == tr.renderCubeFbo)
 	{
 		clearBits |= GL_COLOR_BUFFER_BIT;
 		qglClearColor( 0.0f, 0.0f, 0.0f, 1.0f );


### PR DESCRIPTION
If GL_EXT_framebuffer_object fails to load, `tr.renderCubeFbo` will be left NULL, causing unexpected clearing inside of RB_BeginDrawingView.
