### PR TITLE
Add support for clang 3.4 in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,7 +591,10 @@ ifeq ($(PLATFORM),mingw32)
   endif
 
   LIBS= -lws2_32 -lwinmm -lpsapi
-  CLIENT_LDFLAGS += -mwindows
+  # clang 3.4 doesn't support this
+  ifneq ("$(CC)", $(findstring "$(CC)", "clang" "clang++"))
+    CLIENT_LDFLAGS += -mwindows
+  endif
   CLIENT_LIBS = -lgdi32 -lole32
   RENDERER_LIBS = -lgdi32 -lole32 -lopengl32
 


### PR DESCRIPTION
Clang 3.4 doesn't support -falign-loops=2 or -falign-jumps=2
