### PR TITLE
Implement S_ClearSoundBuffer in OpenAL sound

### DIFF
--- a/code/client/cl_curl.c
+++ b/code/client/cl_curl.c
@@ -225,6 +225,8 @@ CURLcode qcurl_easy_setopt_warn(CURL *curl, CURLoption option, va_list args)
 	if(result != CURLE_OK) {
 		Com_DPrintf("qcurl_easy_setopt failed: %s\n", qcurl_easy_strerror(result));
 	}
+
+	return result;
 }
 
 void CL_cURL_BeginDownload( const char *localName, const char *remoteURL )

--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -769,8 +769,6 @@ void S_AL_SrcShutdown( void )
 	{
 		curSource = &srcList[i];
 
-		srcList[i].isLocked = qfalse;
-		
 		if(curSource->isLocked)
 		{
 			srcList[i].isLocked = qfalse;

--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -772,7 +772,10 @@ void S_AL_SrcShutdown( void )
 		srcList[i].isLocked = qfalse;
 		
 		if(curSource->isLocked)
-			Com_DPrintf( S_COLOR_YELLOW "WARNING: Source %d is locked\n", i);
+		{
+			srcList[i].isLocked = qfalse;
+			Com_DPrintf( S_COLOR_YELLOW "WARNING: Source %d was locked\n", i);
+		}
 
 		if(curSource->entity > 0)
 			entityList[curSource->entity].srcAllocated = qfalse;

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -483,9 +483,9 @@ static void PM_WaterMove( void ) {
 	// jump = head for surface
 	if ( pm->cmd.upmove >= 10 ) {
 		if (pm->ps->velocity[2] > -300) {
-			if ( pm->watertype == CONTENTS_WATER ) {
+			if ( pm->watertype & CONTENTS_WATER ) {
 				pm->ps->velocity[2] = 100;
-			} else if (pm->watertype == CONTENTS_SLIME) {
+			} else if ( pm->watertype & CONTENTS_SLIME ) {
 				pm->ps->velocity[2] = 80;
 			} else {
 				pm->ps->velocity[2] = 50;

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -717,7 +717,7 @@ long FS_SV_FOpenFileRead(const char *filename, fileHandle_t *fp)
 	Q_strncpyz( fsh[f].name, filename, sizeof( fsh[f].name ) );
 
 	// don't let sound stutter
-	S_ClearSoundBuffer();
+//	S_ClearSoundBuffer();
 
 	// search homepath
 	ospath = FS_BuildOSPath( fs_homepath->string, filename, "" );
@@ -777,7 +777,7 @@ void FS_SV_Rename( const char *from, const char *to, qboolean safe ) {
 	}
 
 	// don't let sound stutter
-	S_ClearSoundBuffer();
+//	S_ClearSoundBuffer();
 
 	from_ospath = FS_BuildOSPath( fs_homepath->string, from, "" );
 	to_ospath = FS_BuildOSPath( fs_homepath->string, to, "" );
@@ -811,7 +811,7 @@ void FS_Rename( const char *from, const char *to ) {
 	}
 
 	// don't let sound stutter
-	S_ClearSoundBuffer();
+//	S_ClearSoundBuffer();
 
 	from_ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, from );
 	to_ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, to );
@@ -919,7 +919,7 @@ fileHandle_t FS_FOpenFileAppend( const char *filename ) {
 	Q_strncpyz( fsh[f].name, filename, sizeof( fsh[f].name ) );
 
 	// don't let sound stutter
-	S_ClearSoundBuffer();
+//	S_ClearSoundBuffer();
 
 	ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, filename );
 
@@ -962,7 +962,7 @@ fileHandle_t FS_FCreateOpenPipeFile( const char *filename ) {
 	Q_strncpyz( fsh[f].name, filename, sizeof( fsh[f].name ) );
 
 	// don't let sound stutter
-	S_ClearSoundBuffer();
+//	S_ClearSoundBuffer();
 
 	ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, filename );
 


### PR DESCRIPTION
Fix for Bug 5418

This fixes stuttering looping sounds and background tracks after map changes. Sources and buffers were not cleared like they are in Base sound. Bug has been present for at least three years.

Example video of the bug is posted here:
http://www.youtube.com/watch?v=rQAu_YpnP2o

The bug was not actually caused by revision 1712 as stated.