### PR TITLE
Fix a bunch of typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -433,9 +433,9 @@
 		
 2002-8-05 Timothee Besset <ttimo@idsoftware.com>
 	+ removed sv_allowanonymous, was dummy and polluting the serverinfo
-		(sv_allowanonymous was designed to flag wether server was public or not, but that's replaced by g_needpass)
+		(sv_allowanonymous was designed to flag whether server was public or not, but that's replaced by g_needpass)
 	+ https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=514
-		sv_strictAuth (default 1): server variable to control wether strict CDKEY auth should be performed
+		sv_strictAuth (default 1): server variable to control whether strict CDKEY auth should be performed
 			this is required if you want reliable cl_guid on the server
 		extended the getIpAuthorize (server->auth message) syntax
 		sending the fs_game at all times (default 'baseq3'), dummy sv_allowAnonymous 0, strict auth flag

--- a/ChangeLog
+++ b/ChangeLog
@@ -634,7 +634,7 @@
     #1 current directory
     #2 fs_homepath
     #3 fs_basepath
-    this was needed to make mod developement easier
+    this was needed to make mod development easier
 
 2001-10-09  Timothee Besset <ttimo@idsoftware.com>
   + https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=51
@@ -861,7 +861,7 @@
 2001-04-23  Timothee Besset <ttimo@idsoftware.com>
 
 	* cleanup the mod selection code, remove duplicates
-	* some issues with release builds, my main developement box doesn't build stable binaries with release settings
+	* some issues with release builds, my main development box doesn't build stable binaries with release settings
 	  removing -fomit-frame-pointer seems to fix (there's probably a performance hit)
 	  see OMIT-FRAME-POINTER.txt
 

--- a/code/AL/al.h
+++ b/code/AL/al.h
@@ -363,7 +363,7 @@ typedef void ALvoid;
 /** No error. */
 #define AL_NO_ERROR                              0
 
-/** Invalid name paramater passed to AL call. */
+/** Invalid name parameter passed to AL call. */
 #define AL_INVALID_NAME                          0xA001
 
 /** Invalid enum parameter passed to AL call. */

--- a/code/SDL2/include/SDL_haptic.h
+++ b/code/SDL2/include/SDL_haptic.h
@@ -897,7 +897,7 @@ extern DECLSPEC int SDLCALL SDL_JoystickIsHaptic(SDL_Joystick * joystick);
 /**
  *  \brief Opens a Haptic device for usage from a Joystick device.
  *
- *  You must still close the haptic device seperately.  It will not be closed
+ *  You must still close the haptic device separately.  It will not be closed
  *  with the joystick.
  *
  *  When opening from a joystick you should first close the haptic device before

--- a/code/botlib/aasfile.h
+++ b/code/botlib/aasfile.h
@@ -191,7 +191,7 @@ typedef struct aas_edge_s
 //edge index, negative if vertexes are reversed
 typedef int aas_edgeindex_t;
 
-//a face bounds an area, often it will also seperate two areas
+//a face bounds an area, often it will also separate two areas
 typedef struct aas_face_s
 {
 	int planenum;						//number of the plane this face is in

--- a/code/botlib/be_aas_bspq3.c
+++ b/code/botlib/be_aas_bspq3.c
@@ -70,7 +70,7 @@ typedef struct bsp_entity_s
 	bsp_epair_t *epairs;
 } bsp_entity_t;
 
-//id Sofware BSP data
+//id Software BSP data
 typedef struct bsp_s
 {
 	//true when bsp file is loaded

--- a/code/botlib/be_aas_cluster.c
+++ b/code/botlib/be_aas_cluster.c
@@ -1138,7 +1138,7 @@ void AAS_RemoveNotClusterClosingPortals(void)
 
 void AAS_RemoveNotClusterClosingPortals(void)
 {
-	int i, j, facenum, otherareanum, nonclosingportals, numseperatedclusters;
+	int i, j, facenum, otherareanum, nonclosingportals, numseparatedclusters;
 	aas_area_t *area;
 	aas_face_t *face;
 
@@ -1149,7 +1149,7 @@ void AAS_RemoveNotClusterClosingPortals(void)
 	{
 		if (!(aasworld.areasettings[i].contents & AREACONTENTS_CLUSTERPORTAL)) continue;
 		//
-		numseperatedclusters = 0;
+		numseparatedclusters = 0;
 		//reset all cluster fields
 		AAS_RemoveClusterAreas();
 		//find a non-portal area adjacent to the portal area and flood
@@ -1168,11 +1168,11 @@ void AAS_RemoveNotClusterClosingPortals(void)
 			if (aasworld.areasettings[otherareanum].contents & AREACONTENTS_CLUSTERPORTAL) continue;
 			//if the area already has a cluster set
 			if (aasworld.areasettings[otherareanum].cluster) continue;
-			//another cluster is seperated by this portal
-			numseperatedclusters++;
+			//another cluster is separated by this portal
+			numseparatedclusters++;
 			//flood the cluster
-			AAS_FloodCluster_r(otherareanum, numseperatedclusters);
-			AAS_FloodClusterReachabilities(numseperatedclusters);
+			AAS_FloodCluster_r(otherareanum, numseparatedclusters);
+			AAS_FloodClusterReachabilities(numseparatedclusters);
 		} //end for
 		//use the reachabilities to flood into other areas
 		for (j = 0; j < aasworld.areasettings[i].numreachableareas; j++)
@@ -1185,14 +1185,14 @@ void AAS_RemoveNotClusterClosingPortals(void)
 			if (aasworld.areasettings[otherareanum].contents & AREACONTENTS_CLUSTERPORTAL) continue;
 			//if the area already has a cluster set
 			if (aasworld.areasettings[otherareanum].cluster) continue;
-			//another cluster is seperated by this portal
-			numseperatedclusters++;
+			//another cluster is separated by this portal
+			numseparatedclusters++;
 			//flood the cluster
-			AAS_FloodCluster_r(otherareanum, numseperatedclusters);
-			AAS_FloodClusterReachabilities(numseperatedclusters);
+			AAS_FloodCluster_r(otherareanum, numseparatedclusters);
+			AAS_FloodClusterReachabilities(numseparatedclusters);
 		} //end for
-		//a portal must seperate no more and no less than 2 clusters
-		if (numseperatedclusters != 2)
+		//a portal must separate no more and no less than 2 clusters
+		if (numseparatedclusters != 2)
 		{
 			aasworld.areasettings[i].contents &= ~AREACONTENTS_CLUSTERPORTAL;
 			nonclosingportals++;

--- a/code/botlib/be_aas_cluster.c
+++ b/code/botlib/be_aas_cluster.c
@@ -1479,7 +1479,7 @@ void AAS_InitClustering(void)
 	AAS_RemoveClusterAreas();
 	//find possible cluster portals
 	AAS_FindPossiblePortals();
-	//craete portals to for the bot view
+	//create portals to for the bot view
 	AAS_CreateViewPortals();
 	//remove all portals that are not closing a cluster
 	//AAS_RemoveNotClusterClosingPortals();

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -959,7 +959,7 @@ qboolean AAS_InsideFace(aas_face_t *face, vec3_t pnormal, vec3_t point, float ep
 		//edge) and through both the edge vector and the normal vector
 		//of the plane
 		AAS_OrthogonalToVectors(edgevec, pnormal, sepnormal);
-		//check on wich side of the above plane the point is
+		//check on which side of the above plane the point is
 		//this is done by checking the sign of the dot product of the
 		//vector orthogonal vector from above and the vector from the
 		//origin (first vertex of edge) to the point 

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -1083,7 +1083,7 @@ aas_face_t *AAS_TraceEndFace(aas_trace_t *trace)
 		//if the face is in the same plane as the trace end point
 		if ((face->planenum & ~1) == (trace->planenum & ~1))
 		{
-			//firstface is used for optimization, if theres only one
+			//firstface is used for optimization, if there is only one
 			//face in the plane then it has to be the good one
 			//if there are more faces in the same plane then always
 			//check the one with the fewest edges first

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -699,7 +699,7 @@ aas_trace_t AAS_TraceClientBBox(vec3_t start, vec3_t end, int presencetype,
 				return trace;
 			} //end if
 			//now put the part near the start of the line on the stack so we will
-			//continue with thats part first. This way we'll find the first
+			//continue with that part first. This way we'll find the first
 			//hit of the bbox
 			VectorCopy(cur_start, tstack_p->start);
 			VectorCopy(cur_mid, tstack_p->end);
@@ -885,7 +885,7 @@ int AAS_TraceAreas(vec3_t start, vec3_t end, int *areas, vec3_t *points, int max
 				return numareas;
 			} //end if
 			//now put the part near the start of the line on the stack so we will
-			//continue with thats part first. This way we'll find the first
+			//continue with that part first. This way we'll find the first
 			//hit of the bbox
 			VectorCopy(cur_start, tstack_p->start);
 			VectorCopy(cur_mid, tstack_p->end);

--- a/code/botlib/be_aas_sample.c
+++ b/code/botlib/be_aas_sample.c
@@ -688,7 +688,7 @@ aas_trace_t AAS_TraceClientBBox(vec3_t start, vec3_t end, int presencetype,
 			side = front < 0;
 			//first put the end part of the line on the stack (back side)
 			VectorCopy(cur_mid, tstack_p->start);
-			//not necesary to store because still on stack
+			//not necessary to store because still on stack
 			//VectorCopy(cur_end, tstack_p->end);
 			tstack_p->planenum = aasnode->planenum;
 			tstack_p->nodenum = aasnode->children[!side];
@@ -874,7 +874,7 @@ int AAS_TraceAreas(vec3_t start, vec3_t end, int *areas, vec3_t *points, int max
 			side = front < 0;
 			//first put the end part of the line on the stack (back side)
 			VectorCopy(cur_mid, tstack_p->start);
-			//not necesary to store because still on stack
+			//not necessary to store because still on stack
 			//VectorCopy(cur_end, tstack_p->end);
 			tstack_p->planenum = aasnode->planenum;
 			tstack_p->nodenum = aasnode->children[!side];

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -557,7 +557,7 @@ void StringReplaceWords(char *string, char *synonym, char *replacement)
 	while(str)
 	{
 		//if the synonym isn't part of the replacement which is already in the string
-		//useful for abreviations
+		//useful for abbreviations
 		str2 = StringContainsWord(string, replacement, qfalse);
 		while(str2)
 		{

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -567,7 +567,7 @@ void StringReplaceWords(char *string, char *synonym, char *replacement)
 		if (!str2)
 		{
 			memmove(str + strlen(replacement), str+strlen(synonym), strlen(str+strlen(synonym))+1);
-			//append the synonum replacement
+			//append the synonym replacement
 			Com_Memcpy(str, replacement, strlen(replacement));
 		} //end if
 		//find the next synonym in the string
@@ -855,7 +855,7 @@ void BotReplaceReplySynonyms(char *string, unsigned long int context)
 				//
 				memmove(str1 + strlen(replacement), str1+strlen(synonym->string),
 							strlen(str1+strlen(synonym->string)) + 1);
-				//append the synonum replacement
+				//append the synonym replacement
 				Com_Memcpy(str1, replacement, strlen(replacement));
 				//
 				break;

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -557,7 +557,7 @@ void StringReplaceWords(char *string, char *synonym, char *replacement)
 	while(str)
 	{
 		//if the synonym isn't part of the replacement which is already in the string
-		//usefull for abreviations
+		//useful for abreviations
 		str2 = StringContainsWord(string, replacement, qfalse);
 		while(str2)
 		{

--- a/code/botlib/be_ai_gen.c
+++ b/code/botlib/be_ai_gen.c
@@ -62,7 +62,7 @@ int GeneticSelection(int numranks, float *rankings)
 	} //end for
 	if (sum > 0)
 	{
-		//select a bot where the ones with the higest rankings have
+		//select a bot where the ones with the highest rankings have
 		//the highest chance of being selected
 		//sum *= random();
 		for (i = 0; i < numranks; i++)

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -2744,7 +2744,7 @@ bot_moveresult_t BotTravel_RocketJump(bot_movestate_t *ms, aas_reachability_t *r
 	result.ideal_viewangles[PITCH] = 90;
 	//set the view angles directly
 	EA_View(ms->client, result.ideal_viewangles);
-	//view is important for the movment
+	//view is important for the movement
 	result.flags |= MOVERESULT_MOVEMENTVIEWSET;
 	//select the rocket launcher
 	EA_SelectWeapon(ms->client, (int) weapindex_rocketlauncher->value);
@@ -2804,7 +2804,7 @@ bot_moveresult_t BotTravel_BFGJump(bot_movestate_t *ms, aas_reachability_t *reac
 	result.ideal_viewangles[PITCH] = 90;
 	//set the view angles directly
 	EA_View(ms->client, result.ideal_viewangles);
-	//view is important for the movment
+	//view is important for the movement
 	result.flags |= MOVERESULT_MOVEMENTVIEWSET;
 	//select the rocket launcher
 	EA_SelectWeapon(ms->client, (int) weapindex_bfg10k->value);

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -1980,7 +1980,7 @@ bot_moveresult_t BotTravel_Ladder(bot_movestate_t *ms, aas_reachability_t *reach
 		//elementary action
 		EA_Move(ms->client, origin, 0);
 		EA_MoveForward(ms->client);
-		//set movement view flag so the AI can see the view is focussed
+		//set movement view flag so the AI can see the view is focused
 		result.flags |= MOVERESULT_MOVEMENTVIEW;
 	} //end if
 /*	else

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -1366,7 +1366,7 @@ bot_moveresult_t BotTravel_Walk(bot_movestate_t *ms, aas_reachability_t *reach)
 		if (dist > 0) speed = 400 - (360 - 2 * dist);
 		else speed = 400;
 	} //end else
-	//elemantary action move in direction
+	//elementary action move in direction
 	EA_Move(ms->client, hordir, speed);
 	VectorCopy(hordir, result.movedir);
 	//
@@ -1429,7 +1429,7 @@ bot_moveresult_t BotTravel_Crouch(bot_movestate_t *ms, aas_reachability_t *reach
 	VectorNormalize(hordir);
 	//
 	BotCheckBlocked(ms, hordir, qtrue, &result);
-	//elemantary actions
+	//elementary actions
 	EA_Crouch(ms->client);
 	EA_Move(ms->client, hordir, speed);
 	//
@@ -1513,7 +1513,7 @@ bot_moveresult_t BotTravel_Swim(bot_movestate_t *ms, aas_reachability_t *reach)
 	VectorNormalize(dir);
 	//
 	BotCheckBlocked(ms, dir, qtrue, &result);
-	//elemantary actions
+	//elementary actions
 	EA_Move(ms->client, dir, 400);
 	//
 	VectorCopy(dir, result.movedir);
@@ -1542,7 +1542,7 @@ bot_moveresult_t BotTravel_WaterJump(bot_movestate_t *ms, aas_reachability_t *re
 	//botimport.Print(PRT_MESSAGE, "BotTravel_WaterJump: dir[2] = %f\n", dir[2]);
 	VectorNormalize(dir);
 	dist = VectorNormalize(hordir);
-	//elemantary actions
+	//elementary actions
 	//EA_Move(ms->client, dir, 400);
 	EA_MoveForward(ms->client);
 	//move up if close to the actual out of water jump spot
@@ -1579,7 +1579,7 @@ bot_moveresult_t BotFinishTravel_WaterJump(bot_movestate_t *ms, aas_reachability
 	dir[0] += crandom() * 10;
 	dir[1] += crandom() * 10;
 	dir[2] += 70 + crandom() * 10;
-	//elemantary actions
+	//elementary actions
 	EA_Move(ms->client, dir, 400);
 	//set the ideal view angles
 	Vector2Angles(dir, result.ideal_viewangles);
@@ -1645,7 +1645,7 @@ bot_moveresult_t BotTravel_WalkOffLedge(bot_movestate_t *ms, aas_reachability_t 
 	} //end else
 	//
 	BotCheckBlocked(ms, hordir, qtrue, &result);
-	//elemantary action
+	//elementary action
 	EA_Move(ms->client, hordir, speed);
 	VectorCopy(hordir, result.movedir);
 	//
@@ -1759,7 +1759,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 		hordir[0] = reach->end[0] - ms->origin[0];
 		hordir[1] = reach->end[1] - ms->origin[1];
 		VectorNormalize(hordir);
-		//elemantary action jump
+		//elementary action jump
 		EA_Jump(ms->client);
 		//
 		ms->jumpreach = ms->lastreachnum;
@@ -1772,7 +1772,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 			speed = horspeed * 400 / botlibglobals.sv_maxwalkvelocity->value;
 		} //end if
 	} //end else
-	//elemantary action
+	//elementary action
 	EA_Move(ms->client, hordir, speed);
 	VectorCopy(hordir, result.movedir);
 	//
@@ -1827,7 +1827,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 		hordir[1] = reach->end[1] - ms->origin[1];
 		hordir[2] = 0;
 		VectorNormalize(hordir);
-		//elemantary action jump
+		//elementary action jump
 		if (dist1 < 24) EA_Jump(ms->client);
 		else if (dist1 < 32) EA_DelayedJump(ms->client);
 		EA_Move(ms->client, hordir, 600);
@@ -1893,7 +1893,7 @@ bot_moveresult_t BotTravel_Jump(bot_movestate_t *ms, aas_reachability_t *reach)
 		hordir[1] = reach->end[1] - ms->origin[1];
 		hordir[2] = 0;
 		VectorNormalize(hordir);
-		//elemantary action jump
+		//elementary action jump
 		if (dist1 < 24) EA_Jump(ms->client);
 		else if (dist1 < 32) EA_DelayedJump(ms->client);
 		EA_Move(ms->client, hordir, 600);
@@ -1977,7 +1977,7 @@ bot_moveresult_t BotTravel_Ladder(bot_movestate_t *ms, aas_reachability_t *reach
 		viewdir[1] = dir[1];
 		viewdir[2] = 3 * dir[2];
 		Vector2Angles(viewdir, result.ideal_viewangles);
-		//elemantary action
+		//elementary action
 		EA_Move(ms->client, origin, 0);
 		EA_MoveForward(ms->client);
 		//set movement view flag so the AI can see the view is focussed
@@ -2682,7 +2682,7 @@ bot_moveresult_t BotTravel_Grapple(bot_movestate_t *ms, aas_reachability_t *reac
 			else speed = 400;
 			//
 			BotCheckBlocked(ms, dir, qtrue, &result);
-			//elemantary action move in direction
+			//elementary action move in direction
 			EA_Move(ms->client, dir, speed);
 			VectorCopy(dir, result.movedir);
 		} //end else
@@ -2725,7 +2725,7 @@ bot_moveresult_t BotTravel_RocketJump(bot_movestate_t *ms, aas_reachability_t *r
 		hordir[1] = reach->end[1] - ms->origin[1];
 		hordir[2] = 0;
 		VectorNormalize(hordir);
-		//elemantary action jump
+		//elementary action jump
 		EA_Jump(ms->client);
 		EA_Attack(ms->client);
 		EA_Move(ms->client, hordir, 800);
@@ -2785,7 +2785,7 @@ bot_moveresult_t BotTravel_BFGJump(bot_movestate_t *ms, aas_reachability_t *reac
 		hordir[1] = reach->end[1] - ms->origin[1];
 		hordir[2] = 0;
 		VectorNormalize(hordir);
-		//elemantary action jump
+		//elementary action jump
 		EA_Jump(ms->client);
 		EA_Attack(ms->client);
 		EA_Move(ms->client, hordir, 800);
@@ -2872,7 +2872,7 @@ bot_moveresult_t BotTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t *reac
 	hordir[2] = 0;
 	//
 	BotCheckBlocked(ms, hordir, qtrue, &result);
-	//elemantary action move in direction
+	//elementary action move in direction
 	EA_Move(ms->client, hordir, 400);
 	VectorCopy(hordir, result.movedir);
 	//
@@ -2899,7 +2899,7 @@ bot_moveresult_t BotFinishTravel_JumpPad(bot_movestate_t *ms, aas_reachability_t
 		speed = 400;
 	} //end if
 	BotCheckBlocked(ms, hordir, qtrue, &result);
-	//elemantary action move in direction
+	//elementary action move in direction
 	EA_Move(ms->client, hordir, speed);
 	VectorCopy(hordir, result.movedir);
 	//
@@ -2975,7 +2975,7 @@ bot_moveresult_t BotMoveInGoalArea(bot_movestate_t *ms, bot_goal_t *goal)
 	if (speed < 10) speed = 0;
 	//
 	BotCheckBlocked(ms, dir, qtrue, &result);
-	//elemantary action move in direction
+	//elementary action move in direction
 	EA_Move(ms->client, dir, speed);
 	VectorCopy(dir, result.movedir);
 	//

--- a/code/botlib/be_ai_move.c
+++ b/code/botlib/be_ai_move.c
@@ -1202,7 +1202,7 @@ int BotWalkInDirection(bot_movestate_t *ms, vec3_t dir, float speed, int type)
 		if (type & MOVE_JUMP) EA_Jump(ms->client);
 		if (type & MOVE_CROUCH) EA_Crouch(ms->client);
 		EA_Move(ms->client, hordir, speed);
-		//movement was succesfull
+		//movement was successful
 		return qtrue;
 	} //end if
 	else

--- a/code/botlib/be_ai_weight.c
+++ b/code/botlib/be_ai_weight.c
@@ -726,7 +726,7 @@ void EvolveFuzzySeperator_r(fuzzyseperator_t *fs)
 		//every once in a while an evolution leap occurs, mutation
 		if (random() < 0.01) fs->weight += crandom() * (fs->maxweight - fs->minweight);
 		else fs->weight += crandom() * (fs->maxweight - fs->minweight) * 0.5;
-		//modify bounds if necesary because of mutation
+		//modify bounds if necessary because of mutation
 		if (fs->weight < fs->minweight) fs->minweight = fs->weight;
 		else if (fs->weight > fs->maxweight) fs->maxweight = fs->weight;
 	} //end else if

--- a/code/botlib/be_ai_weight.h
+++ b/code/botlib/be_ai_weight.h
@@ -64,7 +64,7 @@ typedef struct weightconfig_s
 weightconfig_t *ReadWeightConfig(char *filename);
 //free a weight configuration
 void FreeWeightConfig(weightconfig_t *config);
-//writes a weight configuration, returns true if successfull
+//writes a weight configuration, returns true if successful
 qboolean WriteWeightConfig(char *filename, weightconfig_t *config);
 //find the fuzzy weight with the given name
 int FindFuzzyWeight(weightconfig_t *wc, char *name);

--- a/code/botlib/be_interface.c
+++ b/code/botlib/be_interface.c
@@ -210,7 +210,7 @@ int Export_BotLibShutdown(void)
 	BotShutdownCharacters();	//be_ai_char.c
 	//shud down aas
 	AAS_Shutdown();
-	//shut down bot elemantary actions
+	//shut down bot elementary actions
 	EA_Shutdown();
 	//free all libvars
 	LibVarDeAllocAll();

--- a/code/botlib/l_precomp.h
+++ b/code/botlib/l_precomp.h
@@ -141,7 +141,7 @@ void PC_RemoveAllGlobalDefines(void);
 void PC_AddBuiltinDefines(source_t *source);
 //set the source include path
 void PC_SetIncludePath(source_t *source, char *path);
-//set the punction set
+//set the punctuation set
 void PC_SetPunctuations(source_t *source, punctuation_t *p);
 //set the base folder to load files from
 void PC_SetBaseFolder(char *path);

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -99,7 +99,7 @@ punctuation_t default_punctuations[] =
 	{"<=",P_LOGIC_LEQ, NULL},
 	{"==",P_LOGIC_EQ, NULL},
 	{"!=",P_LOGIC_UNEQ, NULL},
-	//arithmatic operators
+	//arithmetic operators
 	{"*=",P_MUL_ASSIGN, NULL},
 	{"/=",P_DIV_ASSIGN, NULL},
 	{"%=",P_MOD_ASSIGN, NULL},
@@ -118,7 +118,7 @@ punctuation_t default_punctuations[] =
 	//C++
 	{"::",P_CPP1, NULL},
 	{".*",P_CPP2, NULL},
-	//arithmatic operators
+	//arithmetic operators
 	{"*",P_MUL, NULL},
 	{"/",P_DIV, NULL},
 	{"%",P_MOD, NULL},

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -838,7 +838,7 @@ int PS_ReadPrimitive(script_t *script, token_t *token)
 	token->string[len] = 0;
 	//copy the token into the script structure
 	Com_Memcpy(&script->token, token, sizeof(token_t));
-	//primitive reading successfull
+	//primitive reading successful
 	return 1;
 } //end of the function PS_ReadPrimitive
 //============================================================================

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -475,7 +475,7 @@ int PS_ReadString(script_t *script, token_t *token, int quote)
 			//
 			tmpscript_p = script->script_p;
 			tmpline = script->line;
-			//read unusefull stuff between possible two following strings
+			//read unuseful stuff between possible two following strings
 			if (!PS_ReadWhiteSpace(script))
 			{
 				script->script_p = tmpscript_p;
@@ -865,7 +865,7 @@ int PS_ReadToken(script_t *script, token_t *token)
 	//start of the white space
 	script->whitespace_p = script->script_p;
 	token->whitespace_p = script->script_p;
-	//read unusefull stuff
+	//read unuseful stuff
 	if (!PS_ReadWhiteSpace(script)) return 0;
 	//end of the white space
 	script->endwhitespace_p = script->script_p;

--- a/code/botlib/l_struct.h
+++ b/code/botlib/l_struct.h
@@ -69,7 +69,7 @@ int ReadStructure(source_t *source, structdef_t *def, char *structure);
 int WriteStructure(FILE *fp, structdef_t *def, char *structure);
 //writes indents
 int WriteIndent(FILE *fp, int indent);
-//writes a float without traling zeros
+//writes a float without trailing zeros
 int WriteFloat(FILE *fp, float value);
 
 

--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -358,7 +358,7 @@ static void CG_TauntDeathInsult_f (void ) {
 }
 
 static void CG_TauntGauntlet_f (void ) {
-	trap_SendConsoleCommand("cmd vsay kill_guantlet\n");
+	trap_SendConsoleCommand("cmd vsay kill_gauntlet\n");
 }
 
 static void CG_TaskSuicide_f (void ) {

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1654,7 +1654,7 @@ static void CG_DrawLagometer( void ) {
 
 	vscale = range / MAX_LAGOMETER_RANGE;
 
-	// draw the frame interpoalte / extrapolate graph
+	// draw the frame interpolate / extrapolate graph
 	for ( a = 0 ; a < aw ; a++ ) {
 		i = ( lagometer.frameCount - 1 - a ) & (LAG_SAMPLES - 1);
 		v = lagometer.frameSamples[i];

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -274,7 +274,7 @@ static void CG_Item( centity_t *cent ) {
 	}
 
 	wi = NULL;
-	// the weapons have their origin where they attatch to player
+	// the weapons have their origin where they attach to player
 	// models, so we need to offset them or they will rotate
 	// eccentricly
 	if ( item->giType == IT_WEAPON ) {

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -276,7 +276,7 @@ static void CG_Item( centity_t *cent ) {
 	wi = NULL;
 	// the weapons have their origin where they attach to player
 	// models, so we need to offset them or they will rotate
-	// eccentricly
+	// eccentrically
 	if ( item->giType == IT_WEAPON ) {
 		wi = &cg_weapons[item->giTag];
 		cent->lerpOrigin[0] -= 

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -605,7 +605,7 @@ typedef struct {
 
 	int			itemPickup;
 	int			itemPickupTime;
-	int			itemPickupBlendTime;	// the pulse around the crosshair is timed seperately
+	int			itemPickupBlendTime;	// the pulse around the crosshair is timed separately
 
 	int			weaponSelectTime;
 	int			weaponAnimation;
@@ -1615,7 +1615,7 @@ void		trap_GetGlconfig( glconfig_t *glconfig );
 void		trap_GetGameState( gameState_t *gamestate );
 
 // cgame will poll each frame to see if a newer snapshot has arrived
-// that it is interested in.  The time is returned seperately so that
+// that it is interested in.  The time is returned separately so that
 // snapshot latency can be calculated.
 void		trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime );
 

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -462,7 +462,7 @@ typedef struct {
 	qboolean	loading;			// don't defer players at initial startup
 	qboolean	intermissionStarted;	// don't play voice rewards, because game will end shortly
 
-	// there are only one or two snapshot_t that are relevent at a time
+	// there are only one or two snapshot_t that are relevant at a time
 	int			latestSnapshotNum;	// the number of snapshots the client system has received
 	int			latestSnapshotTime;	// the time from latestSnapshotNum, so we don't need to read the snapshot yet
 

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -162,7 +162,7 @@ typedef struct {
 
 
 
-// centity_t have a direct corespondence with gentity_t in the game, but
+// centity_t have a direct correspondence with gentity_t in the game, but
 // only the entityState_t is directly communicated to the cgame
 typedef struct centity_s {
 	entityState_t	currentState;	// from cg.frame

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -293,7 +293,7 @@ typedef struct {
 	int				accuracy;
 	int				impressiveCount;
 	int				excellentCount;
-	int				guantletCount;
+	int				gauntletCount;
 	int				defendCount;
 	int				assistCount;
 	int				captures;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -495,7 +495,7 @@ static void CG_RegisterItemSounds( int itemNum ) {
 		trap_S_RegisterSound( item->pickup_sound, qfalse );
 	}
 
-	// parse the space seperated precache string for other media
+	// parse the space separated precache string for other media
 	s = item->sounds;
 	if (!s || !s[0])
 		return;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -381,7 +381,7 @@ void CG_UpdateCvars( void ) {
 		trap_Cvar_Update( cv->vmCvar );
 	}
 
-	// check for modications here
+	// check for modifications here
 
 	// If team overlay is on, ask for updates from the server.  If it's off,
 	// let the server know so we don't receive it

--- a/code/cgame/cg_marks.c
+++ b/code/cgame/cg_marks.c
@@ -82,7 +82,7 @@ void CG_FreeMarkPoly( markPoly_t *le ) {
 ===================
 CG_AllocMark
 
-Will allways succeed, even if it requires freeing an old active mark
+Will always succeed, even if it requires freeing an old active mark
 ===================
 */
 markPoly_t	*CG_AllocMark( void ) {

--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -1455,7 +1455,7 @@ void CG_DrawMedal(int ownerDraw, rectDef_t *rect, float scale, vec4_t color, qha
 			value = score->perfect;
 			break;
 		case CG_GAUNTLET:
-			value = score->guantletCount;
+			value = score->gauntletCount;
 			break;
 		case CG_CAPTURES:
 			value = score->captures;

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -1371,7 +1371,7 @@ static void CG_AddPainTwitch( centity_t *cent, vec3_t torsoAngles ) {
 ===============
 CG_PlayerAngles
 
-Handles seperate torso motion
+Handles separate torso motion
 
   legs pivot based on direction of movement
 

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -1042,7 +1042,7 @@ void CG_NewClientInfo( int clientNum ) {
 
 		forceDefer = trap_MemoryRemaining() < 4000000;
 
-		// if we are defering loads, just have it pick the first valid
+		// if we are deferring loads, just have it pick the first valid
 		if ( forceDefer || (cg_deferPlayers.integer && !cg_buildScript.integer && !cg.loading ) ) {
 			// keep whatever they had if it won't violate team skins
 			CG_SetDeferredClientInfo( clientNum, &newInfo );

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -982,7 +982,7 @@ void CG_NewClientInfo( int clientNum ) {
 
 		slash = strchr( newInfo.modelName, '/' );
 		if ( !slash ) {
-			// modelName didn not include a skin name
+			// modelName did not include a skin name
 			Q_strncpyz( newInfo.skinName, "default", sizeof( newInfo.skinName ) );
 		} else {
 			Q_strncpyz( newInfo.skinName, slash + 1, sizeof( newInfo.skinName ) );
@@ -1026,7 +1026,7 @@ void CG_NewClientInfo( int clientNum ) {
 
 		slash = strchr( newInfo.headModelName, '/' );
 		if ( !slash ) {
-			// modelName didn not include a skin name
+			// modelName did not include a skin name
 			Q_strncpyz( newInfo.headSkinName, "default", sizeof( newInfo.headSkinName ) );
 		} else {
 			Q_strncpyz( newInfo.headSkinName, slash + 1, sizeof( newInfo.headSkinName ) );

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -1482,7 +1482,7 @@ static void CG_PlayerAngles( centity_t *cent, vec3_t legs[3], vec3_t torso[3], v
 	// pain twitch
 	CG_AddPainTwitch( cent, torsoAngles );
 
-	// pull the angles back out of the hierarchial chain
+	// pull the angles back out of the hierarchical chain
 	AnglesSubtract( headAngles, torsoAngles, headAngles );
 	AnglesSubtract( torsoAngles, legsAngles, torsoAngles );
 	AnglesToAxis( legsAngles, legs );

--- a/code/cgame/cg_public.h
+++ b/code/cgame/cg_public.h
@@ -206,7 +206,7 @@ typedef enum {
 
 	CG_SHUTDOWN,
 //	void (*CG_Shutdown)( void );
-	// oportunity to flush and close any open files
+	// opportunity to flush and close any open files
 
 	CG_CONSOLE_COMMAND,
 //	qboolean (*CG_ConsoleCommand)( void );

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -473,7 +473,7 @@ void CG_DrawOldTourneyScoreboard( void ) {
 	color[2] = 1;
 	color[3] = 1;
 
-	// print the mesage of the day
+	// print the message of the day
 	s = CG_ConfigString( CS_MOTD );
 	if ( !s[0] ) {
 		s = "Scoreboard";

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 //
 // cg_servercmds.c -- reliably sequenced text commands sent by the server
-// these are processed at snapshot transition time, so there will definately
+// these are processed at snapshot transition time, so there will definitely
 // be a valid snapshot this frame
 
 #include "cg_local.h"

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -87,7 +87,7 @@ static void CG_ParseScores( void ) {
 		cg.scores[i].accuracy = atoi(CG_Argv(i * 14 + 10));
 		cg.scores[i].impressiveCount = atoi(CG_Argv(i * 14 + 11));
 		cg.scores[i].excellentCount = atoi(CG_Argv(i * 14 + 12));
-		cg.scores[i].guantletCount = atoi(CG_Argv(i * 14 + 13));
+		cg.scores[i].gauntletCount = atoi(CG_Argv(i * 14 + 13));
 		cg.scores[i].defendCount = atoi(CG_Argv(i * 14 + 14));
 		cg.scores[i].assistCount = atoi(CG_Argv(i * 14 + 15));
 		cg.scores[i].perfect = atoi(CG_Argv(i * 14 + 16));

--- a/code/cgame/cg_snapshot.c
+++ b/code/cgame/cg_snapshot.c
@@ -140,7 +140,7 @@ static void CG_TransitionSnapshot( void ) {
 	// execute any server string commands before transitioning entities
 	CG_ExecuteNewServerCommands( cg.nextSnap->serverCommandSequence );
 
-	// if we had a map_restart, set everthing with initial
+	// if we had a map_restart, set everything with initial
 	if ( !cg.snap ) {
 		return;
 	}

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -182,7 +182,7 @@ Sets the coordinates of the rendered window
 static void CG_CalcVrect (void) {
 	int		size;
 
-	// the intermission should allways be full screen
+	// the intermission should always be full screen
 	if ( cg.snap->ps.pm_type == PM_INTERMISSION ) {
 		size = 100;
 	} else {

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1289,7 +1289,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 	nonPredictedCent = &cg_entities[cent->currentState.clientNum];
 
 	// if the index of the nonPredictedCent is not the same as the clientNum
-	// then this is a fake player (like on teh single player podiums), so
+	// then this is a fake player (like on the single player podiums), so
 	// go ahead and use the cent
 	if( ( nonPredictedCent - cg_entities ) != cent->currentState.clientNum ) {
 		nonPredictedCent = cent;

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1240,7 +1240,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 		// add weapon ready sound
 		cent->pe.lightningFiring = qfalse;
 		if ( ( cent->currentState.eFlags & EF_FIRING ) && weapon->firingSound ) {
-			// lightning gun and guantlet make a different sound when fire is held down
+			// lightning gun and gauntlet make a different sound when fire is held down
 			trap_S_AddLoopingSound( cent->currentState.number, cent->lerpOrigin, vec3_origin, weapon->firingSound );
 			cent->pe.lightningFiring = qtrue;
 		} else if ( weapon->readySound ) {

--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -1078,7 +1078,7 @@ void CL_SetCGameTime( void ) {
 	}
 
 	while ( cl.serverTime >= cl.snap.serverTime ) {
-		// feed another messag, which should change
+		// feed another message, which should change
 		// the contents of cl.snap
 		CL_ReadDemoMessage();
 		if ( clc.state != CA_ACTIVE ) {

--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -341,7 +341,7 @@ rescan:
 	// the clientLevelShot command is used during development
 	// to generate 128*128 screenshots from the intermission
 	// point of levels for the menu system to use
-	// we pass it along to the cgame to make apropriate adjustments,
+	// we pass it along to the cgame to make appropriate adjustments,
 	// but we also clear the console and notify lines here
 	if ( !strcmp( cmd, "clientLevelShot" ) ) {
 		// don't do it if we aren't running the server locally,

--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -1036,7 +1036,7 @@ void CL_SetCGameTime( void ) {
 	}
 
 	// if we are playing a demo back, we can just keep reading
-	// messages from the demo file until the cgame definately
+	// messages from the demo file until the cgame definitely
 	// has valid snapshots to interpolate between
 
 	// a timedemo will always use a deterministic set of time samples

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -320,7 +320,7 @@ void CL_KeyMove( usercmd_t *cmd ) {
 
 	//
 	// adjust for speed key / running
-	// the walking flag is to keep animations consistant
+	// the walking flag is to keep animations consistent
 	// even during acceleration and develeration
 	//
 	if ( in_speed.active ^ cl_run->integer ) {

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -129,7 +129,7 @@ void IN_KeyUp( kbutton_t *b ) {
 	} else if ( b->down[1] == k ) {
 		b->down[1] = 0;
 	} else {
-		return;		// key up without coresponding down (menu pass through)
+		return;		// key up without corresponding down (menu pass through)
 	}
 	if ( b->down[0] || b->down[1] ) {
 		return;		// some other key is still holding it down

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -321,7 +321,7 @@ void CL_KeyMove( usercmd_t *cmd ) {
 	//
 	// adjust for speed key / running
 	// the walking flag is to keep animations consistent
-	// even during acceleration and develeration
+	// even during acceleration and deceleration
 	//
 	if ( in_speed.active ^ cl_run->integer ) {
 		movespeed = 127;

--- a/code/client/cl_keys.c
+++ b/code/client/cl_keys.c
@@ -1270,7 +1270,7 @@ void CL_KeyDownEvent( int key, unsigned time )
 	// send the bound action
 	CL_ParseBinding( key, qtrue, time );
 
-	// distribute the key down event to the apropriate handler
+	// distribute the key down event to the appropriate handler
 	if ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) {
 		Console_Key( key );
 	} else if ( Key_GetCatcher( ) & KEYCATCH_UI ) {
@@ -1352,7 +1352,7 @@ void CL_CharEvent( int key ) {
 		return;
 	}
 
-	// distribute the key down event to the apropriate handler
+	// distribute the key down event to the appropriate handler
 	if ( Key_GetCatcher( ) & KEYCATCH_CONSOLE )
 	{
 		Field_CharEvent( &g_consoleField, key );

--- a/code/client/cl_keys.c
+++ b/code/client/cl_keys.c
@@ -177,7 +177,7 @@ keyname_t keynames[] =
 
 	{"PAUSE", K_PAUSE},
 	
-	{"SEMICOLON", ';'},	// because a raw semicolon seperates commands
+	{"SEMICOLON", ';'},	// because a raw semicolon separates commands
 
 	{"WORLD_0", K_WORLD_0},
 	{"WORLD_1", K_WORLD_1},

--- a/code/client/cl_keys.c
+++ b/code/client/cl_keys.c
@@ -889,7 +889,7 @@ void Key_SetBinding( int keynum, const char *binding ) {
 	keys[keynum].binding = CopyString( binding );
 
 	// consider this like modifying an archived cvar, so the
-	// file write will be triggered at the next oportunity
+	// file write will be triggered at the next opportunity
 	cvar_modifiedFlags |= CVAR_ARCHIVE;
 }
 

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -1937,7 +1937,7 @@ void CL_Vid_Restart_f( void ) {
 		cls.cgameStarted = qfalse;
 		cls.soundRegistered = qfalse;
 
-		// unpause so the cgame definately gets a snapshot and renders a frame
+		// unpause so the cgame definitely gets a snapshot and renders a frame
 		Cvar_Set("cl_paused", "0");
 
 		// initialize the renderer interface
@@ -3273,7 +3273,7 @@ void CL_InitRef( void ) {
 
 	re = *ret;
 
-	// unpause so the cgame definately gets a snapshot and renders a frame
+	// unpause so the cgame definitely gets a snapshot and renders a frame
 	Cvar_Set( "cl_paused", "0" );
 }
 

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -1926,7 +1926,7 @@ void CL_Vid_Restart_f( void ) {
 		CL_ShutdownCGame();
 		// shutdown the renderer and clear the renderer interface
 		CL_ShutdownRef();
-		// client is no longer pure untill new checksums are sent
+		// client is no longer pure until new checksums are sent
 		CL_ResetPureClientAtServer();
 		// clear pak references
 		FS_ClearPakReferences( FS_UI_REF | FS_CGAME_REF );

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -2267,7 +2267,7 @@ void CL_InitDownloads(void) {
     if (FS_ComparePaks( missingfiles, sizeof( missingfiles ), qfalse ) )
     {      
       // NOTE TTimo I would rather have that printed as a modal message box
-      //   but at this point while joining the game we don't know wether we will successfully join or not
+      //   but at this point while joining the game we don't know whether we will successfully join or not
       Com_Printf( "\nWARNING: You are missing some files referenced by the server:\n%s"
                   "You might not be able to join the game\n"
                   "Go to the setting menu to turn on autodownload, or get the file elsewhere\n\n", missingfiles );

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -54,7 +54,7 @@ typedef struct {
 
 	int				messageNum;		// copied from netchan->incoming_sequence
 	int				deltaNum;		// messageNum the delta is from
-	int				ping;			// time from when cmdNum-1 was sent to time packet was reeceived
+	int				ping;			// time from when cmdNum-1 was sent to time packet was received
 	byte			areamask[MAX_MAP_AREA_BYTES];		// portalarea visibility bits
 
 	int				cmdNum;			// the next cmdNum the server is expecting

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -92,7 +92,7 @@ typedef struct {
 extern int g_console_field_width;
 
 typedef struct {
-	int			timeoutcount;		// it requres several frames in a timeout condition
+	int			timeoutcount;		// it requires several frames in a timeout condition
 									// to disconnect, preventing debugging breaks from
 									// causing immediate disconnects on continue
 	clSnapshot_t	snap;			// latest received from server

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -121,7 +121,7 @@ typedef struct {
 
 	// cmds[cmdNumber] is the predicted command, [cmdNumber-1] is the last
 	// properly generated command
-	usercmd_t	cmds[CMD_BACKUP];	// each mesage will send several old cmds
+	usercmd_t	cmds[CMD_BACKUP];	// each message will send several old cmds
 	int			cmdNumber;			// incremented each frame, because multiple
 									// frames may need to be packed into a single packet
 

--- a/code/client/keycodes.h
+++ b/code/client/keycodes.h
@@ -268,7 +268,7 @@ typedef enum {
 
 // MAX_KEYS replaces K_LAST_KEY, however some mods may have used K_LAST_KEY
 // in detecting binds, so we leave it defined to the old hardcoded value
-// of maxiumum keys to prevent mods from crashing older versions of the engine
+// of maximum keys to prevent mods from crashing older versions of the engine
 #define K_LAST_KEY              256
 
 // The menu code needs to get both key and char events, but

--- a/code/client/snd_mix.c
+++ b/code/client/snd_mix.c
@@ -515,7 +515,7 @@ static void S_PaintChannelFrom16_scalar( channel_t *ch, const sfx_t *sc, int cou
 static void S_PaintChannelFrom16( channel_t *ch, const sfx_t *sc, int count, int sampleOffset, int bufferOffset ) {
 #if idppc_altivec
 	if (com_altivec->integer) {
-		// must be in a seperate function or G3 systems will crash.
+		// must be in a separate function or G3 systems will crash.
 		S_PaintChannelFrom16_altivec( ch, sc, count, sampleOffset, bufferOffset );
 		return;
 	}

--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -2255,7 +2255,7 @@ void S_AL_Respatialize( int entityNum, const vec3_t origin, vec3_t axis[3], int 
 	lastListenerNumber = entityNum;
 	VectorCopy( sorigin, lastListenerOrigin );
 
-	// Set OpenAL listener paramaters
+	// Set OpenAL listener parameters
 	qalListenerfv(AL_POSITION, (ALfloat *)sorigin);
 	qalListenerfv(AL_VELOCITY, vec3_origin);
 	qalListenerfv(AL_ORIENTATION, orientation);

--- a/code/client/snd_public.h
+++ b/code/client/snd_public.h
@@ -58,7 +58,7 @@ void S_DisableSounds( void );
 
 void S_BeginRegistration( void );
 
-// RegisterSound will allways return a valid sample, even if it
+// RegisterSound will always return a valid sample, even if it
 // has to create a placeholder.  This prevents continuous filesystem
 // checks for missing files
 sfxHandle_t	S_RegisterSound( const char *sample, qboolean compressed );

--- a/code/client/snd_wavelet.c
+++ b/code/client/snd_wavelet.c
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 void daub4(float b[], unsigned long n, int isign)
 {
 	float wksp[4097] = { 0.0f };
-	float	*a=b-1;						// numerical recipies so a[1] = b[0]
+	float	*a=b-1;						// numerical recipes so a[1] = b[0]
 
 	unsigned long nh,nh1,i,j;
 

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -329,7 +329,7 @@ int BotGetItemLongTermGoal(bot_state_t *bs, int tfl, bot_goal_t *goal) {
 ==================
 BotGetLongTermGoal
 
-we could also create a seperate AI node for every long term goal type
+we could also create a separate AI node for every long term goal type
 however this saves us a lot of code
 ==================
 */

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -1337,7 +1337,7 @@ void BotClearPath(bot_state_t *bs, bot_moveresult_t *moveresult) {
 	bsp_trace_t bsptrace;
 	entityState_t state;
 
-	// if there is a dead body wearing kamikze nearby
+	// if there is a dead body wearing kamikaze nearby
 	if (bs->kamikazebody) {
 		// if the bot's view angles and weapon are not used for movement
 		if ( !(moveresult->flags & (MOVERESULT_MOVEMENTVIEW | MOVERESULT_MOVEMENTWEAPON)) ) {

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -285,7 +285,7 @@ qboolean EntityHasQuad(aas_entityinfo_t *entinfo) {
 #ifdef MISSIONPACK
 /*
 ==================
-EntityHasKamikze
+EntityHasKamikaze
 ==================
 */
 qboolean EntityHasKamikaze(aas_entityinfo_t *entinfo) {

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -2763,7 +2763,7 @@ bot_moveresult_t BotAttackMove(bot_state_t *bs, int tfl) {
 		bs->flags ^= BFL_STRAFERIGHT;
 		bs->attackstrafe_time = 0;
 	}
-	//bot couldn't do any usefull movement
+	//bot couldn't do any useful movement
 //	bs->attackchase_time = AAS_Time() + 6;
 	return moveresult;
 }

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -1257,7 +1257,7 @@ int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean resta
 	if (restart) {
 		BotReadSessionData(bs);
 	}
-	//bot has been setup succesfully
+	//bot has been setup successfully
 	return qtrue;
 }
 

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -899,7 +899,7 @@ static void PM_NoclipMove( void ) {
 ================
 PM_FootstepForSurface
 
-Returns an event number apropriate for the groundsurface
+Returns an event number appropriate for the groundsurface
 ================
 */
 static int PM_FootstepForSurface( void ) {
@@ -1402,7 +1402,7 @@ static void PM_Footsteps( void ) {
 	old = pm->ps->bobCycle;
 	pm->ps->bobCycle = (int)( old + bobmove * pml.msec ) & 255;
 
-	// if we just crossed a cycle boundary, play an apropriate footstep event
+	// if we just crossed a cycle boundary, play an appropriate footstep event
 	if ( ( ( old + 64 ) ^ ( pm->ps->bobCycle + 64 ) ) & 128 ) {
 		if ( pm->waterlevel == 0 ) {
 			// on ground will only play sounds if running

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1614,7 +1614,7 @@ static void PM_Weapon( void ) {
 
 	// start the animation even if out of ammo
 	if ( pm->ps->weapon == WP_GAUNTLET ) {
-		// the guantlet only "fires" when it actually hits something
+		// the gauntlet only "fires" when it actually hits something
 		if ( !pm->gauntletHit ) {
 			pm->ps->weaponTime = 0;
 			pm->ps->weaponstate = WEAPON_READY;

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1875,7 +1875,7 @@ void PmoveSingle (pmove_t *pmove) {
 		pm->ps->pm_flags &= ~PMF_RESPAWNED;
 	}
 
-	// if talk button is down, dissallow all other input
+	// if talk button is down, disallow all other input
 	// this is to prevent any possible intercept proxy from
 	// adding fake talk balloons
 	if ( pmove->cmd.buttons & BUTTON_TALK ) {

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -233,7 +233,7 @@ typedef enum {
 	PERS_EXCELLENT_COUNT,			// two successive kills in a short amount of time
 	PERS_DEFEND_COUNT,				// defend awards
 	PERS_ASSIST_COUNT,				// assist awards
-	PERS_GAUNTLET_FRAG_COUNT,		// kills with the guantlet
+	PERS_GAUNTLET_FRAG_COUNT,		// kills with the gauntlet
 	PERS_CAPTURES					// captures
 } persEnum_t;
 

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -279,7 +279,7 @@ void	G_TouchTriggers( gentity_t *ent ) {
 			}
 		}
 
-		// use seperate code for determining if an item is picked up
+		// use separate code for determining if an item is picked up
 		// so you don't have to actually contact its bounding box
 		if ( hit->s.eType == ET_ITEM ) {
 			if ( !BG_PlayerTouchesItem( &ent->client->ps, &hit->s, level.time ) ) {

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -627,7 +627,7 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 		case EV_USE_ITEM3:		// kamikaze
 			// make sure the invulnerability is off
 			ent->client->invulnerabilityTime = 0;
-			// start the kamikze
+			// start the kamikaze
 			G_StartKamikaze( ent );
 			break;
 

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -69,7 +69,7 @@ void P_DamageFeedback( gentity_t *player ) {
 		client->ps.damageYaw = angles[YAW]/360.0 * 256;
 	}
 
-	// play an apropriate pain sound
+	// play an appropriate pain sound
 	if ( (level.time > player->pain_debounce_time) && !(player->flags & FL_GODMODE) ) {
 		player->pain_debounce_time = level.time + 700;
 		G_AddEvent( player, EV_PAIN, player->health );

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -970,7 +970,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 		}
 	}
 
-	// get and distribute relevent paramters
+	// get and distribute relevant paramters
 	G_LogPrintf( "ClientConnect: %i\n", clientNum );
 	ClientUserinfoChanged( clientNum );
 

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -922,7 +922,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 
  	// IP filtering
  	// https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=500
- 	// recommanding PB based IP / GUID banning, the builtin system is pretty limited
+	// recommending PB based IP / GUID banning, the builtin system is pretty limited
  	// check to see if they are on the banned IP list
 	value = Info_ValueForKey (userinfo, "ip");
 	if ( G_FilterPacket( value ) ) {

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -970,7 +970,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 		}
 	}
 
-	// get and distribute relevant paramters
+	// get and distribute relevant parameters
 	G_LogPrintf( "ClientConnect: %i\n", clientNum );
 	ClientUserinfoChanged( clientNum );
 

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -907,7 +907,7 @@ void G_Say( gentity_t *ent, gentity_t *target, int mode, const char *chatText ) 
 		G_Printf( "%s%s\n", name, text);
 	}
 
-	// send it to all the apropriate clients
+	// send it to all the appropriate clients
 	for (j = 0; j < level.maxclients; j++) {
 		other = &g_entities[j];
 		G_SayTo( ent, other, mode, color, name, text );
@@ -1034,7 +1034,7 @@ void G_Voice( gentity_t *ent, gentity_t *target, int mode, const char *id, qbool
 		G_Printf( "voice: %s %s\n", ent->client->pers.netname, id);
 	}
 
-	// send it to all the apropriate clients
+	// send it to all the appropriate clients
 	for (j = 0; j < level.maxclients; j++) {
 		other = &g_entities[j];
 		G_VoiceTo( ent, other, mode, id, voiceonly );

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -630,7 +630,7 @@ void SetTeam( gentity_t *ent, char *s ) {
 
 	BroadcastTeamChange( client, oldTeam );
 
-	// get and distribute relevant paramters
+	// get and distribute relevant parameters
 	ClientUserinfoChanged( clientNum );
 
 	ClientBegin( clientNum );

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -630,7 +630,7 @@ void SetTeam( gentity_t *ent, char *s ) {
 
 	BroadcastTeamChange( client, oldTeam );
 
-	// get and distribute relevent paramters
+	// get and distribute relevant paramters
 	ClientUserinfoChanged( clientNum );
 
 	ClientBegin( clientNum );

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Respawnable items don't actually go away when picked up, they are
   just made invisible and untouchable.  This allows them to ride
-  movers and respawn apropriately.
+  movers and respawn appropriately.
 */
 
 

--- a/code/game/g_mover.c
+++ b/code/game/g_mover.c
@@ -1279,7 +1279,7 @@ void Reached_Train( gentity_t *ent ) {
 	vec3_t			move;
 	float			length;
 
-	// copy the apropriate values
+	// copy the appropriate values
 	next = ent->nextTrain;
 	if ( !next || !next->nextTrain ) {
 		return;		// just stop

--- a/code/game/g_mover.c
+++ b/code/game/g_mover.c
@@ -718,7 +718,7 @@ void InitMover( gentity_t *ent ) {
 	qboolean	lightSet, colorSet;
 	char		*sound;
 
-	// if the "model2" key is set, use a seperate model
+	// if the "model2" key is set, use a separate model
 	// for drawing, but clip against the brushes
 	if ( ent->model2 ) {
 		ent->s.modelindex2 = G_ModelIndex( ent->model2 );

--- a/code/game/g_mover.c
+++ b/code/game/g_mover.c
@@ -424,7 +424,7 @@ void G_MoverTeam( gentity_t *ent ) {
 
 	obstacle = NULL;
 
-	// make sure all team slaves can move before commiting
+	// make sure all team slaves can move before committing
 	// any moves or calling any think functions
 	// if the move is blocked, all moved objects will be backed out
 	pushed_p = pushed;

--- a/code/game/g_mover.c
+++ b/code/game/g_mover.c
@@ -180,7 +180,7 @@ qboolean	G_TryPushingEntity( gentity_t *check, gentity_t *pusher, vec3_t move, v
 	}
 
 	// if it is ok to leave in the old position, do it
-	// this is only relevent for riding entities, not pushed
+	// this is only relevant for riding entities, not pushed
 	// Sliding trapdoors can cause this.
 	VectorCopy( (pushed_p-1)->origin, check->s.pos.trBase);
 	if ( check->client ) {

--- a/code/opus-1.1/include/opus_multistream.h
+++ b/code/opus-1.1/include/opus_multistream.h
@@ -510,7 +510,7 @@ OPUS_EXPORT OPUS_WARN_UNUSED_RESULT OpusMSDecoder *opus_multistream_decoder_crea
       int *error
 ) OPUS_ARG_NONNULL(5);
 
-/** Intialize a previously allocated decoder state object.
+/** Initialize a previously allocated decoder state object.
   * The memory pointed to by \a st must be at least the size returned by
   * opus_multistream_encoder_get_size().
   * This is intended for applications which use their own allocator instead of

--- a/code/q3_ui/ui_atoms.c
+++ b/code/q3_ui/ui_atoms.c
@@ -803,7 +803,7 @@ static void NeedCDKeyAction( qboolean result ) {
 
 void UI_SetActiveMenu( uiMenuCommand_t menu ) {
 	// this should be the ONLY way the menu system is brought up
-	// enusure minumum menu data is cached
+	// ensure minimum menu data is cached
 	Menu_Cache();
 
 	switch ( menu ) {

--- a/code/q3_ui/ui_controls2.c
+++ b/code/q3_ui/ui_controls2.c
@@ -1637,10 +1637,10 @@ static void Controls_MenuInit( void )
 	// initialize the current config
 	Controls_GetConfig();
 
-	// intialize the model
+	// initialize the model
 	Controls_InitModel();
 
-	// intialize the weapons
+	// initialize the weapons
 	Controls_InitWeapons ();
 
 	// initial default section

--- a/code/q3_ui/ui_playermodel.c
+++ b/code/q3_ui/ui_playermodel.c
@@ -339,14 +339,14 @@ static void PlayerModel_PicEvent( void* ptr, int event )
 		Q_strncpyz(s_playermodel.modelskin,buffptr,pdest-buffptr+1);
 		strcat(s_playermodel.modelskin,pdest + 5);
 
-		// seperate the model name
+		// separate the model name
 		maxlen = pdest-buffptr;
 		if (maxlen > 16)
 			maxlen = 16;
 		Q_strncpyz( s_playermodel.modelname.string, buffptr, maxlen );
 		Q_strupr( s_playermodel.modelname.string );
 
-		// seperate the skin name
+		// separate the skin name
 		maxlen = strlen(pdest+5)+1;
 		if (maxlen > 16)
 			maxlen = 16;
@@ -494,14 +494,14 @@ static void PlayerModel_SetMenuItems( void )
 			s_playermodel.selectedmodel = i;
 			s_playermodel.modelpage     = i/MAX_MODELSPERPAGE;
 
-			// seperate the model name
+			// separate the model name
 			maxlen = pdest-buffptr;
 			if (maxlen > 16)
 				maxlen = 16;
 			Q_strncpyz( s_playermodel.modelname.string, buffptr, maxlen );
 			Q_strupr( s_playermodel.modelname.string );
 
-			// seperate the skin name
+			// separate the skin name
 			maxlen = strlen(pdest+5)+1;
 			if (maxlen > 16)
 				maxlen = 16;

--- a/code/q3_ui/ui_players.c
+++ b/code/q3_ui/ui_players.c
@@ -615,7 +615,7 @@ static void UI_PlayerAngles( playerInfo_t *pi, vec3_t legs[3], vec3_t torso[3], 
 	UI_SwingAngles( dest, 15, 30, 0.1f, &pi->torso.pitchAngle, &pi->torso.pitching );
 	torsoAngles[PITCH] = pi->torso.pitchAngle;
 
-	// pull the angles back out of the hierarchial chain
+	// pull the angles back out of the hierarchical chain
 	AnglesSubtract( headAngles, torsoAngles, headAngles );
 	AnglesSubtract( torsoAngles, legsAngles, torsoAngles );
 	AnglesToAxis( legsAngles, legs );

--- a/code/q3_ui/ui_qmenu.c
+++ b/code/q3_ui/ui_qmenu.c
@@ -54,7 +54,7 @@ vec4_t pulse_color          = {1.00f, 1.00f, 1.00f, 1.00f};
 vec4_t text_color_disabled  = {0.50f, 0.50f, 0.50f, 1.00f};	// light gray
 vec4_t text_color_normal    = {1.00f, 0.43f, 0.00f, 1.00f};	// light orange
 vec4_t text_color_highlight = {1.00f, 1.00f, 0.00f, 1.00f};	// bright yellow
-vec4_t listbar_color        = {1.00f, 0.43f, 0.00f, 0.30f};	// transluscent orange
+vec4_t listbar_color        = {1.00f, 0.43f, 0.00f, 0.30f};	// translucent orange
 vec4_t text_color_status    = {1.00f, 1.00f, 1.00f, 1.00f};	// bright white	
 
 // action widget

--- a/code/q3_ui/ui_servers2.c
+++ b/code/q3_ui/ui_servers2.c
@@ -796,7 +796,7 @@ void ArenaServers_LoadFavorites( void )
 
 		if (j < numtempitems)
 		{
-			// found server - add exisiting results
+			// found server - add existing results
 			memcpy( &g_favoriteserverlist[g_numfavoriteservers], &templist[j], sizeof(servernode_t) );
 			found = qtrue;
 		}

--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -1424,7 +1424,7 @@ void CM_TraceThroughPatchCollide( traceWork_t *tw, const struct patchCollide_s *
 		VectorCopy(planes->plane, plane);
 		plane[3] = planes->plane[3];
 		if ( tw->sphere.use ) {
-			// adjust the plane distance apropriately for radius
+			// adjust the plane distance appropriately for radius
 			plane[3] += tw->sphere.radius;
 
 			// find the closest point on the capsule to the plane
@@ -1463,7 +1463,7 @@ void CM_TraceThroughPatchCollide( traceWork_t *tw, const struct patchCollide_s *
 				plane[3] = planes->plane[3];
 			}
 			if ( tw->sphere.use ) {
-				// adjust the plane distance apropriately for radius
+				// adjust the plane distance appropriately for radius
 				plane[3] += tw->sphere.radius;
 
 				// find the closest point on the capsule to the plane
@@ -1552,7 +1552,7 @@ qboolean CM_PositionTestInPatchCollide( traceWork_t *tw, const struct patchColli
 		VectorCopy(planes->plane, plane);
 		plane[3] = planes->plane[3];
 		if ( tw->sphere.use ) {
-			// adjust the plane distance apropriately for radius
+			// adjust the plane distance appropriately for radius
 			plane[3] += tw->sphere.radius;
 
 			// find the closest point on the capsule to the plane
@@ -1585,7 +1585,7 @@ qboolean CM_PositionTestInPatchCollide( traceWork_t *tw, const struct patchColli
 				plane[3] = planes->plane[3];
 			}
 			if ( tw->sphere.use ) {
-				// adjust the plane distance apropriately for radius
+				// adjust the plane distance appropriately for radius
 				plane[3] += tw->sphere.radius;
 
 				// find the closest point on the capsule to the plane

--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -120,7 +120,7 @@ static int CM_SignbitsForNormal( vec3_t normal ) {
 =====================
 CM_PlaneFromPoints
 
-Returns false if the triangle is degenrate.
+Returns false if the triangle is degenerate.
 The normal will point out of the clock for clockwise ordered points
 =====================
 */
@@ -1078,7 +1078,7 @@ static void CM_PatchCollideFromGrid( cGrid_t *grid, patchCollide_t *pf ) {
 
 			if ( gridPlanes[i][j][0] == gridPlanes[i][j][1] ) {
 				if ( gridPlanes[i][j][0] == -1 ) {
-					continue;		// degenrate
+					continue;		// degenerate
 				}
 				facet->surfacePlane = gridPlanes[i][j][0];
 				facet->numBorders = 4;

--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -282,7 +282,7 @@ static void CM_SetGridWrapWidth( cGrid_t *grid ) {
 CM_SubdivideGridColumns
 
 Adds columns as necessary to the grid until
-all the aproximating points are within SUBDIVIDE_DISTANCE
+all the approximating points are within SUBDIVIDE_DISTANCE
 from the true curve
 =================
 */
@@ -291,11 +291,11 @@ static void CM_SubdivideGridColumns( cGrid_t *grid ) {
 
 	for ( i = 0 ; i < grid->width - 2 ;  ) {
 		// grid->points[i][x] is an interpolating control point
-		// grid->points[i+1][x] is an aproximating control point
+		// grid->points[i+1][x] is an approximating control point
 		// grid->points[i+2][x] is an interpolating control point
 
 		//
-		// first see if we can collapse the aproximating collumn away
+		// first see if we can collapse the approximating collumn away
 		//
 		for ( j = 0 ; j < grid->height ; j++ ) {
 			if ( CM_NeedsSubdivision( grid->points[i][j], grid->points[i+1][j], grid->points[i+2][j] ) ) {
@@ -343,7 +343,7 @@ static void CM_SubdivideGridColumns( cGrid_t *grid ) {
 
 		grid->width += 2;
 
-		// the new aproximating point at i+1 may need to be removed
+		// the new approximating point at i+1 may need to be removed
 		// or subdivided farther, so don't advance i
 	}
 }
@@ -1205,7 +1205,7 @@ struct patchCollide_s	*CM_GeneratePatchCollide( int width, int height, vec3_t *p
 	CM_RemoveDegenerateColumns( &grid );
 
 	// we now have a grid of points exactly on the curve
-	// the aproximate surface defined by these points will be
+	// the approximate surface defined by these points will be
 	// collided against
 	pf = Hunk_Alloc( sizeof( *pf ), h_high );
 	ClearBounds( pf->bounds[0], pf->bounds[1] );

--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -1096,7 +1096,7 @@ static void CM_PatchCollideFromGrid( cGrid_t *grid, patchCollide_t *pf ) {
 					numFacets++;
 				}
 			} else {
-				// two seperate triangles
+				// two separate triangles
 				facet->surfacePlane = gridPlanes[i][j][0];
 				facet->numBorders = 3;
 				facet->borderPlanes[0] = borders[EN_TOP];

--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -1360,7 +1360,7 @@ int CM_CheckFacetPlane(float *plane, vec3_t start, vec3_t end, float *enterFrac,
 		return qfalse;
 	}
 
-	// if it doesn't cross the plane, the plane isn't relevent
+	// if it doesn't cross the plane, the plane isn't relevant
 	if (d1 <= 0 && d2 <= 0 ) {
 		return qtrue;
 	}

--- a/code/qcommon/cm_trace.c
+++ b/code/qcommon/cm_trace.c
@@ -548,7 +548,7 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush ) {
 				return;
 			}
 
-			// if it doesn't cross the plane, the plane isn't relevent
+			// if it doesn't cross the plane, the plane isn't relevant
 			if (d1 <= 0 && d2 <= 0 ) {
 				continue;
 			}
@@ -602,7 +602,7 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush ) {
 				return;
 			}
 
-			// if it doesn't cross the plane, the plane isn't relevent
+			// if it doesn't cross the plane, the plane isn't relevant
 			if (d1 <= 0 && d2 <= 0 ) {
 				continue;
 			}

--- a/code/qcommon/cm_trace.c
+++ b/code/qcommon/cm_trace.c
@@ -189,7 +189,7 @@ void CM_TestBoxInBrush( traceWork_t *tw, cbrush_t *brush ) {
 			side = brush->sides + i;
 			plane = side->plane;
 
-			// adjust the plane distance apropriately for radius
+			// adjust the plane distance appropriately for radius
 			dist = plane->dist + tw->sphere.radius;
 			// find the closest point on the capsule to the plane
 			t = DotProduct( plane->normal, tw->sphere.offset );
@@ -214,7 +214,7 @@ void CM_TestBoxInBrush( traceWork_t *tw, cbrush_t *brush ) {
 			side = brush->sides + i;
 			plane = side->plane;
 
-			// adjust the plane distance apropriately for mins/maxs
+			// adjust the plane distance appropriately for mins/maxs
 			dist = plane->dist - DotProduct( tw->offsets[ plane->signbits ], plane->normal );
 
 			d1 = DotProduct( tw->start, plane->normal ) - dist;
@@ -517,7 +517,7 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush ) {
 			side = brush->sides + i;
 			plane = side->plane;
 
-			// adjust the plane distance apropriately for radius
+			// adjust the plane distance appropriately for radius
 			dist = plane->dist + tw->sphere.radius;
 
 			// find the closest point on the capsule to the plane
@@ -584,7 +584,7 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush ) {
 			side = brush->sides + i;
 			plane = side->plane;
 
-			// adjust the plane distance apropriately for mins/maxs
+			// adjust the plane distance appropriately for mins/maxs
 			dist = plane->dist - DotProduct( tw->offsets[ plane->signbits ], plane->normal );
 
 			d1 = DotProduct( tw->start, plane->normal ) - dist;
@@ -1059,7 +1059,7 @@ void CM_TraceThroughTree( traceWork_t *tw, int num, float p1f, float p2f, vec3_t
 	node = cm.nodes + num;
 	plane = node->plane;
 
-	// adjust the plane distance apropriately for mins/maxs
+	// adjust the plane distance appropriately for mins/maxs
 	if ( plane->type < 3 ) {
 		t1 = p1[plane->type] - plane->dist;
 		t2 = p2[plane->type] - plane->dist;
@@ -1204,7 +1204,7 @@ void CM_Trace( trace_t *results, const vec3_t start, const vec3_t end, vec3_t mi
 
 	tw.maxOffset = tw.size[1][0] + tw.size[1][1] + tw.size[1][2];
 
-	// tw.offsets[signbits] = vector to apropriate corner from origin
+	// tw.offsets[signbits] = vector to appropriate corner from origin
 	tw.offsets[0][0] = tw.size[0][0];
 	tw.offsets[0][1] = tw.size[0][1];
 	tw.offsets[0][2] = tw.size[0][2];

--- a/code/qcommon/cmd.c
+++ b/code/qcommon/cmd.c
@@ -489,7 +489,7 @@ void Cmd_Args_Sanitize(void)
 Cmd_TokenizeString
 
 Parses the given string into command line tokens.
-The text is copied to a seperate buffer and 0 characters
+The text is copied to a separate buffer and 0 characters
 are inserted in the apropriate place, The argv array
 will point into this temporary buffer.
 ============

--- a/code/qcommon/cmd.c
+++ b/code/qcommon/cmd.c
@@ -490,7 +490,7 @@ Cmd_TokenizeString
 
 Parses the given string into command line tokens.
 The text is copied to a separate buffer and 0 characters
-are inserted in the apropriate place, The argv array
+are inserted in the appropriate place, The argv array
 will point into this temporary buffer.
 ============
 */

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2918,7 +2918,7 @@ void Com_WriteConfiguration( void ) {
 #if !defined(DEDICATED) && !defined(STANDALONE)
 	cvar_t	*fs;
 #endif
-	// if we are quiting without fully initializing, make sure
+	// if we are quitting without fully initializing, make sure
 	// we don't write out anything
 	if ( !com_fullyInitialized ) {
 		return;

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -152,7 +152,7 @@ void Com_EndRedirect (void)
 Com_Printf
 
 Both client and server can use this, and it will output
-to the apropriate place.
+to the appropriate place.
 
 A raw string should NEVER be passed as fmt, because of "%f" type crashers.
 =============
@@ -349,7 +349,7 @@ void QDECL Com_Error( int code, const char *fmt, ... ) {
 Com_Quit_f
 
 Both client and server can use this, and it will
-do the apropriate things.
+do the appropriate things.
 =============
 */
 void Com_Quit_f( void ) {

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -377,7 +377,7 @@ void Com_Quit_f( void ) {
 
 COMMAND LINE FUNCTIONS
 
-+ characters seperate the commandLine string into multiple console
++ characters separate the commandLine string into multiple console
 command lines.
 
 All of these are valid:
@@ -486,7 +486,7 @@ void Com_StartupVariable( const char *match ) {
 Com_AddStartupCommands
 
 Adds command line parameters as script statements
-Commands are seperated by + signs
+Commands are separated by + signs
 
 Returns qtrue if any late commands were added, which
 will keep the demoloop from immediately starting

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -2517,7 +2517,7 @@ int	FS_GetModList( char *listbuf, int bufsize ) {
 		// we drop "baseq3" "." and ".."
 		if (Q_stricmp(name, com_basegame->string) && Q_stricmpn(name, ".", 1)) {
 			// now we need to find some .pk3 files to validate the mod
-			// NOTE TTimo: (actually I'm not sure why .. what if it's a mod under developement with no .pk3?)
+			// NOTE TTimo: (actually I'm not sure why .. what if it's a mod under development with no .pk3?)
 			// we didn't keep the information when we merged the directory names, as to what OS Path it was found under
 			//   so it could be in base path, cd path or home path
 			//   we will try each three of them here (yes, it's a bit messy)

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -3684,7 +3684,7 @@ const char *FS_ReferencedPakPureChecksums( void ) {
 	numPaks = 0;
 	for (nFlags = FS_CGAME_REF; nFlags; nFlags = nFlags >> 1) {
 		if (nFlags & FS_GENERAL_REF) {
-			// add a delimter between must haves and general refs
+			// add a delimiter between must haves and general refs
 			//Q_strcat(info, sizeof(info), "@ ");
 			info[strlen(info)+1] = '\0';
 			info[strlen(info)+2] = '\0';

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -286,7 +286,7 @@ typedef struct {
 static fileHandleData_t	fsh[MAX_FILE_HANDLES];
 
 // TTimo - https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=540
-// wether we did a reorder on the current search path when joining the server
+// whether we did a reorder on the current search path when joining the server
 static qboolean fs_reordered;
 
 // never load anything from pk3 files that are not present at the server when pure
@@ -2524,7 +2524,7 @@ int	FS_GetModList( char *listbuf, int bufsize ) {
 			path = FS_BuildOSPath( fs_basepath->string, name, "" );
 			nPaks = 0;
 			pPaks = Sys_ListFiles(path, ".pk3", NULL, &nPaks, qfalse); 
-			Sys_FreeFileList( pPaks ); // we only use Sys_ListFiles to check wether .pk3 files are present
+			Sys_FreeFileList( pPaks ); // we only use Sys_ListFiles to check whether .pk3 files are present
 
 			/* try on home path */
 			if ( nPaks <= 0 )

--- a/code/qcommon/q_math.c
+++ b/code/qcommon/q_math.c
@@ -263,7 +263,7 @@ float NormalizeColor( const vec3_t in, vec3_t out ) {
 =====================
 PlaneFromPoints
 
-Returns false if the triangle is degenrate.
+Returns false if the triangle is degenerate.
 The normal will point out of the clock for clockwise ordered points
 =====================
 */

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -251,7 +251,7 @@ typedef int		clipHandle_t;
 
 #define	MAX_SAY_TEXT	150
 
-// paramters for command buffer stuffing
+// parameters for command buffer stuffing
 typedef enum {
 	EXEC_NOW,			// don't return until completed, a VM should NEVER use this,
 						// because some commands might cause the VM to be unloaded...

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1040,7 +1040,7 @@ typedef struct {
 
 // sound channels
 // channel 0 never willingly overrides
-// other channels will allways override a playing sound on that channel
+// other channels will always override a playing sound on that channel
 typedef enum {
 	CHAN_AUTO,
 	CHAN_LOCAL,		// menu sounds, etc

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -638,7 +638,7 @@ int		FS_GetModList(  char *listbuf, int bufsize );
 fileHandle_t	FS_FOpenFileWrite( const char *qpath );
 fileHandle_t	FS_FOpenFileAppend( const char *filename );
 fileHandle_t	FS_FCreateOpenPipeFile( const char *filename );
-// will properly create any needed paths and deal with seperater character issues
+// will properly create any needed paths and deal with separater character issues
 
 fileHandle_t FS_SV_FOpenFileWrite( const char *filename );
 long		FS_SV_FOpenFileRead( const char *filename, fileHandle_t *fp );

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -458,7 +458,7 @@ char	*Cmd_Cmd (void);
 void	Cmd_Args_Sanitize( void );
 // The functions that execute commands get their parameters with these
 // functions. Cmd_Argv () will return an empty string, not a NULL
-// if arg > argc, so string operations are allways safe.
+// if arg > argc, so string operations are always safe.
 
 void	Cmd_TokenizeString( const char *text );
 void	Cmd_TokenizeStringIgnoreQuotes( const char *text_in );

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -128,7 +128,7 @@ NET
 
 
 #define	PACKET_BACKUP	32	// number of old messages that must be kept on client and
-							// server for delta comrpession and ping estimation
+							// server for delta compression and ping estimation
 #define	PACKET_MASK		(PACKET_BACKUP-1)
 
 #define	MAX_PACKET_USERCMDS		32		// max number of usercmd_t in a packet

--- a/code/qcommon/qfiles.h
+++ b/code/qcommon/qfiles.h
@@ -402,7 +402,7 @@ typedef struct {
 	int			contentFlags;
 } dshader_t;
 
-// planes x^1 is allways the opposite of plane x
+// planes x^1 is always the opposite of plane x
 
 typedef struct {
 	float		normal[3];

--- a/code/qcommon/surfaceflags.h
+++ b/code/qcommon/surfaceflags.h
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 // This file must be identical in the quake and utils directories
 
-// contents flags are seperate bits
+// contents flags are separate bits
 // a given brush can contribute multiple content bits
 
 // these definitions also need to be in q_shared.h!

--- a/code/qcommon/vm.c
+++ b/code/qcommon/vm.c
@@ -470,7 +470,7 @@ vmHeader_t *VM_LoadQVM( vm_t *vm, qboolean alloc, qboolean unpure)
 		Com_Memset(vm->dataBase, 0, dataLength);
 	}
 
-	// copy the intialized data
+	// copy the initialized data
 	Com_Memcpy( vm->dataBase, (byte *)header.h + header.h->dataOffset,
 		header.h->dataLength + header.h->litLength );
 

--- a/code/qcommon/vm_x86.c
+++ b/code/qcommon/vm_x86.c
@@ -1583,7 +1583,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 			break;
 		case OP_CVFI:
 #ifndef FTOL_PTR // WHENHELLISFROZENOVER
-			// not IEEE complient, but simple and fast
+			// not IEEE compliant, but simple and fast
 			EmitString("D9 04 9F");				// fld dword ptr [edi + ebx * 4]
 			EmitString("DB 1C 9F");				// fistp dword ptr [edi + ebx * 4]
 #else // FTOL_PTR

--- a/code/renderercommon/tr_font.c
+++ b/code/renderercommon/tr_font.c
@@ -52,7 +52,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 // To generate new font data you need to go through the following steps.
 // 1. delete the fontImage_x_xx.tga files and fontImage_xx.dat files from the fonts path.
-// 2. in a ui script, specificy a font, smallFont, and bigFont keyword with font name and 
+// 2. in a ui script, specify a font, smallFont, and bigFont keyword with font name and 
 //    point size. the original TrueType fonts must exist in fonts at this point.
 // 3. run the game, you should see things normally.
 // 4. Exit the game and there will be three dat files and at least three tga files. The 

--- a/code/renderercommon/tr_image_png.c
+++ b/code/renderercommon/tr_image_png.c
@@ -571,7 +571,7 @@ static uint32_t DecompressIDATs(struct BufferedFile *BF, uint8_t **Buffer)
 		{
 			/*
 			 *  Rewind to the start of this adventure
-			 *  and return unsuccessfull
+			 *  and return unsuccessful
 			 */
 
 			BufferedFileRewind(BF, BytesToRewind);
@@ -754,7 +754,7 @@ static uint32_t DecompressIDATs(struct BufferedFile *BF, uint8_t **Buffer)
 	ri.Free(CompressedData);
 
 	/*
-	 *  Check if the last puff() was successfull.
+	 *  Check if the last puff() was successful.
 	 */
 
 	if(!((puffResult == 0) && (puffDestLen > 0)))

--- a/code/renderercommon/tr_types.h
+++ b/code/renderercommon/tr_types.h
@@ -173,7 +173,7 @@ typedef enum {
 } glDriverType_t;
 
 typedef enum {
-	GLHW_GENERIC,			// where everthing works the way it should
+	GLHW_GENERIC,			// where everything works the way it should
 	GLHW_3DFX_2D3D,			// Voodoo Banshee or Voodoo3, relevant since if this is
 							// the hardware type then there can NOT exist a secondary
 							// display adapter

--- a/code/renderercommon/tr_types.h
+++ b/code/renderercommon/tr_types.h
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	REFENTITYNUM_WORLD	((1<<REFENTITYNUM_BITS) - 1)
 
 // renderfx flags
-#define	RF_MINLIGHT		0x0001		// allways have some light (viewmodel, some items)
+#define	RF_MINLIGHT		0x0001		// always have some light (viewmodel, some items)
 #define	RF_THIRD_PERSON		0x0002		// don't draw through eyes, only mirrors (player bodies, chat sprites)
 #define	RF_FIRST_PERSON		0x0004		// only draw through eyes (view weapon, damage blood blob)
 #define	RF_DEPTHHACK		0x0008		// for view weapon Z crunching

--- a/code/renderergl1/tr_backend.c
+++ b/code/renderergl1/tr_backend.c
@@ -741,7 +741,7 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 		RB_EndSurface();
 	}
 
-	// we definately want to sync every frame for the cinematics
+	// we definitely want to sync every frame for the cinematics
 	qglFinish();
 
 	start = 0;

--- a/code/renderergl1/tr_backend.c
+++ b/code/renderergl1/tr_backend.c
@@ -543,7 +543,7 @@ void RB_RenderDrawSurfList( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 
 		//
 		// change the tess parameters if needed
-		// a "entityMergable" shader is a shader that can have surfaces from seperate
+		// a "entityMergable" shader is a shader that can have surfaces from separate
 		// entities merged into a single batch, like smoke and blood puff sprites
 		if ( shader != NULL && ( shader != oldShader || fogNum != oldFogNum || dlighted != oldDlighted 
 			|| ( entityNum != oldEntityNum && !shader->entityMergable ) ) ) {

--- a/code/renderergl1/tr_curve.c
+++ b/code/renderergl1/tr_curve.c
@@ -466,7 +466,7 @@ srfGridMesh_t *R_SubdividePatchToGrid( int width, int height,
 	}
 
 
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	PutPointsOnCurve( ctrl, width, height );
 
 	// cull out any rows or columns that are colinear
@@ -554,7 +554,7 @@ srfGridMesh_t *R_GridInsertColumn( srfGridMesh_t *grid, int column, int row, vec
 	for (j = 0; j < grid->height; j++) {
 		errorTable[1][j] = grid->heightLodError[j];
 	}
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	//PutPointsOnCurve( ctrl, width, height );
 	// calculate normals
 	MakeMeshNormals( width, height, ctrl );
@@ -608,7 +608,7 @@ srfGridMesh_t *R_GridInsertRow( srfGridMesh_t *grid, int row, int column, vec3_t
 	for (j = 0; j < grid->width; j++) {
 		errorTable[0][j] = grid->widthLodError[j];
 	}
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	//PutPointsOnCurve( ctrl, width, height );
 	// calculate normals
 	MakeMeshNormals( width, height, ctrl );

--- a/code/renderergl1/tr_light.c
+++ b/code/renderergl1/tr_light.c
@@ -134,7 +134,7 @@ static void R_SetupEntityLightingGrid( trRefEntity_t *ent ) {
 	float	totalFactor;
 
 	if ( ent->e.renderfx & RF_LIGHTING_ORIGIN ) {
-		// seperate lightOrigins are needed so an object that is
+		// separate lightOrigins are needed so an object that is
 		// sinking into the ground can still be lit, and so
 		// multi-part models can be lit identically
 		VectorCopy( ent->e.lightingOrigin, lightOrigin );
@@ -298,7 +298,7 @@ void R_SetupEntityLighting( const trRefdef_t *refdef, trRefEntity_t *ent ) {
 	// trace a sample point down to find ambient light
 	//
 	if ( ent->e.renderfx & RF_LIGHTING_ORIGIN ) {
-		// seperate lightOrigins are needed so an object that is
+		// separate lightOrigins are needed so an object that is
 		// sinking into the ground can still be lit, and so
 		// multi-part models can be lit identically
 		VectorCopy( ent->e.lightingOrigin, lightOrigin );

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -834,7 +834,7 @@ typedef struct {
 	int		msec;			// total msec for backend run
 } backEndCounters_t;
 
-// all state modified by the back end is seperated
+// all state modified by the back end is separated
 // from the front end state
 typedef struct {
 	trRefdef_t	refdef;

--- a/code/renderergl1/tr_shade.c
+++ b/code/renderergl1/tr_shade.c
@@ -443,7 +443,7 @@ static void ProjectDlightTexture_altivec( void ) {
 		dlight_t	*dl;
 
 		if ( !( tess.dlightBits & ( 1 << l ) ) ) {
-			continue;	// this surface definately doesn't have any of this light
+			continue;	// this surface definitely doesn't have any of this light
 		}
 		texCoords = texCoordsArray[0];
 		colors = colorArray[0];
@@ -608,7 +608,7 @@ static void ProjectDlightTexture_scalar( void ) {
 		dlight_t	*dl;
 
 		if ( !( tess.dlightBits & ( 1 << l ) ) ) {
-			continue;	// this surface definately doesn't have any of this light
+			continue;	// this surface definitely doesn't have any of this light
 		}
 		texCoords = texCoordsArray[0];
 		colors = colorArray[0];

--- a/code/renderergl1/tr_shade.c
+++ b/code/renderergl1/tr_shade.c
@@ -740,7 +740,7 @@ static void ProjectDlightTexture_scalar( void ) {
 static void ProjectDlightTexture( void ) {
 #if idppc_altivec
 	if (com_altivec->integer) {
-		// must be in a seperate function or G3 systems will crash.
+		// must be in a separate function or G3 systems will crash.
 		ProjectDlightTexture_altivec();
 		return;
 	}

--- a/code/renderergl1/tr_shade_calc.c
+++ b/code/renderergl1/tr_shade_calc.c
@@ -1206,7 +1206,7 @@ void RB_CalcDiffuseColor( unsigned char *colors )
 {
 #if idppc_altivec
 	if (com_altivec->integer) {
-		// must be in a seperate function or G3 systems will crash.
+		// must be in a separate function or G3 systems will crash.
 		RB_CalcDiffuseColor_altivec( colors );
 		return;
 	}

--- a/code/renderergl1/tr_shader.c
+++ b/code/renderergl1/tr_shader.c
@@ -2466,18 +2466,18 @@ be defined for every single image used in the game, three default
 shader behaviors can be auto-created for any image:
 
 If lightmapIndex == LIGHTMAP_NONE, then the image will have
-dynamic diffuse lighting applied to it, as apropriate for most
+dynamic diffuse lighting applied to it, as appropriate for most
 entity skin surfaces.
 
 If lightmapIndex == LIGHTMAP_2D, then the image will be used
 for 2D rendering unless an explicit shader is found
 
 If lightmapIndex == LIGHTMAP_BY_VERTEX, then the image will use
-the vertex rgba modulate values, as apropriate for misc_model
+the vertex rgba modulate values, as appropriate for misc_model
 pre-lit surfaces.
 
 Other lightmapIndex values will have a lightmap stage created
-and src*dest blending applied with the texture, as apropriate for
+and src*dest blending applied with the texture, as appropriate for
 most world construction surfaces.
 
 ===============
@@ -2524,7 +2524,7 @@ shader_t *R_FindShader( const char *name, int lightmapIndex, qboolean mipRawImag
 
 	InitShader( strippedName, lightmapIndex );
 
-	// FIXME: set these "need" values apropriately
+	// FIXME: set these "need" values appropriately
 	shader.needsNormal = qtrue;
 	shader.needsST1 = qtrue;
 	shader.needsST2 = qtrue;
@@ -2662,7 +2662,7 @@ qhandle_t RE_RegisterShaderFromImage(const char *name, int lightmapIndex, image_
 
 	InitShader( name, lightmapIndex );
 
-	// FIXME: set these "need" values apropriately
+	// FIXME: set these "need" values appropriately
 	shader.needsNormal = qtrue;
 	shader.needsST1 = qtrue;
 	shader.needsST2 = qtrue;

--- a/code/renderergl1/tr_shader.c
+++ b/code/renderergl1/tr_shader.c
@@ -2061,7 +2061,7 @@ static shader_t *GeneratePermanentShader( void ) {
 VertexLightingCollapse
 
 If vertex lighting is enabled, only render a single
-pass, trying to guess which is the correct one to best aproximate
+pass, trying to guess which is the correct one to best approximate
 what it is supposed to look like.
 =================
 */

--- a/code/renderergl1/tr_surface.c
+++ b/code/renderergl1/tr_surface.c
@@ -844,7 +844,7 @@ static void LerpMeshVertexes(md3Surface_t *surf, float backlerp)
 {
 #if idppc_altivec
 	if (com_altivec->integer) {
-		// must be in a seperate function or G3 systems will crash.
+		// must be in a separate function or G3 systems will crash.
 		LerpMeshVertexes_altivec( surf, backlerp );
 		return;
 	}

--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -624,7 +624,7 @@ void RB_RenderDrawSurfList( drawSurf_t *drawSurfs, int numDrawSurfs ) {
 
 		//
 		// change the tess parameters if needed
-		// a "entityMergable" shader is a shader that can have surfaces from seperate
+		// a "entityMergable" shader is a shader that can have surfaces from separate
 		// entities merged into a single batch, like smoke and blood puff sprites
 		if ( shader != NULL && ( shader != oldShader || fogNum != oldFogNum || dlighted != oldDlighted || pshadowed != oldPshadowed || cubemapIndex != oldCubemapIndex
 			|| ( entityNum != oldEntityNum && !shader->entityMergable ) ) ) {

--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -851,7 +851,7 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 		RB_EndSurface();
 	}
 
-	// we definately want to sync every frame for the cinematics
+	// we definitely want to sync every frame for the cinematics
 	qglFinish();
 
 	start = 0;

--- a/code/renderergl2/tr_curve.c
+++ b/code/renderergl2/tr_curve.c
@@ -584,7 +584,7 @@ srfBspSurface_t *R_SubdividePatchToGrid( int width, int height,
 	}
 
 
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	PutPointsOnCurve( ctrl, width, height );
 
 	// cull out any rows or columns that are colinear
@@ -680,7 +680,7 @@ srfBspSurface_t *R_GridInsertColumn( srfBspSurface_t *grid, int column, int row,
 	for (j = 0; j < grid->height; j++) {
 		errorTable[1][j] = grid->heightLodError[j];
 	}
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	//PutPointsOnCurve( ctrl, width, height );
 
 	// calculate indexes
@@ -740,7 +740,7 @@ srfBspSurface_t *R_GridInsertRow( srfBspSurface_t *grid, int row, int column, ve
 	for (j = 0; j < grid->width; j++) {
 		errorTable[0][j] = grid->widthLodError[j];
 	}
-	// put all the aproximating points on the curve
+	// put all the approximating points on the curve
 	//PutPointsOnCurve( ctrl, width, height );
 
 	// calculate indexes

--- a/code/renderergl2/tr_light.c
+++ b/code/renderergl2/tr_light.c
@@ -139,7 +139,7 @@ static void R_SetupEntityLightingGrid( trRefEntity_t *ent, world_t *world ) {
 	float	totalFactor;
 
 	if ( ent->e.renderfx & RF_LIGHTING_ORIGIN ) {
-		// seperate lightOrigins are needed so an object that is
+		// separate lightOrigins are needed so an object that is
 		// sinking into the ground can still be lit, and so
 		// multi-part models can be lit identically
 		VectorCopy( ent->e.lightingOrigin, lightOrigin );
@@ -338,7 +338,7 @@ void R_SetupEntityLighting( const trRefdef_t *refdef, trRefEntity_t *ent ) {
 	// trace a sample point down to find ambient light
 	//
 	if ( ent->e.renderfx & RF_LIGHTING_ORIGIN ) {
-		// seperate lightOrigins are needed so an object that is
+		// separate lightOrigins are needed so an object that is
 		// sinking into the ground can still be lit, and so
 		// multi-part models can be lit identically
 		VectorCopy( ent->e.lightingOrigin, lightOrigin );

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1447,7 +1447,7 @@ typedef struct {
 	int		msec;			// total msec for backend run
 } backEndCounters_t;
 
-// all state modified by the back end is seperated
+// all state modified by the back end is separated
 // from the front end state
 typedef struct {
 	trRefdef_t	refdef;

--- a/code/renderergl2/tr_shade.c
+++ b/code/renderergl2/tr_shade.c
@@ -377,7 +377,7 @@ static void ProjectDlightTexture( void ) {
 		vec4_t vector;
 
 		if ( !( tess.dlightBits & ( 1 << l ) ) ) {
-			continue;	// this surface definately doesn't have any of this light
+			continue;	// this surface definitely doesn't have any of this light
 		}
 
 		dl = &backEnd.refdef.dlights[l];
@@ -734,7 +734,7 @@ static void ForwardDlight( void ) {
 		vec4_t texOffTurb;
 
 		if ( !( tess.dlightBits & ( 1 << l ) ) ) {
-			continue;	// this surface definately doesn't have any of this light
+			continue;	// this surface definitely doesn't have any of this light
 		}
 
 		dl = &backEnd.refdef.dlights[l];
@@ -908,7 +908,7 @@ static void ProjectPshadowVBOGLSL( void ) {
 		vec4_t vector;
 
 		if ( !( tess.pshadowBits & ( 1 << l ) ) ) {
-			continue;	// this surface definately doesn't have any of this shadow
+			continue;	// this surface definitely doesn't have any of this shadow
 		}
 
 		ps = &backEnd.refdef.pshadows[l];

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -2678,7 +2678,7 @@ static shader_t *GeneratePermanentShader( void ) {
 VertexLightingCollapse
 
 If vertex lighting is enabled, only render a single
-pass, trying to guess which is the correct one to best aproximate
+pass, trying to guess which is the correct one to best approximate
 what it is supposed to look like.
 =================
 */

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -3093,18 +3093,18 @@ be defined for every single image used in the game, three default
 shader behaviors can be auto-created for any image:
 
 If lightmapIndex == LIGHTMAP_NONE, then the image will have
-dynamic diffuse lighting applied to it, as apropriate for most
+dynamic diffuse lighting applied to it, as appropriate for most
 entity skin surfaces.
 
 If lightmapIndex == LIGHTMAP_2D, then the image will be used
 for 2D rendering unless an explicit shader is found
 
 If lightmapIndex == LIGHTMAP_BY_VERTEX, then the image will use
-the vertex rgba modulate values, as apropriate for misc_model
+the vertex rgba modulate values, as appropriate for misc_model
 pre-lit surfaces.
 
 Other lightmapIndex values will have a lightmap stage created
-and src*dest blending applied with the texture, as apropriate for
+and src*dest blending applied with the texture, as appropriate for
 most world construction surfaces.
 
 ===============

--- a/code/renderergl2/tr_surface.c
+++ b/code/renderergl2/tr_surface.c
@@ -1198,7 +1198,7 @@ static void LerpMeshVertexes(mdvSurface_t *surf, float backlerp)
 #if 0
 #if idppc_altivec
 	if (com_altivec->integer) {
-		// must be in a seperate function or G3 systems will crash.
+		// must be in a separate function or G3 systems will crash.
 		LerpMeshVertexes_altivec( surf, backlerp );
 		return;
 	}

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -631,7 +631,7 @@ void SV_FreeClient(client_t *client)
 SV_DropClient
 
 Called when the player is totally leaving the server, either willingly
-or unwillingly.  This is NOT called if the entire server is quiting
+or unwillingly.  This is NOT called if the entire server is quitting
 or crashing -- SV_FinalMessage() will handle that
 =====================
 */

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -128,7 +128,7 @@ void SV_SetConfigstring (int index, const char *val) {
 	// spawning a new server
 	if ( sv.state == SS_GAME || sv.restarting ) {
 
-		// send the data to all relevent clients
+		// send the data to all relevant clients
 		for (i = 0, client = svs.clients; i < sv_maxclients->integer ; i++, client++) {
 			if ( client->state < CS_ACTIVE ) {
 				if ( client->state == CS_PRIMED )

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -376,7 +376,7 @@ static void SV_ClearServer(void) {
 ================
 SV_TouchCGame
 
-  touch the cgame.vm so that a pure client can load it if it's in a seperate pk3
+  touch the cgame.vm so that a pure client can load it if it's in a separate pk3
 ================
 */
 static void SV_TouchCGame(void) {
@@ -575,7 +575,7 @@ void SV_SpawnServer( char *server, qboolean killBots ) {
 		Cvar_Set( "sv_pakNames", p );
 
 		// if a dedicated pure server we need to touch the cgame because it could be in a
-		// seperate pk3 file and the client will need to load the latest cgame.qvm
+		// separate pk3 file and the client will need to load the latest cgame.qvm
 		if ( com_dedicated->integer ) {
 			SV_TouchCGame();
 		}

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -208,7 +208,7 @@ void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...) {
 		Com_Printf ("broadcast: %s\n", SV_ExpandNewlines((char *)message) );
 	}
 
-	// send the data to all relevent clients
+	// send the data to all relevant clients
 	for (j = 0, client = svs.clients; j < sv_maxclients->integer ; j++, client++) {
 		SV_AddServerCommand( client, (char *)message );
 	}

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -90,7 +90,7 @@ unsigned long sys_timeBase = 0;
 /* current time in ms, using sys_timeBase as origin
    NOTE: sys_timeBase*1000 + curtime -> ms since the Epoch
      0x7fffffff ms - ~24 days
-   although timeval:tv_usec is an int, I'm not sure wether it is actually used as an unsigned int
+   although timeval:tv_usec is an int, I'm not sure whether it is actually used as an unsigned int
      (which would affect the wrap period) */
 int curtime;
 int Sys_Milliseconds (void)

--- a/code/tools/asm/notes.txt
+++ b/code/tools/asm/notes.txt
@@ -1,5 +1,5 @@
 
-don't do any paramter conversion (double to float, etc)
+don't do any parameter conversion (double to float, etc)
 
 
 

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -5275,7 +5275,7 @@ void _UI_SetActiveMenu( uiMenuCommand_t menu ) {
 	char buf[256];
 
 	// this should be the ONLY way the menu system is brought up
-	// enusure minumum menu data is cached
+	// ensure minimum menu data is cached
   if (Menu_Count() > 0) {
 		vec3_t v;
 		v[0] = v[1] = v[2] = 0;

--- a/code/ui/ui_players.c
+++ b/code/ui/ui_players.c
@@ -616,7 +616,7 @@ static void UI_PlayerAngles( playerInfo_t *pi, vec3_t legs[3], vec3_t torso[3], 
 	UI_SwingAngles( dest, 15, 30, 0.1f, &pi->torso.pitchAngle, &pi->torso.pitching );
 	torsoAngles[PITCH] = pi->torso.pitchAngle;
 
-	// pull the angles back out of the hierarchial chain
+	// pull the angles back out of the hierarchical chain
 	AnglesSubtract( headAngles, torsoAngles, headAngles );
 	AnglesSubtract( torsoAngles, legsAngles, torsoAngles );
 	AnglesToAxis( legsAngles, legs );

--- a/code/zlib/zlib.h
+++ b/code/zlib/zlib.h
@@ -869,7 +869,7 @@ ZEXTERN int ZEXPORT inflateBackInit OF((z_streamp strm, int windowBits,
      See inflateBack() for the usage of these routines.
 
      inflateBackInit will return Z_OK on success, Z_STREAM_ERROR if any of
-   the paramaters are invalid, Z_MEM_ERROR if the internal state could not
+   the parameters are invalid, Z_MEM_ERROR if the internal state could not
    be allocated, or Z_VERSION_ERROR if the version of the library does not
    match the version of the header file.
 */


### PR DESCRIPTION
So I searched and fixed a bunch of typos spotted by aspell. Most of them are in comments and only the change for `separated` affected few variable names.
I cut each typo fix in one separate commit, I hope it is okay for you.