### PR TITLE
don't regenerate GLSL shaders unless required

### DIFF
--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -883,10 +883,10 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 	VectorSet2(texCoords[2], (cols - 0.5f) / cols, (rows - 0.5f) / rows);
 	VectorSet2(texCoords[3], 0.5f / cols,          (rows - 0.5f) / rows);
 
-	GLSL_BindProgram(&tr.textureColorShader);
+	GLSL_BindProgram(&trs.textureColorShader);
 	
-	GLSL_SetUniformMat4(&tr.textureColorShader, UNIFORM_MODELVIEWPROJECTIONMATRIX, glState.modelviewProjection);
-	GLSL_SetUniformVec4(&tr.textureColorShader, UNIFORM_COLOR, colorWhite);
+	GLSL_SetUniformMat4(&trs.textureColorShader, UNIFORM_MODELVIEWPROJECTIONMATRIX, glState.modelviewProjection);
+	GLSL_SetUniformVec4(&trs.textureColorShader, UNIFORM_COLOR, colorWhite);
 
 	RB_InstantQuad2(quadVerts, texCoords);
 }
@@ -1119,18 +1119,18 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 			GL_State( GLS_DEPTHTEST_DISABLE );
 
-			GLSL_BindProgram(&tr.shadowmaskShader);
+			GLSL_BindProgram(&trs.shadowmaskShader);
 
 			GL_BindToTMU(tr.renderDepthImage, TB_COLORMAP);
 			GL_BindToTMU(tr.sunShadowDepthImage[0], TB_SHADOWMAP);
 			GL_BindToTMU(tr.sunShadowDepthImage[1], TB_SHADOWMAP2);
 			GL_BindToTMU(tr.sunShadowDepthImage[2], TB_SHADOWMAP3);
 
-			GLSL_SetUniformMat4(&tr.shadowmaskShader, UNIFORM_SHADOWMVP,  backEnd.refdef.sunShadowMvp[0]);
-			GLSL_SetUniformMat4(&tr.shadowmaskShader, UNIFORM_SHADOWMVP2, backEnd.refdef.sunShadowMvp[1]);
-			GLSL_SetUniformMat4(&tr.shadowmaskShader, UNIFORM_SHADOWMVP3, backEnd.refdef.sunShadowMvp[2]);
+			GLSL_SetUniformMat4(&trs.shadowmaskShader, UNIFORM_SHADOWMVP,  backEnd.refdef.sunShadowMvp[0]);
+			GLSL_SetUniformMat4(&trs.shadowmaskShader, UNIFORM_SHADOWMVP2, backEnd.refdef.sunShadowMvp[1]);
+			GLSL_SetUniformMat4(&trs.shadowmaskShader, UNIFORM_SHADOWMVP3, backEnd.refdef.sunShadowMvp[2]);
 			
-			GLSL_SetUniformVec3(&tr.shadowmaskShader, UNIFORM_VIEWORIGIN,  backEnd.refdef.vieworg);
+			GLSL_SetUniformVec3(&trs.shadowmaskShader, UNIFORM_VIEWORIGIN,  backEnd.refdef.vieworg);
 			{
 				vec4_t viewInfo;
 				vec3_t viewVector;
@@ -1142,15 +1142,15 @@ const void	*RB_DrawSurfs( const void *data ) {
 				float zmin = r_znear->value;
 
 				VectorScale(backEnd.refdef.viewaxis[0], zmax, viewVector);
-				GLSL_SetUniformVec3(&tr.shadowmaskShader, UNIFORM_VIEWFORWARD, viewVector);
+				GLSL_SetUniformVec3(&trs.shadowmaskShader, UNIFORM_VIEWFORWARD, viewVector);
 				VectorScale(backEnd.refdef.viewaxis[1], xmax, viewVector);
-				GLSL_SetUniformVec3(&tr.shadowmaskShader, UNIFORM_VIEWLEFT,    viewVector);
+				GLSL_SetUniformVec3(&trs.shadowmaskShader, UNIFORM_VIEWLEFT,    viewVector);
 				VectorScale(backEnd.refdef.viewaxis[2], ymax, viewVector);
-				GLSL_SetUniformVec3(&tr.shadowmaskShader, UNIFORM_VIEWUP,      viewVector);
+				GLSL_SetUniformVec3(&trs.shadowmaskShader, UNIFORM_VIEWUP,      viewVector);
 
 				VectorSet4(viewInfo, zmax / zmin, zmax, 0.0, 0.0);
 
-				GLSL_SetUniformVec4(&tr.shadowmaskShader, UNIFORM_VIEWINFO, viewInfo);
+				GLSL_SetUniformVec4(&trs.shadowmaskShader, UNIFORM_VIEWINFO, viewInfo);
 			}
 
 
@@ -1179,7 +1179,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 			GL_State( GLS_DEPTHTEST_DISABLE );
 
-			GLSL_BindProgram(&tr.ssaoShader);
+			GLSL_BindProgram(&trs.ssaoShader);
 
 			GL_BindToTMU(tr.hdrDepthImage, TB_COLORMAP);
 
@@ -1191,7 +1191,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 				VectorSet4(viewInfo, zmax / zmin, zmax, 0.0, 0.0);
 
-				GLSL_SetUniformVec4(&tr.ssaoShader, UNIFORM_VIEWINFO, viewInfo);
+				GLSL_SetUniformVec4(&trs.ssaoShader, UNIFORM_VIEWINFO, viewInfo);
 			}
 
 			RB_InstantQuad2(quadVerts, texCoords); //, color, shaderProgram, invTexRes);
@@ -1202,7 +1202,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 			qglViewport(0, 0, tr.quarterFbo[1]->width, tr.quarterFbo[1]->height);
 			qglScissor(0, 0, tr.quarterFbo[1]->width, tr.quarterFbo[1]->height);
 
-			GLSL_BindProgram(&tr.depthBlurShader[0]);
+			GLSL_BindProgram(&trs.depthBlurShader[0]);
 
 			GL_BindToTMU(tr.quarterImage[0],  TB_COLORMAP);
 			GL_BindToTMU(tr.hdrDepthImage, TB_LIGHTMAP);
@@ -1215,7 +1215,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 				VectorSet4(viewInfo, zmax / zmin, zmax, 0.0, 0.0);
 
-				GLSL_SetUniformVec4(&tr.depthBlurShader[0], UNIFORM_VIEWINFO, viewInfo);
+				GLSL_SetUniformVec4(&trs.depthBlurShader[0], UNIFORM_VIEWINFO, viewInfo);
 			}
 
 			RB_InstantQuad2(quadVerts, texCoords); //, color, shaderProgram, invTexRes);
@@ -1226,7 +1226,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 			qglViewport(0, 0, tr.screenSsaoFbo->width, tr.screenSsaoFbo->height);
 			qglScissor(0, 0, tr.screenSsaoFbo->width, tr.screenSsaoFbo->height);
 
-			GLSL_BindProgram(&tr.depthBlurShader[1]);
+			GLSL_BindProgram(&trs.depthBlurShader[1]);
 
 			GL_BindToTMU(tr.quarterImage[1],  TB_COLORMAP);
 			GL_BindToTMU(tr.hdrDepthImage, TB_LIGHTMAP);
@@ -1239,7 +1239,7 @@ const void	*RB_DrawSurfs( const void *data ) {
 
 				VectorSet4(viewInfo, zmax / zmin, zmax, 0.0, 0.0);
 
-				GLSL_SetUniformVec4(&tr.depthBlurShader[1], UNIFORM_VIEWINFO, viewInfo);
+				GLSL_SetUniformVec4(&trs.depthBlurShader[1], UNIFORM_VIEWINFO, viewInfo);
 			}
 
 
@@ -1702,8 +1702,8 @@ const void *RB_PostProcess(const void *data)
 		if (cubemapIndex)
 		{
 			VectorSet4(dstBox, 0, glConfig.vidHeight - 256, 256, 256);
-			//FBO_BlitFromTexture(tr.renderCubeImage, NULL, NULL, NULL, dstBox, &tr.testcubeShader, NULL, 0);
-			FBO_BlitFromTexture(tr.cubemaps[cubemapIndex - 1], NULL, NULL, NULL, dstBox, &tr.testcubeShader, NULL, 0);
+			//FBO_BlitFromTexture(tr.renderCubeImage, NULL, NULL, NULL, dstBox, &trs.testcubeShader, NULL, 0);
+			FBO_BlitFromTexture(tr.cubemaps[cubemapIndex - 1], NULL, NULL, NULL, dstBox, &trs.testcubeShader, NULL, 0);
 		}
 	}
 #endif

--- a/code/renderergl2/tr_fbo.c
+++ b/code/renderergl2/tr_fbo.c
@@ -722,7 +722,7 @@ void FBO_BlitFromTexture(struct image_s *src, ivec4_t inSrcBox, vec2_t inSrcTexS
 
 	if (!shaderProgram)
 	{
-		shaderProgram = &tr.textureColorShader;
+		shaderProgram = &trs.textureColorShader;
 	}
 
 	FBO_Bind(dst);

--- a/code/renderergl2/tr_glsl.c
+++ b/code/renderergl2/tr_glsl.c
@@ -860,15 +860,54 @@ void GLSL_DeleteGPUShader(shaderProgram_t *program)
 	}
 }
 
+// these cvars directly effect shader generation,
+// we'll need to rebuild shaders if they've changed
+static cvar_t **shaderInfo[] = {
+	&r_cubeMapping,
+	&r_deluxeMapping,
+	&r_deluxeSpecular,
+	&r_dlightMode,
+	&r_floatLightmap,
+	&r_hdr,
+	&r_normalMapping,
+	&r_parallaxMapping,
+	&r_specularIsMetallic,
+	&r_specularMapping,
+	&r_shadowCascadeZFar,
+	&r_shadowFilter,
+	&r_shadowMapSize,
+	&r_sunlightMode
+};
+
 void GLSL_InitGPUShaders(void)
 {
-	int             startTime, endTime;
-	int i;
+	int startTime, endTime;
+	int i, l;
 	char extradefines[1024];
 	int attribs;
 	int numGenShaders = 0, numLightShaders = 0, numEtcShaders = 0;
+	qboolean dirty = qfalse;
 
 	ri.Printf(PRINT_ALL, "------- GLSL_InitGPUShaders -------\n");
+
+	// check if any cvars that control shader generation have changed
+	for (i = 0, l = sizeof(shaderInfo) / sizeof(cvar_t**); i < l; i++) {
+		cvar_t *cvar = *shaderInfo[i];
+		if (cvar->modified) {
+			dirty = qtrue;
+			cvar->modified = qfalse;
+		}
+	}
+
+	if (trs.shadersInitialized) {
+		if (!dirty) {
+			ri.Printf(PRINT_ALL, "(using cache)\n");
+			return;
+		}
+
+		// cleanup old shaders if we need to rebuild
+		GLSL_ShutdownGPUShaders();
+	}
 
 	R_IssuePendingRenderCommands();
 
@@ -906,19 +945,19 @@ void GLSL_InitGPUShaders(void)
 		if (r_hdr->integer && !(glRefConfig.textureFloat && glRefConfig.halfFloatPixel && r_floatLightmap->integer))
 			Q_strcat(extradefines, 1024, "#define RGBM_LIGHTMAP\n");
 
-		if (!GLSL_InitGPUShader(&tr.genericShader[i], "generic", attribs, qtrue, extradefines, qtrue, fallbackShader_generic_vp, fallbackShader_generic_fp))
+		if (!GLSL_InitGPUShader(&trs.genericShader[i], "generic", attribs, qtrue, extradefines, qtrue, fallbackShader_generic_vp, fallbackShader_generic_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load generic shader!");
 		}
 
-		GLSL_InitUniforms(&tr.genericShader[i]);
+		GLSL_InitUniforms(&trs.genericShader[i]);
 
-		qglUseProgramObjectARB(tr.genericShader[i].program);
-		GLSL_SetUniformInt(&tr.genericShader[i], UNIFORM_DIFFUSEMAP, TB_DIFFUSEMAP);
-		GLSL_SetUniformInt(&tr.genericShader[i], UNIFORM_LIGHTMAP,   TB_LIGHTMAP);
+		qglUseProgramObjectARB(trs.genericShader[i].program);
+		GLSL_SetUniformInt(&trs.genericShader[i], UNIFORM_DIFFUSEMAP, TB_DIFFUSEMAP);
+		GLSL_SetUniformInt(&trs.genericShader[i], UNIFORM_LIGHTMAP,   TB_LIGHTMAP);
 		qglUseProgramObjectARB(0);
 
-		GLSL_FinishGPUShader(&tr.genericShader[i]);
+		GLSL_FinishGPUShader(&trs.genericShader[i]);
 
 		numGenShaders++;
 	}
@@ -926,18 +965,18 @@ void GLSL_InitGPUShaders(void)
 
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 
-	if (!GLSL_InitGPUShader(&tr.textureColorShader, "texturecolor", attribs, qtrue, NULL, qfalse, fallbackShader_texturecolor_vp, fallbackShader_texturecolor_fp))
+	if (!GLSL_InitGPUShader(&trs.textureColorShader, "texturecolor", attribs, qtrue, NULL, qfalse, fallbackShader_texturecolor_vp, fallbackShader_texturecolor_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load texturecolor shader!");
 	}
 	
-	GLSL_InitUniforms(&tr.textureColorShader);
+	GLSL_InitUniforms(&trs.textureColorShader);
 
-	qglUseProgramObjectARB(tr.textureColorShader.program);
-	GLSL_SetUniformInt(&tr.textureColorShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
+	qglUseProgramObjectARB(trs.textureColorShader.program);
+	GLSL_SetUniformInt(&trs.textureColorShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.textureColorShader);
+	GLSL_FinishGPUShader(&trs.textureColorShader);
 
 	numEtcShaders++;
 
@@ -952,13 +991,13 @@ void GLSL_InitGPUShaders(void)
 		if (i & FOGDEF_USE_VERTEX_ANIMATION)
 			Q_strcat(extradefines, 1024, "#define USE_VERTEX_ANIMATION\n");
 
-		if (!GLSL_InitGPUShader(&tr.fogShader[i], "fogpass", attribs, qtrue, extradefines, qtrue, fallbackShader_fogpass_vp, fallbackShader_fogpass_fp))
+		if (!GLSL_InitGPUShader(&trs.fogShader[i], "fogpass", attribs, qtrue, extradefines, qtrue, fallbackShader_fogpass_vp, fallbackShader_fogpass_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load fogpass shader!");
 		}
 
-		GLSL_InitUniforms(&tr.fogShader[i]);
-		GLSL_FinishGPUShader(&tr.fogShader[i]);
+		GLSL_InitUniforms(&trs.fogShader[i]);
+		GLSL_FinishGPUShader(&trs.fogShader[i]);
 
 		numEtcShaders++;
 	}
@@ -974,18 +1013,18 @@ void GLSL_InitGPUShaders(void)
 			Q_strcat(extradefines, 1024, "#define USE_DEFORM_VERTEXES\n");
 		}
 
-		if (!GLSL_InitGPUShader(&tr.dlightShader[i], "dlight", attribs, qtrue, extradefines, qtrue, fallbackShader_dlight_vp, fallbackShader_dlight_fp))
+		if (!GLSL_InitGPUShader(&trs.dlightShader[i], "dlight", attribs, qtrue, extradefines, qtrue, fallbackShader_dlight_vp, fallbackShader_dlight_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load dlight shader!");
 		}
 
-		GLSL_InitUniforms(&tr.dlightShader[i]);
+		GLSL_InitUniforms(&trs.dlightShader[i]);
 		
-		qglUseProgramObjectARB(tr.dlightShader[i].program);
-		GLSL_SetUniformInt(&tr.dlightShader[i], UNIFORM_DIFFUSEMAP, TB_DIFFUSEMAP);
+		qglUseProgramObjectARB(trs.dlightShader[i].program);
+		GLSL_SetUniformInt(&trs.dlightShader[i], UNIFORM_DIFFUSEMAP, TB_DIFFUSEMAP);
 		qglUseProgramObjectARB(0);
 
-		GLSL_FinishGPUShader(&tr.dlightShader[i]);
+		GLSL_FinishGPUShader(&trs.dlightShader[i]);
 
 		numEtcShaders++;
 	}
@@ -1132,24 +1171,24 @@ void GLSL_InitGPUShaders(void)
 #endif
 		}
 
-		if (!GLSL_InitGPUShader(&tr.lightallShader[i], "lightall", attribs, qtrue, extradefines, qtrue, fallbackShader_lightall_vp, fallbackShader_lightall_fp))
+		if (!GLSL_InitGPUShader(&trs.lightallShader[i], "lightall", attribs, qtrue, extradefines, qtrue, fallbackShader_lightall_vp, fallbackShader_lightall_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load lightall shader!");
 		}
 
-		GLSL_InitUniforms(&tr.lightallShader[i]);
+		GLSL_InitUniforms(&trs.lightallShader[i]);
 
-		qglUseProgramObjectARB(tr.lightallShader[i].program);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_DIFFUSEMAP,  TB_DIFFUSEMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_LIGHTMAP,    TB_LIGHTMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_NORMALMAP,   TB_NORMALMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_DELUXEMAP,   TB_DELUXEMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_SPECULARMAP, TB_SPECULARMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_SHADOWMAP,   TB_SHADOWMAP);
-		GLSL_SetUniformInt(&tr.lightallShader[i], UNIFORM_CUBEMAP,     TB_CUBEMAP);
+		qglUseProgramObjectARB(trs.lightallShader[i].program);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_DIFFUSEMAP,  TB_DIFFUSEMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_LIGHTMAP,    TB_LIGHTMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_NORMALMAP,   TB_NORMALMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_DELUXEMAP,   TB_DELUXEMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_SPECULARMAP, TB_SPECULARMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_SHADOWMAP,   TB_SHADOWMAP);
+		GLSL_SetUniformInt(&trs.lightallShader[i], UNIFORM_CUBEMAP,     TB_CUBEMAP);
 		qglUseProgramObjectARB(0);
 
-		GLSL_FinishGPUShader(&tr.lightallShader[i]);
+		GLSL_FinishGPUShader(&trs.lightallShader[i]);
 
 		numLightShaders++;
 	}
@@ -1158,13 +1197,13 @@ void GLSL_InitGPUShaders(void)
 
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.shadowmapShader, "shadowfill", attribs, qtrue, extradefines, qtrue, fallbackShader_shadowfill_vp, fallbackShader_shadowfill_fp))
+	if (!GLSL_InitGPUShader(&trs.shadowmapShader, "shadowfill", attribs, qtrue, extradefines, qtrue, fallbackShader_shadowfill_vp, fallbackShader_shadowfill_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load shadowfill shader!");
 	}
 
-	GLSL_InitUniforms(&tr.shadowmapShader);
-	GLSL_FinishGPUShader(&tr.shadowmapShader);
+	GLSL_InitUniforms(&trs.shadowmapShader);
+	GLSL_FinishGPUShader(&trs.shadowmapShader);
 
 	numEtcShaders++;
 
@@ -1173,18 +1212,18 @@ void GLSL_InitGPUShaders(void)
 
 	Q_strcat(extradefines, 1024, "#define USE_PCF\n#define USE_DISCARD\n");
 
-	if (!GLSL_InitGPUShader(&tr.pshadowShader, "pshadow", attribs, qtrue, extradefines, qtrue, fallbackShader_pshadow_vp, fallbackShader_pshadow_fp))
+	if (!GLSL_InitGPUShader(&trs.pshadowShader, "pshadow", attribs, qtrue, extradefines, qtrue, fallbackShader_pshadow_vp, fallbackShader_pshadow_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load pshadow shader!");
 	}
 	
-	GLSL_InitUniforms(&tr.pshadowShader);
+	GLSL_InitUniforms(&trs.pshadowShader);
 
-	qglUseProgramObjectARB(tr.pshadowShader.program);
-	GLSL_SetUniformInt(&tr.pshadowShader, UNIFORM_SHADOWMAP, TB_DIFFUSEMAP);
+	qglUseProgramObjectARB(trs.pshadowShader.program);
+	GLSL_SetUniformInt(&trs.pshadowShader, UNIFORM_SHADOWMAP, TB_DIFFUSEMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.pshadowShader);
+	GLSL_FinishGPUShader(&trs.pshadowShader);
 
 	numEtcShaders++;
 
@@ -1192,18 +1231,18 @@ void GLSL_InitGPUShaders(void)
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.down4xShader, "down4x", attribs, qtrue, extradefines, qtrue, fallbackShader_down4x_vp, fallbackShader_down4x_fp))
+	if (!GLSL_InitGPUShader(&trs.down4xShader, "down4x", attribs, qtrue, extradefines, qtrue, fallbackShader_down4x_vp, fallbackShader_down4x_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load down4x shader!");
 	}
 	
-	GLSL_InitUniforms(&tr.down4xShader);
+	GLSL_InitUniforms(&trs.down4xShader);
 
-	qglUseProgramObjectARB(tr.down4xShader.program);
-	GLSL_SetUniformInt(&tr.down4xShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
+	qglUseProgramObjectARB(trs.down4xShader.program);
+	GLSL_SetUniformInt(&trs.down4xShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.down4xShader);
+	GLSL_FinishGPUShader(&trs.down4xShader);
 
 	numEtcShaders++;
 
@@ -1211,18 +1250,18 @@ void GLSL_InitGPUShaders(void)
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.bokehShader, "bokeh", attribs, qtrue, extradefines, qtrue, fallbackShader_bokeh_vp, fallbackShader_bokeh_fp))
+	if (!GLSL_InitGPUShader(&trs.bokehShader, "bokeh", attribs, qtrue, extradefines, qtrue, fallbackShader_bokeh_vp, fallbackShader_bokeh_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load bokeh shader!");
 	}
 
-	GLSL_InitUniforms(&tr.bokehShader);
+	GLSL_InitUniforms(&trs.bokehShader);
 
-	qglUseProgramObjectARB(tr.bokehShader.program);
-	GLSL_SetUniformInt(&tr.bokehShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
+	qglUseProgramObjectARB(trs.bokehShader.program);
+	GLSL_SetUniformInt(&trs.bokehShader, UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.bokehShader);
+	GLSL_FinishGPUShader(&trs.bokehShader);
 
 	numEtcShaders++;
 
@@ -1230,19 +1269,19 @@ void GLSL_InitGPUShaders(void)
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.tonemapShader, "tonemap", attribs, qtrue, extradefines, qtrue, fallbackShader_tonemap_vp, fallbackShader_tonemap_fp))
+	if (!GLSL_InitGPUShader(&trs.tonemapShader, "tonemap", attribs, qtrue, extradefines, qtrue, fallbackShader_tonemap_vp, fallbackShader_tonemap_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load tonemap shader!");
 	}
 
-	GLSL_InitUniforms(&tr.tonemapShader);
+	GLSL_InitUniforms(&trs.tonemapShader);
 
-	qglUseProgramObjectARB(tr.tonemapShader.program);
-	GLSL_SetUniformInt(&tr.tonemapShader, UNIFORM_TEXTUREMAP, TB_COLORMAP);
-	GLSL_SetUniformInt(&tr.tonemapShader, UNIFORM_LEVELSMAP,  TB_LEVELSMAP);
+	qglUseProgramObjectARB(trs.tonemapShader.program);
+	GLSL_SetUniformInt(&trs.tonemapShader, UNIFORM_TEXTUREMAP, TB_COLORMAP);
+	GLSL_SetUniformInt(&trs.tonemapShader, UNIFORM_LEVELSMAP,  TB_LEVELSMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.tonemapShader);
+	GLSL_FinishGPUShader(&trs.tonemapShader);
 
 	numEtcShaders++;
 
@@ -1255,18 +1294,18 @@ void GLSL_InitGPUShaders(void)
 		if (!i)
 			Q_strcat(extradefines, 1024, "#define FIRST_PASS\n");
 
-		if (!GLSL_InitGPUShader(&tr.calclevels4xShader[i], "calclevels4x", attribs, qtrue, extradefines, qtrue, fallbackShader_calclevels4x_vp, fallbackShader_calclevels4x_fp))
+		if (!GLSL_InitGPUShader(&trs.calclevels4xShader[i], "calclevels4x", attribs, qtrue, extradefines, qtrue, fallbackShader_calclevels4x_vp, fallbackShader_calclevels4x_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load calclevels4x shader!");
 		}
 
-		GLSL_InitUniforms(&tr.calclevels4xShader[i]);
+		GLSL_InitUniforms(&trs.calclevels4xShader[i]);
 
-		qglUseProgramObjectARB(tr.calclevels4xShader[i].program);
-		GLSL_SetUniformInt(&tr.calclevels4xShader[i], UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
+		qglUseProgramObjectARB(trs.calclevels4xShader[i].program);
+		GLSL_SetUniformInt(&trs.calclevels4xShader[i], UNIFORM_TEXTUREMAP, TB_DIFFUSEMAP);
 		qglUseProgramObjectARB(0);
 
-		GLSL_FinishGPUShader(&tr.calclevels4xShader[i]);
+		GLSL_FinishGPUShader(&trs.calclevels4xShader[i]);
 
 		numEtcShaders++;		
 	}
@@ -1287,21 +1326,21 @@ void GLSL_InitGPUShaders(void)
 	Q_strcat(extradefines, 1024, va("#define r_shadowCascadeZFar %f\n", r_shadowCascadeZFar->value));
 
 
-	if (!GLSL_InitGPUShader(&tr.shadowmaskShader, "shadowmask", attribs, qtrue, extradefines, qtrue, fallbackShader_shadowmask_vp, fallbackShader_shadowmask_fp))
+	if (!GLSL_InitGPUShader(&trs.shadowmaskShader, "shadowmask", attribs, qtrue, extradefines, qtrue, fallbackShader_shadowmask_vp, fallbackShader_shadowmask_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load shadowmask shader!");
 	}
 	
-	GLSL_InitUniforms(&tr.shadowmaskShader);
+	GLSL_InitUniforms(&trs.shadowmaskShader);
 
-	qglUseProgramObjectARB(tr.shadowmaskShader.program);
-	GLSL_SetUniformInt(&tr.shadowmaskShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
-	GLSL_SetUniformInt(&tr.shadowmaskShader, UNIFORM_SHADOWMAP,  TB_SHADOWMAP);
-	GLSL_SetUniformInt(&tr.shadowmaskShader, UNIFORM_SHADOWMAP2, TB_SHADOWMAP2);
-	GLSL_SetUniformInt(&tr.shadowmaskShader, UNIFORM_SHADOWMAP3, TB_SHADOWMAP3);
+	qglUseProgramObjectARB(trs.shadowmaskShader.program);
+	GLSL_SetUniformInt(&trs.shadowmaskShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
+	GLSL_SetUniformInt(&trs.shadowmaskShader, UNIFORM_SHADOWMAP,  TB_SHADOWMAP);
+	GLSL_SetUniformInt(&trs.shadowmaskShader, UNIFORM_SHADOWMAP2, TB_SHADOWMAP2);
+	GLSL_SetUniformInt(&trs.shadowmaskShader, UNIFORM_SHADOWMAP3, TB_SHADOWMAP3);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.shadowmaskShader);
+	GLSL_FinishGPUShader(&trs.shadowmaskShader);
 
 	numEtcShaders++;
 
@@ -1309,18 +1348,18 @@ void GLSL_InitGPUShaders(void)
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.ssaoShader, "ssao", attribs, qtrue, extradefines, qtrue, fallbackShader_ssao_vp, fallbackShader_ssao_fp))
+	if (!GLSL_InitGPUShader(&trs.ssaoShader, "ssao", attribs, qtrue, extradefines, qtrue, fallbackShader_ssao_vp, fallbackShader_ssao_fp))
 	{
 		ri.Error(ERR_FATAL, "Could not load ssao shader!");
 	}
 
-	GLSL_InitUniforms(&tr.ssaoShader);
+	GLSL_InitUniforms(&trs.ssaoShader);
 
-	qglUseProgramObjectARB(tr.ssaoShader.program);
-	GLSL_SetUniformInt(&tr.ssaoShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
+	qglUseProgramObjectARB(trs.ssaoShader.program);
+	GLSL_SetUniformInt(&trs.ssaoShader, UNIFORM_SCREENDEPTHMAP, TB_COLORMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.ssaoShader);
+	GLSL_FinishGPUShader(&trs.ssaoShader);
 
 	numEtcShaders++;
 
@@ -1336,19 +1375,19 @@ void GLSL_InitGPUShaders(void)
 			Q_strcat(extradefines, 1024, "#define USE_HORIZONTAL_BLUR\n");
 
 
-		if (!GLSL_InitGPUShader(&tr.depthBlurShader[i], "depthBlur", attribs, qtrue, extradefines, qtrue, fallbackShader_depthblur_vp, fallbackShader_depthblur_fp))
+		if (!GLSL_InitGPUShader(&trs.depthBlurShader[i], "depthBlur", attribs, qtrue, extradefines, qtrue, fallbackShader_depthblur_vp, fallbackShader_depthblur_fp))
 		{
 			ri.Error(ERR_FATAL, "Could not load depthBlur shader!");
 		}
 		
-		GLSL_InitUniforms(&tr.depthBlurShader[i]);
+		GLSL_InitUniforms(&trs.depthBlurShader[i]);
 
-		qglUseProgramObjectARB(tr.depthBlurShader[i].program);
-		GLSL_SetUniformInt(&tr.depthBlurShader[i], UNIFORM_SCREENIMAGEMAP, TB_COLORMAP);
-		GLSL_SetUniformInt(&tr.depthBlurShader[i], UNIFORM_SCREENDEPTHMAP, TB_LIGHTMAP);
+		qglUseProgramObjectARB(trs.depthBlurShader[i].program);
+		GLSL_SetUniformInt(&trs.depthBlurShader[i], UNIFORM_SCREENIMAGEMAP, TB_COLORMAP);
+		GLSL_SetUniformInt(&trs.depthBlurShader[i], UNIFORM_SCREENDEPTHMAP, TB_LIGHTMAP);
 		qglUseProgramObjectARB(0);
 
-		GLSL_FinishGPUShader(&tr.depthBlurShader[i]);
+		GLSL_FinishGPUShader(&trs.depthBlurShader[i]);
 
 		numEtcShaders++;
 	}
@@ -1357,18 +1396,18 @@ void GLSL_InitGPUShaders(void)
 	attribs = ATTR_POSITION | ATTR_TEXCOORD;
 	extradefines[0] = '\0';
 
-	if (!GLSL_InitGPUShader(&tr.testcubeShader, "testcube", attribs, qtrue, extradefines, qtrue, NULL, NULL))
+	if (!GLSL_InitGPUShader(&trs.testcubeShader, "testcube", attribs, qtrue, extradefines, qtrue, NULL, NULL))
 	{
 		ri.Error(ERR_FATAL, "Could not load testcube shader!");
 	}
 
-	GLSL_InitUniforms(&tr.testcubeShader);
+	GLSL_InitUniforms(&trs.testcubeShader);
 
-	qglUseProgramObjectARB(tr.testcubeShader.program);
-	GLSL_SetUniformInt(&tr.testcubeShader, UNIFORM_TEXTUREMAP, TB_COLORMAP);
+	qglUseProgramObjectARB(trs.testcubeShader.program);
+	GLSL_SetUniformInt(&trs.testcubeShader, UNIFORM_TEXTUREMAP, TB_COLORMAP);
 	qglUseProgramObjectARB(0);
 
-	GLSL_FinishGPUShader(&tr.testcubeShader);
+	GLSL_FinishGPUShader(&trs.testcubeShader);
 
 	numEtcShaders++;
 #endif
@@ -1379,6 +1418,8 @@ void GLSL_InitGPUShaders(void)
 	ri.Printf(PRINT_ALL, "loaded %i GLSL shaders (%i gen %i light %i etc) in %5.2f seconds\n", 
 		numGenShaders + numLightShaders + numEtcShaders, numGenShaders, numLightShaders, 
 		numEtcShaders, (endTime - startTime) / 1000.0);
+
+	trs.shadersInitialized = qtrue;
 }
 
 void GLSL_ShutdownGPUShaders(void)
@@ -1404,33 +1445,33 @@ void GLSL_ShutdownGPUShaders(void)
 	GLSL_BindNullProgram();
 
 	for ( i = 0; i < GENERICDEF_COUNT; i++)
-		GLSL_DeleteGPUShader(&tr.genericShader[i]);
+		GLSL_DeleteGPUShader(&trs.genericShader[i]);
 
-	GLSL_DeleteGPUShader(&tr.textureColorShader);
+	GLSL_DeleteGPUShader(&trs.textureColorShader);
 
 	for ( i = 0; i < FOGDEF_COUNT; i++)
-		GLSL_DeleteGPUShader(&tr.fogShader[i]);
+		GLSL_DeleteGPUShader(&trs.fogShader[i]);
 
 	for ( i = 0; i < DLIGHTDEF_COUNT; i++)
-		GLSL_DeleteGPUShader(&tr.dlightShader[i]);
+		GLSL_DeleteGPUShader(&trs.dlightShader[i]);
 
 	for ( i = 0; i < LIGHTDEF_COUNT; i++)
-		GLSL_DeleteGPUShader(&tr.lightallShader[i]);
+		GLSL_DeleteGPUShader(&trs.lightallShader[i]);
 
-	GLSL_DeleteGPUShader(&tr.shadowmapShader);
-	GLSL_DeleteGPUShader(&tr.pshadowShader);
-	GLSL_DeleteGPUShader(&tr.down4xShader);
-	GLSL_DeleteGPUShader(&tr.bokehShader);
-	GLSL_DeleteGPUShader(&tr.tonemapShader);
-
-	for ( i = 0; i < 2; i++)
-		GLSL_DeleteGPUShader(&tr.calclevels4xShader[i]);
-
-	GLSL_DeleteGPUShader(&tr.shadowmaskShader);
-	GLSL_DeleteGPUShader(&tr.ssaoShader);
+	GLSL_DeleteGPUShader(&trs.shadowmapShader);
+	GLSL_DeleteGPUShader(&trs.pshadowShader);
+	GLSL_DeleteGPUShader(&trs.down4xShader);
+	GLSL_DeleteGPUShader(&trs.bokehShader);
+	GLSL_DeleteGPUShader(&trs.tonemapShader);
 
 	for ( i = 0; i < 2; i++)
-		GLSL_DeleteGPUShader(&tr.depthBlurShader[i]);
+		GLSL_DeleteGPUShader(&trs.calclevels4xShader[i]);
+
+	GLSL_DeleteGPUShader(&trs.shadowmaskShader);
+	GLSL_DeleteGPUShader(&trs.ssaoShader);
+
+	for ( i = 0; i < 2; i++)
+		GLSL_DeleteGPUShader(&trs.depthBlurShader[i]);
 
 	glState.currentProgram = 0;
 	qglUseProgramObjectARB(0);
@@ -1795,5 +1836,5 @@ shaderProgram_t *GLSL_GetGenericShaderProgram(int stage)
 		shaderAttribs |= GENERICDEF_USE_TCGEN_AND_TCMOD;
 	}
 
-	return &tr.genericShader[shaderAttribs];
+	return &trs.genericShader[shaderAttribs];
 }

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -1479,15 +1479,17 @@ void RE_Shutdown( qboolean destroyWindow ) {
 			FBO_Shutdown();
 		R_DeleteTextures();
 		R_ShutdownVBOs();
-		GLSL_ShutdownGPUShaders();
 	}
 
 	R_DoneFreeType();
 
 	// shut down platform specific OpenGL stuff
 	if ( destroyWindow ) {
+		GLSL_ShutdownGPUShaders();
+
 		GLimp_Shutdown();
 
+		Com_Memset( &trs, 0, sizeof( trs ) );
 		Com_Memset( &glConfig, 0, sizeof( glConfig ) );
 		Com_Memset( &glState, 0, sizeof( glState ) );
 	}

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1581,25 +1581,6 @@ typedef struct {
 	int						shiftedEntityNum;	// currentEntityNum << QSORT_REFENTITYNUM_SHIFT
 	model_t					*currentModel;
 
-	//
-	// GPU shader programs
-	//
-	shaderProgram_t genericShader[GENERICDEF_COUNT];
-	shaderProgram_t textureColorShader;
-	shaderProgram_t fogShader[FOGDEF_COUNT];
-	shaderProgram_t dlightShader[DLIGHTDEF_COUNT];
-	shaderProgram_t lightallShader[LIGHTDEF_COUNT];
-	shaderProgram_t shadowmapShader;
-	shaderProgram_t pshadowShader;
-	shaderProgram_t down4xShader;
-	shaderProgram_t bokehShader;
-	shaderProgram_t tonemapShader;
-	shaderProgram_t calclevels4xShader[2];
-	shaderProgram_t shadowmaskShader;
-	shaderProgram_t ssaoShader;
-	shaderProgram_t depthBlurShader[2];
-	shaderProgram_t testcubeShader;
-
 
 	// -----------------------------------------
 
@@ -1666,8 +1647,30 @@ typedef struct {
 	float					fogTable[FOG_TABLE_SIZE];
 } trGlobals_t;
 
+// data not cleared between renderer restarts
+// only when the window context is destroyed
+typedef struct {
+	qboolean shadersInitialized;
+	shaderProgram_t genericShader[GENERICDEF_COUNT];
+	shaderProgram_t textureColorShader;
+	shaderProgram_t fogShader[FOGDEF_COUNT];
+	shaderProgram_t dlightShader[DLIGHTDEF_COUNT];
+	shaderProgram_t lightallShader[LIGHTDEF_COUNT];
+	shaderProgram_t shadowmapShader;
+	shaderProgram_t pshadowShader;
+	shaderProgram_t down4xShader;
+	shaderProgram_t bokehShader;
+	shaderProgram_t tonemapShader;
+	shaderProgram_t calclevels4xShader[2];
+	shaderProgram_t shadowmaskShader;
+	shaderProgram_t ssaoShader;
+	shaderProgram_t depthBlurShader[2];
+	shaderProgram_t testcubeShader;
+} trStatic_t;
+
 extern backEndState_t	backEnd;
 extern trGlobals_t	tr;
+extern trStatic_t	trs;
 extern glstate_t	glState;		// outside of TR since it shouldn't be cleared during ref re-init
 extern glRefConfig_t glRefConfig;
 

--- a/code/renderergl2/tr_main.c
+++ b/code/renderergl2/tr_main.c
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <string.h> // memcpy
 
 trGlobals_t		tr;
+trStatic_t		trs;
 
 static float	s_flipMatrix[16] = {
 	// convert from our coordinate system (looking down X)

--- a/code/renderergl2/tr_postprocess.c
+++ b/code/renderergl2/tr_postprocess.c
@@ -40,7 +40,7 @@ void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, in
 
 			VectorSet4(dstBox, 0, 0, size, size);
 
-			FBO_Blit(hdrFbo, hdrBox, NULL, tr.textureScratchFbo[0], dstBox, &tr.calclevels4xShader[0], NULL, 0);
+			FBO_Blit(hdrFbo, hdrBox, NULL, tr.textureScratchFbo[0], dstBox, &trs.calclevels4xShader[0], NULL, 0);
 
 			srcFbo = tr.textureScratchFbo[0];
 			dstFbo = tr.textureScratchFbo[1];
@@ -56,7 +56,7 @@ void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, in
 				if (size == 1)
 					dstFbo = tr.targetLevelsFbo;
 
-				//FBO_Blit(targetFbo, srcBox, NULL, tr.textureScratchFbo[nextScratch], dstBox, &tr.calclevels4xShader[1], NULL, 0);
+				//FBO_Blit(targetFbo, srcBox, NULL, tr.textureScratchFbo[nextScratch], dstBox, &trs.calclevels4xShader[1], NULL, 0);
 				FBO_FastBlit(srcFbo, srcBox, dstFbo, dstBox, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 				tmp = srcFbo;
@@ -90,7 +90,7 @@ void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, in
 	else
 		GL_BindToTMU(tr.fixedLevelsImage, TB_LEVELSMAP);
 
-	FBO_Blit(hdrFbo, hdrBox, NULL, ldrFbo, ldrBox, &tr.tonemapShader, color, 0);
+	FBO_Blit(hdrFbo, hdrBox, NULL, ldrFbo, ldrBox, &trs.tonemapShader, color, 0);
 }
 
 /*
@@ -178,12 +178,12 @@ void RB_BokehBlur(FBO_t *src, ivec4_t srcBox, FBO_t *dst, ivec4_t dstBox, float 
 				color[3] = 1.0f;
 
 				if (i != 0)
-					FBO_Blit(tr.textureScratchFbo[0], NULL, blurTexScale, tr.textureScratchFbo[1], NULL, &tr.bokehShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE);
+					FBO_Blit(tr.textureScratchFbo[0], NULL, blurTexScale, tr.textureScratchFbo[1], NULL, &trs.bokehShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE);
 				else
-					FBO_Blit(tr.textureScratchFbo[0], NULL, blurTexScale, tr.textureScratchFbo[1], NULL, &tr.bokehShader, color, 0);
+					FBO_Blit(tr.textureScratchFbo[0], NULL, blurTexScale, tr.textureScratchFbo[1], NULL, &trs.bokehShader, color, 0);
 			}
 
-			FBO_Blit(tr.textureScratchFbo[1], NULL, NULL, dst, dstBox, &tr.textureColorShader, NULL, 0);
+			FBO_Blit(tr.textureScratchFbo[1], NULL, NULL, dst, dstBox, &trs.textureColorShader, NULL, 0);
 		}
 #else // higher quality blur, but slower
 		else if (blur > 1.0f)
@@ -214,10 +214,10 @@ void RB_BokehBlur(FBO_t *src, ivec4_t srcBox, FBO_t *dst, ivec4_t dstBox, float 
 				else
 					color[3] = 0.5f;
 
-				FBO_Blit(tr.quarterFbo[0], NULL, blurTexScale, tr.quarterFbo[1], NULL, &tr.bokehShader, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
+				FBO_Blit(tr.quarterFbo[0], NULL, blurTexScale, tr.quarterFbo[1], NULL, &trs.bokehShader, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
 			}
 
-			FBO_Blit(tr.quarterFbo[1], NULL, NULL, dst, dstBox, &tr.textureColorShader, NULL, 0);
+			FBO_Blit(tr.quarterFbo[1], NULL, NULL, dst, dstBox, &trs.textureColorShader, NULL, 0);
 		}
 #endif
 	}
@@ -243,7 +243,7 @@ static void RB_RadialBlur(FBO_t *srcFbo, FBO_t *dstFbo, int passes, float stretc
 
 		VectorSet4(srcBox, 0, 0, srcFbo->width, srcFbo->height);
 		VectorSet4(dstBox, x, y, w, h);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, 0);
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, 0);
 
 		--passes;
 		scale = mul;
@@ -270,7 +270,7 @@ static void RB_RadialBlur(FBO_t *srcFbo, FBO_t *dstFbo, int passes, float stretc
 				srcBox[3] = (t1 - t0) * glConfig.vidHeight;
 			}
 			
-			FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+			FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 
 			scale *= mul;
 			--passes;
@@ -415,7 +415,7 @@ void RB_SunRays(FBO_t *srcFbo, ivec4_t srcBox, FBO_t *dstFbo, ivec4_t dstBox)
 
 		VectorSet4(color, mul, mul, mul, 1);
 
-		FBO_Blit(tr.quarterFbo[0], NULL, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE);
+		FBO_Blit(tr.quarterFbo[0], NULL, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE);
 	}
 }
 
@@ -451,23 +451,23 @@ static void RB_BlurAxis(FBO_t *srcFbo, FBO_t *dstFbo, float strength, qboolean h
 		VectorSet4(color, weights[0], weights[0], weights[0], 1.0f);
 		VectorSet4(srcBox, 0, 0, srcFbo->width, srcFbo->height);
 		VectorSet4(dstBox, 0, 0, dstFbo->width, dstFbo->height);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, 0 );
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, 0 );
 
 		VectorSet4(color, weights[1], weights[1], weights[1], 1.0f);
 		dx = offsets[1] * xmul;
 		dy = offsets[1] * ymul;
 		VectorSet4(srcBox, dx, dy, srcFbo->width, srcFbo->height);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 		VectorSet4(srcBox, -dx, -dy, srcFbo->width, srcFbo->height);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 
 		VectorSet4(color, weights[2], weights[2], weights[2], 1.0f);
 		dx = offsets[2] * xmul;
 		dy = offsets[2] * ymul;
 		VectorSet4(srcBox, dx, dy, srcFbo->width, srcFbo->height);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 		VectorSet4(srcBox, -dx, -dy, srcFbo->width, srcFbo->height);
-		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+		FBO_Blit(srcFbo, srcBox, texScale, dstFbo, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 	}
 }
 
@@ -507,7 +507,7 @@ void RB_GaussianBlur(float blur)
 		VectorSet4(srcBox, 0, 0, tr.whiteImage->width, tr.whiteImage->height);
 		VectorSet4(dstBox, 0, 0, tr.textureScratchFbo[0]->width, tr.textureScratchFbo[0]->height);
 		qglColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-		FBO_BlitFromTexture(tr.whiteImage, srcBox, texScale, tr.textureScratchFbo[0], dstBox, &tr.textureColorShader, color, GLS_DEPTHTEST_DISABLE);
+		FBO_BlitFromTexture(tr.whiteImage, srcBox, texScale, tr.textureScratchFbo[0], dstBox, &trs.textureColorShader, color, GLS_DEPTHTEST_DISABLE);
 		qglColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
 		// blur the tiny buffer horizontally and vertically
@@ -518,6 +518,6 @@ void RB_GaussianBlur(float blur)
 		VectorSet4(srcBox, 0, 0, tr.textureScratchFbo[0]->width, tr.textureScratchFbo[0]->height);
 		VectorSet4(dstBox, 0, 0, glConfig.vidWidth,              glConfig.vidHeight);
 		color[3] = factor;
-		FBO_Blit(tr.textureScratchFbo[0], srcBox, texScale, NULL, dstBox, &tr.textureColorShader, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
+		FBO_Blit(tr.textureScratchFbo[0], srcBox, texScale, NULL, dstBox, &trs.textureColorShader, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
 	}
 }

--- a/code/renderergl2/tr_shade.c
+++ b/code/renderergl2/tr_shade.c
@@ -142,7 +142,7 @@ static void DrawTris (shaderCommands_t *input) {
 	qglDepthRange( 0, 0 );
 
 	{
-		shaderProgram_t *sp = &tr.textureColorShader;
+		shaderProgram_t *sp = &trs.textureColorShader;
 		vec4_t color;
 
 		GLSL_VertexAttribsState(ATTR_POSITION);
@@ -386,7 +386,7 @@ static void ProjectDlightTexture( void ) {
 		radius = dl->radius;
 		scale = 1.0f / radius;
 
-		sp = &tr.dlightShader[deformGen == DGEN_NONE ? 0 : 1];
+		sp = &trs.dlightShader[deformGen == DGEN_NONE ? 0 : 1];
 
 		backEnd.pc.c_dlightDraws++;
 
@@ -743,14 +743,14 @@ static void ForwardDlight( void ) {
 		radius = dl->radius;
 		//scale = 1.0f / radius;
 
-		//if (pStage->glslShaderGroup == tr.lightallShader)
+		//if (pStage->glslShaderGroup == trs.lightallShader)
 		{
 			int index = pStage->glslShaderIndex;
 
 			index &= ~LIGHTDEF_LIGHTTYPE_MASK;
 			index |= LIGHTDEF_USE_LIGHT_VECTOR;
 
-			sp = &tr.lightallShader[index];
+			sp = &trs.lightallShader[index];
 		}
 
 		backEnd.pc.c_lightallDraws++;
@@ -890,7 +890,7 @@ static void ProjectPshadowVBOGLSL( void ) {
 		VectorCopy( ps->lightOrigin, origin );
 		radius = ps->lightRadius;
 
-		sp = &tr.pshadowShader;
+		sp = &trs.pshadowShader;
 
 		GLSL_BindProgram(sp);
 
@@ -965,7 +965,7 @@ static void RB_FogPass( void ) {
 		if (glState.vertexAnimation)
 			index |= FOGDEF_USE_VERTEX_ANIMATION;
 		
-		sp = &tr.fogShader[index];
+		sp = &trs.fogShader[index];
 	}
 
 	backEnd.pc.c_fogDraws++;
@@ -1062,7 +1062,7 @@ static void RB_IterateStagesGeneric( shaderCommands_t *input )
 
 		if (backEnd.depthFill)
 		{
-			if (pStage->glslShaderGroup == tr.lightallShader)
+			if (pStage->glslShaderGroup == trs.lightallShader)
 			{
 				int index = 0;
 
@@ -1097,10 +1097,10 @@ static void RB_IterateStagesGeneric( shaderCommands_t *input )
 					shaderAttribs |= GENERICDEF_USE_TCGEN_AND_TCMOD;
 				}
 
-				sp = &tr.genericShader[shaderAttribs];
+				sp = &trs.genericShader[shaderAttribs];
 			}
 		}
-		else if (pStage->glslShaderGroup == tr.lightallShader)
+		else if (pStage->glslShaderGroup == trs.lightallShader)
 		{
 			int index = pStage->glslShaderIndex;
 
@@ -1236,7 +1236,7 @@ static void RB_IterateStagesGeneric( shaderCommands_t *input )
 			else if ( pStage->bundle[TB_COLORMAP].image[0] != 0 )
 				R_BindAnimatedImageToTMU( &pStage->bundle[TB_COLORMAP], TB_COLORMAP );
 		}
-		else if ( pStage->glslShaderGroup == tr.lightallShader )
+		else if ( pStage->glslShaderGroup == trs.lightallShader )
 		{
 			int i;
 			vec4_t enableTextures;
@@ -1385,7 +1385,7 @@ static void RB_RenderShadowmap( shaderCommands_t *input )
 	ComputeDeformValues(&deformGen, deformParams);
 
 	{
-		shaderProgram_t *sp = &tr.shadowmapShader;
+		shaderProgram_t *sp = &trs.shadowmapShader;
 
 		vec4_t vector;
 
@@ -1563,7 +1563,7 @@ void RB_StageIteratorGeneric( void )
 	//
 	if ( tess.dlightBits && tess.shader->sort <= SS_OPAQUE
 		&& !(tess.shader->surfaceFlags & (SURF_NODLIGHT | SURF_SKY) ) ) {
-		if (tess.shader->numUnfoggedPasses == 1 && tess.xstages[0]->glslShaderGroup == tr.lightallShader
+		if (tess.shader->numUnfoggedPasses == 1 && tess.xstages[0]->glslShaderGroup == trs.lightallShader
 			&& (tess.xstages[0]->glslShaderIndex & LIGHTDEF_LIGHTTYPE_MASK) && r_dlightMode->integer)
 		{
 			ForwardDlight();

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -1952,7 +1952,7 @@ static void ComputeVertexAttribs(void)
 			break;
 		}
 
-		if (pStage->glslShaderGroup == tr.lightallShader)
+		if (pStage->glslShaderGroup == trs.lightallShader)
 		{
 			shader.vertexAttribs |= ATTR_NORMAL;
 
@@ -2273,7 +2273,7 @@ static void CollapseStagesToLightall(shaderStage_t *diffuse,
 
 	//ri.Printf(PRINT_ALL, ".\n");
 
-	diffuse->glslShaderGroup = tr.lightallShader;
+	diffuse->glslShaderGroup = trs.lightallShader;
 	diffuse->glslShaderIndex = defs;
 }
 
@@ -2534,7 +2534,7 @@ static qboolean CollapseStagesToGLSL(void)
 
 			if (pStage->bundle[TB_DIFFUSEMAP].tcGen == TCGEN_LIGHTMAP)
 			{
-				pStage->glslShaderGroup = tr.lightallShader;
+				pStage->glslShaderGroup = trs.lightallShader;
 				pStage->glslShaderIndex = LIGHTDEF_USE_LIGHTMAP;
 				pStage->bundle[TB_LIGHTMAP] = pStage->bundle[TB_DIFFUSEMAP];
 				pStage->bundle[TB_DIFFUSEMAP].image[0] = tr.whiteImage;
@@ -2559,7 +2559,7 @@ static qboolean CollapseStagesToGLSL(void)
 
 			if (pStage->rgbGen == CGEN_LIGHTING_DIFFUSE)
 			{
-				pStage->glslShaderGroup = tr.lightallShader;
+				pStage->glslShaderGroup = trs.lightallShader;
 				pStage->glslShaderIndex = LIGHTDEF_USE_LIGHT_VECTOR;
 
 				if (pStage->bundle[0].tcGen != TCGEN_TEXTURE || pStage->bundle[0].numTexMods != 0)
@@ -2576,7 +2576,7 @@ static qboolean CollapseStagesToGLSL(void)
 		if (!pStage->active)
 			continue;
 
-		if (pStage->glslShaderGroup != tr.lightallShader)
+		if (pStage->glslShaderGroup != trs.lightallShader)
 			continue;
 
 		if ((pStage->glslShaderIndex & LIGHTDEF_LIGHTTYPE_MASK) == 0)

--- a/code/renderergl2/tr_sky.c
+++ b/code/renderergl2/tr_sky.c
@@ -424,7 +424,7 @@ static void DrawSkySide( struct image_s *image, const int mins[2], const int max
 	RB_UpdateVBOs(ATTR_POSITION | ATTR_TEXCOORD);
 /*
 	{
-		shaderProgram_t *sp = &tr.textureColorShader;
+		shaderProgram_t *sp = &trs.textureColorShader;
 
 		GLSL_VertexAttribsState(ATTR_POSITION | ATTR_TEXCOORD);
 		GLSL_BindProgram(sp);
@@ -439,7 +439,7 @@ static void DrawSkySide( struct image_s *image, const int mins[2], const int max
 	}
 */
 	{
-		shaderProgram_t *sp = &tr.lightallShader[0];
+		shaderProgram_t *sp = &trs.lightallShader[0];
 		vec4_t vector;
 
 		GLSL_VertexAttribsState(ATTR_POSITION | ATTR_TEXCOORD);

--- a/code/renderergl2/tr_surface.c
+++ b/code/renderergl2/tr_surface.c
@@ -226,10 +226,10 @@ void RB_InstantQuad(vec4_t quadVerts[4])
 	VectorSet2(texCoords[2], 1.0f, 1.0f);
 	VectorSet2(texCoords[3], 0.0f, 1.0f);
 
-	GLSL_BindProgram(&tr.textureColorShader);
+	GLSL_BindProgram(&trs.textureColorShader);
 	
-	GLSL_SetUniformMat4(&tr.textureColorShader, UNIFORM_MODELVIEWPROJECTIONMATRIX, glState.modelviewProjection);
-	GLSL_SetUniformVec4(&tr.textureColorShader, UNIFORM_COLOR, colorWhite);
+	GLSL_SetUniformMat4(&trs.textureColorShader, UNIFORM_MODELVIEWPROJECTIONMATRIX, glState.modelviewProjection);
+	GLSL_SetUniformVec4(&trs.textureColorShader, UNIFORM_COLOR, colorWhite);
 
 	RB_InstantQuad2(quadVerts, texCoords);
 }
@@ -536,7 +536,7 @@ static void RB_SurfaceBeam( void )
 {
 #define NUM_BEAM_SEGS 6
 	refEntity_t *e;
-	shaderProgram_t *sp = &tr.textureColorShader;
+	shaderProgram_t *sp = &trs.textureColorShader;
 	int	i;
 	vec3_t perpvec;
 	vec3_t direction, normalized_direction;


### PR DESCRIPTION
To preface this, I realize this change may be completely undesired, but I thought I'd at least present it.

On my Macbook Pro currently shader generation takes ~1.1 seconds on renderer2, and the renderer restarts 3 times when launching directly into a map. So, about ~2.2 seconds of time is wasted generating shaders.

In my actual use case (compiling ioq3 to run on the web), shader generation is even more expensive (~2.5 seconds) making it 5+ seconds wasted generating shaders.

With this change, I've added a a trStatic_t structure that holds onto data unrelated to the hunk, which is only reset when the context is destroyed (perhaps this makes sense to merge this and glState_t, they have the same lifecycle I believe).

I've then moved the shaderProgram_t structures into this new structure, and we early out and avoid rebuilding shaders unless cvars that control the shader generation have changed.

Aside from that, there was a global find and replace to change references from `tr.[shader]` to `trs.[shader]`.
