### PR TITLE
build: if tput fails, fall back to a reasonable text width

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1231,7 +1231,7 @@ release:
 	  CLIENT_CFLAGS="$(CLIENT_CFLAGS)" SERVER_CFLAGS="$(SERVER_CFLAGS)" V=$(V)
 
 ifneq ($(call bin_path, tput),)
-  TERM_COLUMNS=$(shell echo $$((`tput cols`-4)))
+  TERM_COLUMNS=$(shell if c=`tput cols`; then echo $$(($$c-4)); else echo 76; fi)
 else
   TERM_COLUMNS=76
 endif


### PR DESCRIPTION
If TERM is not set (which can happen in autobuilders and other
batch environments), or if tput cannot determine the number of
columns for some other reason, then it can fail and not produce
any output. Prior to this change, that would result in passing
field width -4 to fmt, which is an error and causes fmt to
produce no output.