### PR TITLE
Remove netadr_t adr cache in SV_MasterHeartbeat

### DIFF
--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -237,11 +237,12 @@ but not on every player enter or exit.
 #define	HEARTBEAT_MSEC	300*1000
 void SV_MasterHeartbeat(const char *message)
 {
-	static netadr_t	adr[MAX_MASTER_SERVERS][2]; // [2] for v4 and v6 address for the same address string.
-	int			i;
-	int			res;
-	int			netenabled;
+	netadr_t adr[2]; // [2] for v4 and v6 address for the same address string.
+	int	 i;
+	int	 res;
+	int	 netenabled;
 
+	Com_Memset(adr, 0, sizeof(netadr_t) * 2);
 	netenabled = Cvar_VariableIntegerValue("net_enabled");
 
 	// "dedicated 1" is for lan play, "dedicated 2" is for inet public play
@@ -263,56 +264,53 @@ void SV_MasterHeartbeat(const char *message)
 		if(!sv_master[i]->string[0])
 			continue;
 
-		// see if we haven't already resolved the name
-		// resolving usually causes hitches on win95, so only
-		// do it when needed
-		if(sv_master[i]->modified || (adr[i][0].type == NA_BAD && adr[i][1].type == NA_BAD))
+		// enforce to check everytime the ip
+		// when moving the master to a new ip, server would still
+		// resolve the old ip
+		sv_master[i]->modified = qfalse;
+
+		if(netenabled & NET_ENABLEV4)
 		{
+			Com_Printf("Resolving %s (IPv4)\n", sv_master[i]->string);
+			res = NET_StringToAdr(sv_master[i]->string, &adr[0], NA_IP);
+
+			if(res == 2)
+			{
+				// if no port was specified, use the default master port
+				adr[0].port = BigShort(PORT_MASTER);
+			}
+
+			if(res)
+				Com_Printf( "%s resolved to %s\n", sv_master[i]->string, NET_AdrToStringwPort(adr[0]));
+			else
+				Com_Printf( "%s has no IPv4 address.\n", sv_master[i]->string);
+		}
+
+		if(netenabled & NET_ENABLEV6)
+		{
+			Com_Printf("Resolving %s (IPv6)\n", sv_master[i]->string);
+			res = NET_StringToAdr(sv_master[i]->string, &adr[1], NA_IP6);
+
+			if(res == 2)
+			{
+				// if no port was specified, use the default master port
+				adr[1].port = BigShort(PORT_MASTER);
+			}
+
+			if(res)
+				Com_Printf( "%s resolved to %s\n", sv_master[i]->string, NET_AdrToStringwPort(adr[1]));
+			else
+				Com_Printf( "%s has no IPv6 address.\n", sv_master[i]->string);
+		}
+
+		if(adr[0].type == NA_BAD && adr[1].type == NA_BAD)
+		{
+			// if the address failed to resolve, clear it
+			// so we don't take repeated dns hits
+			Com_Printf("Couldn't resolve address: %s\n", sv_master[i]->string);
+			Cvar_Set(sv_master[i]->name, "");
 			sv_master[i]->modified = qfalse;
-			
-			if(netenabled & NET_ENABLEV4)
-			{
-				Com_Printf("Resolving %s (IPv4)\n", sv_master[i]->string);
-				res = NET_StringToAdr(sv_master[i]->string, &adr[i][0], NA_IP);
-
-				if(res == 2)
-				{
-					// if no port was specified, use the default master port
-					adr[i][0].port = BigShort(PORT_MASTER);
-				}
-				
-				if(res)
-					Com_Printf( "%s resolved to %s\n", sv_master[i]->string, NET_AdrToStringwPort(adr[i][0]));
-				else
-					Com_Printf( "%s has no IPv4 address.\n", sv_master[i]->string);
-			}
-			
-			if(netenabled & NET_ENABLEV6)
-			{
-				Com_Printf("Resolving %s (IPv6)\n", sv_master[i]->string);
-				res = NET_StringToAdr(sv_master[i]->string, &adr[i][1], NA_IP6);
-
-				if(res == 2)
-				{
-					// if no port was specified, use the default master port
-					adr[i][1].port = BigShort(PORT_MASTER);
-				}
-				
-				if(res)
-					Com_Printf( "%s resolved to %s\n", sv_master[i]->string, NET_AdrToStringwPort(adr[i][1]));
-				else
-					Com_Printf( "%s has no IPv6 address.\n", sv_master[i]->string);
-			}
-
-			if(adr[i][0].type == NA_BAD && adr[i][1].type == NA_BAD)
-			{
-				// if the address failed to resolve, clear it
-				// so we don't take repeated dns hits
-				Com_Printf("Couldn't resolve address: %s\n", sv_master[i]->string);
-				Cvar_Set(sv_master[i]->name, "");
-				sv_master[i]->modified = qfalse;
-				continue;
-			}
+			continue;
 		}
 
 
@@ -321,10 +319,10 @@ void SV_MasterHeartbeat(const char *message)
 		// this command should be changed if the server info / status format
 		// ever incompatably changes
 
-		if(adr[i][0].type != NA_BAD)
-			NET_OutOfBandPrint( NS_SERVER, adr[i][0], "heartbeat %s\n", message);
-		if(adr[i][1].type != NA_BAD)
-			NET_OutOfBandPrint( NS_SERVER, adr[i][1], "heartbeat %s\n", message);
+		if(adr[0].type != NA_BAD)
+			NET_OutOfBandPrint( NS_SERVER, adr[0], "heartbeat %s\n", message);
+		if(adr[1].type != NA_BAD)
+			NET_OutOfBandPrint( NS_SERVER, adr[1], "heartbeat %s\n", message);
 	}
 }
 


### PR DESCRIPTION
As TimeDoctor said, they are currently transitioning to a new master server. The problem is that people keep registering to the wrong ip until they have restarted their server.

This patch removes the ip cache and forces the hostname resolution to be done everytime a heartbeat is prepared to be sent.

I am open to any questions, remarks or improvements.
