### PR TITLE
No fixed console linewidth

### DIFF
--- a/code/client/cl_console.c
+++ b/code/client/cl_console.c
@@ -273,7 +273,7 @@ void Con_CheckResize (void)
 	int		i, j, width, oldwidth, oldtotallines, numlines, numchars;
 	short	tbuf[CON_TEXTSIZE];
 
-	width = (SCREEN_WIDTH / SMALLCHAR_WIDTH) - 2;
+	width = (cls.glconfig.vidWidth / SMALLCHAR_WIDTH) - 2;
 
 	if (width == con.linewidth)
 		return;


### PR DESCRIPTION
No need to limit the text to SCREEN_WIDTH=640.
