### PR TITLE
Enhancements for system libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1074,11 +1074,10 @@ ifeq ($(USE_INTERNAL_JPEG),1)
   BASE_CFLAGS += -DUSE_INTERNAL_JPEG
   BASE_CFLAGS += -I$(JPDIR)
 else
-  # libjpeg doesn't have pkg-config yet, but let users override with
-  # "make JPEG_CFLAGS=-I/opt/jpeg/include JPEG_LIBS='-L/opt/jpeg/lib -ljpeg'"
-  # if they need to
-  JPEG_CFLAGS ?=
-  JPEG_LIBS ?= -ljpeg
+  # IJG libjpeg doesn't have pkg-config, but libjpeg-turbo uses libjpeg.pc;
+  # we fall back to hard-coded answers if libjpeg.pc is unavailable
+  JPEG_CFLAGS ?= $(shell pkg-config --silence-errors --cflags libjpeg || true)
+  JPEG_LIBS ?= $(shell pkg-config --silence-errors --libs libjpeg || echo -ljpeg)
   BASE_CFLAGS += $(JPEG_CFLAGS)
   RENDERER_LIBS += $(JPEG_LIBS)
 endif

--- a/code/qcommon/unzip.c
+++ b/code/qcommon/unzip.c
@@ -1,4 +1,10 @@
 /* unzip.c -- IO for uncompress .zip files using zlib
+
+   Modified for Quake III Arena to use the Z_Malloc() memory pool;
+   this means a system copy of minizip is not a suitable replacement.
+
+   Based on minizip:
+
    Version 1.01e, February 12th, 2005
 
    Copyright (C) 1998-2005 Gilles Vollant


### PR DESCRIPTION
unzip.[ch] and ioapi.[ch] are available as a system library on Debian, Ubuntu, Fedora.

While looking at the relevant section of the Makefile I noticed that I hadn't added support for libjpeg.pc because IJG libjpeg doesn't have it; but libjpeg-turbo does.