### PR TITLE
When cross compiling on mingw32, make sure it finds a CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -534,6 +534,10 @@ ifeq ($(PLATFORM),mingw32)
     endif
   endif
 
+  ifeq ($(CC),)
+    $(error Cannot find a suitable cross compiler for $(PLATFORM))
+  endif
+
   BASE_CFLAGS = -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
     -DUSE_ICON
 


### PR DESCRIPTION
WIthout this check, it will leave CC= and try to use the first CFLAG as a compiler if the user forgot to install a cross compiler.

Tested on Debian testing with mingw64.
