### PR TITLE
don't clear screen during CA_LOADING and CA_PRIMED

### DIFF
--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -481,7 +481,7 @@ void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 
 	// wide aspect ratio screens need to have the sides cleared
 	// unless they are displaying game renderings
-	if ( uiFullscreen || (clc.state != CA_ACTIVE && clc.state != CA_CINEMATIC) ) {
+	if ( uiFullscreen || clc.state < CA_LOADING ) {
 		if ( cls.glconfig.vidWidth * 480 > cls.glconfig.vidHeight * 640 ) {
 			re.SetColor( g_color_table[0] );
 			re.DrawStretchPic( 0, 0, cls.glconfig.vidWidth, cls.glconfig.vidHeight, 0, 0, 0, 0, cls.whiteShader );


### PR DESCRIPTION
Just as it currently doesn't clear for CA_ACTIVE, we also should not be clearing for CA_LOADING and CA_PRIMED (in other words, anytime CG_DrawActiveFrame is called). During these states, trap_UpdateScreen may be called to perform an explicit partial flush, and we shouldn't clear the existing screen when this happens.

It perhaps makes more sense to add a boolean to SCR_UpdateScreen that indicates if this is an explicit partial flush or not (and only clear if not), but I wanted to be conservative with what was changed.

This issue currently manifests itself when loading levels with Q3F with a widescreen resolution:

`+set fs_game q3f2 +set r_mode -1 +set r_customWidth 1024 +set r_customHeight 512 +map q3f_2stag2`

Vanilla Q3 calls trap_UpdateScreen throughout CG_Init, which will clear the screen, and re-draw the loading screen as part of CL_CGameRendering.

Q3F is a bit different. It draws its UI menus throughout CG_Init and calls trap_UpdateScreen to flush the changes, but calling CL_CGameRendering while loading doesn't actually cause anything to be drawn. This results in the UI being drawn over by the screen clear, and only a black screen being rendered during level load.
