### PR TITLE
Made MinGW statically link libgcc to patch run-time renderer error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,10 +574,6 @@ ifeq ($(PLATFORM),mingw32)
 
   BINEXT=.exe
 
-  ifeq ($(CROSS_COMPILING),0)
-    TOOLS_BINEXT=.exe
-  endif
-
   LIBS= -lws2_32 -lwinmm -lpsapi
   CLIENT_LDFLAGS += -mwindows
   CLIENT_LIBS = -lgdi32 -lole32

--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,12 @@ ifeq ($(PLATFORM),mingw32)
   CLIENT_LDFLAGS += -mwindows
   CLIENT_LIBS = -lgdi32 -lole32
   RENDERER_LIBS = -lgdi32 -lole32 -lopengl32
-
+  
+  ifeq ($(CROSS_COMPILING),0)
+    TOOLS_BINEXT=.exe
+    RENDERER_LIBS += -static-libgcc	
+  endif
+  
   ifeq ($(USE_FREETYPE),1)
     BASE_CFLAGS += -Ifreetype2
   endif


### PR DESCRIPTION
Compiling on Windows using `make` through MinGW with GCC v.4.8.1-4 and `USE_RENDERER_DLOPEN=1` results in _libgcc_ becoming dynamically linked in the renderer DLLs. This again results in the following run-time error when the engine loads the renderer:

```
The program can't start because libgcc_s_dw2-1.dll is missing from your
computer. Try reinstalling the program to fix this problem.
```

This pull request ensures that libgcc is statically linked during the build. It is not an issue when cross-compiling.
