### PR TITLE
Fix Cvar_Unset not notifying cvar_modifiedFlags

### DIFF
--- a/code/qcommon/cvar.c
+++ b/code/qcommon/cvar.c
@@ -1117,6 +1117,9 @@ cvar_t *Cvar_Unset(cvar_t *cv)
 {
 	cvar_t *next = cv->next;
 
+	// note what types of cvars have been modified (userinfo, archive, serverinfo, systeminfo)
+	cvar_modifiedFlags |= cv->flags;
+
 	if(cv->name)
 		Z_Free(cv->name);
 	if(cv->string)


### PR DESCRIPTION
Ensures functions that want to know about changes to certain types of cvars are notified that one of their cvars have been unset.

i.e. doing `/unset myvar` on a `CVAR_USERINFO|CVAR_USER_CREATED` cvar 'myvar' will let `CL_CheckUserinfo()` know that there's been a change and will send a new `userinfo` command to the server without 'myvar' in it.

Upstream: JACoders/OpenJK@9a5e9e87ff2d1302261978fa3f1adafb851bd6d6