### PR TITLE
Ensure reads from /dev/urandom are unbuffered

### DIFF
--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -123,6 +123,8 @@ qboolean Sys_RandomBytes( byte *string, int len )
 	if( !fp )
 		return qfalse;
 
+	setvbuf( fp, NULL, _IONBF, 0 ); // don't buffer reads from /dev/urandom
+
 	if( fread( string, sizeof( byte ), len, fp ) != len )
 	{
 		fclose( fp );


### PR DESCRIPTION
The default fopen behaviour is fully-buffered I/O, which causes blocks of BUFSIZ (4KiB typically) to be read in while fread'ing. This change makes sure only the actual amount of bytes we need from /dev/urandom are read from the stream, to avoid wasting entropy.

Upstream: JACoders/OpenJK@de6a9dfd40065ae9a5a2b0b3ef701feee8dac867