### PR TITLE
Don't print to console for special cases 'all' and 'allbots'

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -90,7 +90,8 @@ static client_t *SV_GetPlayerByHandle( void ) {
 		}
 	}
 
-	Com_Printf( "Player %s is not on the server\n", s );
+	if ( Q_stricmp( "all", s ) || Q_stricmp( "allbots", s ) )
+		Com_Printf( "Player %s is not on the server\n", s );
 
 	return NULL;
 }


### PR DESCRIPTION
SV_GetPlayerByHandle currently prints "Player all/allbots is not on the server" to server console when used to kick, etc.