### PR TITLE
don't restart renderer in SV_SpawnServer

### DIFF
--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -422,11 +422,6 @@ void SV_SpawnServer( char *server, qboolean killBots ) {
 	// clear the whole hunk because we're (re)loading the server
 	Hunk_Clear();
 
-#ifndef DEDICATED
-	// Restart renderer
-	CL_StartHunkUsers( qtrue );
-#endif
-
 	// clear collision map data
 	CM_ClearMap();
 
@@ -613,6 +608,14 @@ void SV_SpawnServer( char *server, qboolean killBots ) {
 	SV_Heartbeat_f();
 
 	Hunk_SetMark();
+
+#ifndef DEDICATED
+	if ( com_dedicated->integer ) {
+		// restart renderer in order to show console for dedicated servers
+		// launched through the regular binary
+		CL_StartHunkUsers( qtrue );
+	}
+#endif
 
 	Com_Printf ("-----------------------------------\n");
 }


### PR DESCRIPTION
The renderer restart in SV_SpawnServer doesn't appear to do anything. As per https://github.com/ioquake/ioq3/blob/master/code/client/cl_scrn.c#L494, the connect screen isn't rendered until the UI VM is loaded anyways, at which point the renderer would have restarted again due to CL_FlushMemory being called once the gamestate is parsed. I throttled the connection process to validate this while loading a map.

Furthermore (and the reason I changed this in the first place) restarting the renderer here leaves the hunk memory it allocates trapped under the mark set at the bottom of SV_SpawnServer (https://github.com/ioquake/ioq3/blob/master/code/server/sv_init.c#L615).
