### PR TITLE
Add mingw prefix for cygwin32 and mingw32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,7 @@ ifeq ($(PLATFORM),mingw32)
       MINGW_PREFIXES=amd64-mingw32msvc x86_64-w64-mingw32
     endif
     ifeq ($(ARCH),x86)
-      MINGW_PREFIXES=i586-mingw32msvc i686-w64-mingw32
+      MINGW_PREFIXES=i586-mingw32msvc i686-w64-mingw32 i686-pc-mingw32
     endif
 
     ifndef CC


### PR DESCRIPTION
I am running Cygwin 32-bit. Make was unable to find the CC command, because the Make file was not looking for the correct location. GCC is installed on my setup as  /usr/bin/i686-pc-mingw32-gcc.

So I added the appropriate prefix to the Make file to allow building.

After this change, everything compiles fine.