### PR TITLE
Fix check for jpeg_mem_ to work with libjpeg-turbo

### DIFF
--- a/code/renderercommon/tr_image_jpg.c
+++ b/code/renderercommon/tr_image_jpg.c
@@ -37,8 +37,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <jpeglib.h>
 
 #ifndef USE_INTERNAL_JPEG
-#  if JPEG_LIB_VERSION < 80
-#    error Need system libjpeg >= 80
+#  if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
+#    error Need system libjpeg >= 80 or jpeg_mem_ support
 #  endif
 #endif
 


### PR DESCRIPTION
ioq3 does not really depend on the v8 libjpeg API except for the jpeg_mem_\* functions. Those are present with e.g. libjpeg-turbo (v6 API) as well.

Related Gentoo issue https://bugs.gentoo.org/show_bug.cgi?id=479502#c6
