### PR TITLE
Fix building with curl on Linux PPC and Sparc

### DIFF
--- a/code/libcurl-7.35.0/curl/curlbuild.h
+++ b/code/libcurl-7.35.0/curl/curlbuild.h
@@ -528,7 +528,8 @@
 
 #elif defined(__GNUC__)
 #  if defined(__ILP32__) || \
-      defined(__i386__) || defined(__ppc__) || defined(__arm__)
+      defined(__i386__) || defined(__ppc__) || defined(__powerpc__) || \
+      defined(__arm__) || defined(__sparc__)
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
@@ -538,7 +539,8 @@
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__LP64__) || \
-        defined(__x86_64__) || defined(__ppc64__)
+        defined(__x86_64__) || defined(__ppc64__) || defined(__powerpc64__) || \
+        defined(__sparc64__)
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"


### PR DESCRIPTION
ioquake3 fails to build due to missing defines for PPC and Sparc

Changes were submitted and merged upstream in curl repo
