### PR TITLE
fixed crash in amd64 qsnapvectorsse

### DIFF
--- a/code/asm/snapvector.asm
+++ b/code/asm/snapvector.asm
@@ -46,7 +46,6 @@ IFDEF idx64
 ; qsnapvector using SSE
 
   qsnapvectorsse PROC
-    sub rsp, 8
 	movaps xmm1, ssemask		; initialize the mask register
 	movups xmm0, [rcx]			; here is stored our vector. Read 4 values in one go
 	movaps xmm2, xmm0			; keep a copy of the original data


### PR DESCRIPTION
seems to be leftover from
https://github.com/ioquake/ioq3/commit/8a500d71daaadf199957309f5ee4d8c0fc2157da
im really surprised noone noticed yet?
but it seems to be used on win64 only 