### PR TITLE
Ensure that mbstowcs does not overflow its buffer

### DIFF
--- a/code/client/libmumblelink.c
+++ b/code/client/libmumblelink.c
@@ -146,7 +146,7 @@ void mumble_set_identity(const char* identity)
 	size_t len;
 	if (!lm)
 		return;
-	len = MIN(sizeof(lm->identity), strlen(identity)+1);
+	len = MIN(sizeof(lm->identity)/sizeof(wchar_t), strlen(identity)+1);
 	mbstowcs(lm->identity, identity, len);
 }
 
@@ -164,7 +164,7 @@ void mumble_set_description(const char* description)
 	size_t len;
 	if (!lm)
 		return;
-	len = MIN(sizeof(lm->description), strlen(description)+1);
+	len = MIN(sizeof(lm->description)/sizeof(wchar_t), strlen(description)+1);
 	mbstowcs(lm->description, description, len);
 }
 


### PR DESCRIPTION
Similar to one of the changes by Tim Angus in fd986da: mbstowcs' third
argument is the number of wchar_t available in dest, not the number
of bytes.

This does not appear to be exploitable, because ioquake3 does
not actually call mumble_set_identity() or mumble_set_description()
anywhere, but it might be relevant to derivatives.

Spotted via compiler warnings.