### PR TITLE
Don't play idlogo.roq in standalone games

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2805,11 +2805,15 @@ void Com_Init( char *commandLine ) {
 	if ( !Com_AddStartupCommands() ) {
 		// if the user didn't give any commands, run default action
 		if ( !com_dedicated->integer ) {
+#ifndef STANDALONE
 			Cbuf_AddText ("cinematic idlogo.RoQ\n");
 			if( !com_introPlayed->integer ) {
 				Cvar_Set( com_introPlayed->name, "1" );
 				Cvar_Set( "nextmap", "cinematic intro.RoQ" );
 			}
+#else
+			// Add some custom cinematic here if needed
+#endif
 		}
 	}
 


### PR DESCRIPTION
When starting the game, idlogo.roq and intro.roq (only once) cinematics will be played. The files will not exist if the game is standalone, so the programmer can choose a different behaviour if STANDALONE is defined.