### PR TITLE
Fix possible division by zero in S_PaintChannelFrom16_altivec

### DIFF
--- a/code/client/snd_mix.c
+++ b/code/client/snd_mix.c
@@ -236,6 +236,10 @@ static void S_PaintChannelFrom16_altivec( channel_t *ch, const sfx_t *sc, int co
 	short					*samples;
 	float					ooff, fdata[2], fdiv, fleftvol, frightvol;
 
+	if (sc->soundChannels <= 0) {
+		return;
+	}
+
 	samp = &paintbuffer[ bufferOffset ];
 
 	if (ch->doppler) {


### PR DESCRIPTION
Fixed recently in S_PaintChannelFrom16_scalar but missed in S_PaintChannelFrom16_altivec
