### PR TITLE
Add support for x86_64 cross compiling in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ compiler:
   - gcc
   - clang
   - i686-w64-mingw32-gcc
+  - x86_64-w64-mingw32-gcc
 
 script: ./travis-ci-build.sh
 

--- a/travis-ci-build.sh
+++ b/travis-ci-build.sh
@@ -8,6 +8,11 @@ if [ "$CC" = "i686-w64-mingw32-gcc" ]; then
 	export ARCH=x86
 	export CC=
 	haveExternalLibs=0
+elif [ "$CC" = "x86_64-w64-mingw32-gcc" ]; then
+	export PLATFORM=mingw32
+	export ARCH=x86_64
+	export CC=
+	haveExternalLibs=0
 else
 	haveExternalLibs=1
 fi


### PR DESCRIPTION
Add x86_64 cross compiling support.  This was tested with OpenArena/engine.
