### PR TITLE
generate less shaders when r_sunlightMode is disabled

### DIFF
--- a/code/renderergl2/glsl/lightall_fp.glsl
+++ b/code/renderergl2/glsl/lightall_fp.glsl
@@ -299,6 +299,7 @@ float CalcLightAttenuation(float point, float normDist)
 	return attenuation;
 }
 
+#if defined(USE_LIGHT)
 // from http://www.thetenthplanet.de/archives/1180
 mat3 cotangent_frame( vec3 N, vec3 p, vec2 uv )
 {
@@ -318,6 +319,7 @@ mat3 cotangent_frame( vec3 N, vec3 p, vec2 uv )
 	float invmax = inversesqrt( max( dot(T,T), dot(B,B) ) );
 	return mat3( T * invmax, B * invmax, N );
 }
+#endif
 
 void main()
 {

--- a/code/renderergl2/tr_glsl.c
+++ b/code/renderergl2/tr_glsl.c
@@ -1000,6 +1000,9 @@ void GLSL_InitGPUShaders(void)
 		if ((i & LIGHTDEF_USE_PARALLAXMAP) && !r_parallaxMapping->integer)
 			continue;
 
+		if ((i & LIGHTDEF_USE_SHADOWMAP) && !r_sunlightMode->integer)
+			continue;
+
 		if (!lightType && (i & LIGHTDEF_USE_PARALLAXMAP))
 			continue;
 
@@ -1027,10 +1030,10 @@ void GLSL_InitGPUShaders(void)
 
 		if (lightType)
 		{
-			Q_strcat(extradefines, 1024, "#define USE_LIGHT\n");
-
 			if (fastLight)
 				Q_strcat(extradefines, 1024, "#define USE_FAST_LIGHT\n");
+			else
+				Q_strcat(extradefines, 1024, "#define USE_LIGHT\n");
 
 			switch (lightType)
 			{


### PR DESCRIPTION
- don't generate shaders for LIGHTDEF_USE_SHADOWMAP when r_sunlightMode is disabled (16 less iirc)
- wrap usage of standard derivatives functions in conditional so they can compile when unsupported and disabled
