### PR TITLE
No unix memmove for MSVC

### DIFF
--- a/code/tools/lcc/cpp/unix.c
+++ b/code/tools/lcc/cpp/unix.c
@@ -99,7 +99,8 @@ char *basepath( char *fname )
 /* memmove is defined here because some vendors don't provide it at
    all and others do a terrible job (like calling malloc) */
 // -- ouch, that hurts -- ln
-#ifndef MACOS_X   /* always use the system memmove() on Mac OS X. --ryan. */
+/* always use the system memmove() on Mac OS X. --ryan. */
+#if !defined(MACOS_X) && !defined(_MSC_VER)
 #ifdef memmove
 #undef memmove
 #endif


### PR DESCRIPTION
Fix for:
MSVCRT.lib(MSVCR100.dll) : error LNK2005: _memmove already defined in unix.obj
fatal error LNK1169: one or more multiply defined symbols found