### PR TITLE
Fix architecture for x86 in ioq3demo.sh and ioquake3.sh

### DIFF
--- a/misc/setup/ioq3demo.sh
+++ b/misc/setup/ioq3demo.sh
@@ -38,8 +38,8 @@ export LD_LIBRARY_PATH
 
 archs=`uname -m`
 case "$archs" in
-	i?86) archs=i386 ;;
-	x86_64) archs="x86_64 i386" ;;
+	i?86) archs=x86 ;;
+	x86_64) archs="x86_64 x86" ;;
 	ppc64) archs="ppc64 ppc" ;;
 esac
 

--- a/misc/setup/ioquake3.sh
+++ b/misc/setup/ioquake3.sh
@@ -38,8 +38,8 @@ export LD_LIBRARY_PATH
 
 archs=`uname -m`
 case "$archs" in
-	i?86) archs=i386 ;;
-	x86_64) archs="x86_64 i386" ;;
+	i?86) archs=x86 ;;
+	x86_64) archs="x86_64 x86" ;;
 	ppc64) archs="ppc64 ppc" ;;
 esac
 


### PR DESCRIPTION
Fix architecture for x86: changed from i386 to x86.
