### PR TITLE
Fix compile error with ml64 assembler

### DIFF
--- a/code/asm/ftola.asm
+++ b/code/asm/ftola.asm
@@ -21,10 +21,9 @@
 ; MASM ftol conversion functions using SSE or FPU
 ; assume __cdecl calling convention is being used for x86, __fastcall for x64
 
+IFNDEF idx64
 .686p
 .xmm
-
-IFNDEF idx64
 .model flat, c
 ENDIF
 

--- a/code/asm/snapvector.asm
+++ b/code/asm/snapvector.asm
@@ -24,10 +24,9 @@
 ; function prototype:
 ; void qsnapvector(vec3_t vec)
 
+IFNDEF idx64
 .686p
 .xmm
-
-IFNDEF idx64
 .model flat, c
 ENDIF
 


### PR DESCRIPTION
ml64 does not recognise .686p and .xmm directives (i assume because they are superfluous on 64 bit processors) and produces errors.
