### PR TITLE
fix a stupid use of strcpy()

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -1256,7 +1256,7 @@ void Info_RemoveKey_Big( char *s, const char *key ) {
 
 		if (!strcmp (key, pkey) )
 		{
-			strcpy (start, s);	// remove this part
+			memmove(start, s, strlen(s) + 1); // remove this part
 			return;
 		}
 


### PR DESCRIPTION
strcpy() arguments may not overlap !