### PR TITLE
Ensure R_PrintLongString doesn't split words between buffers

### DIFF
--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -883,18 +883,34 @@ R_PrintLongString
 Workaround for ri.Printf's 1024 characters buffer limit.
 ================
 */
-void R_PrintLongString(const char *string) {
+void R_PrintLongString(const char *string)
+{
 	char buffer[1024];
-	const char *p;
-	int size = strlen(string);
+	const char *p = string;
+	int remainingLength = strlen(string);
 
-	p = string;
-	while(size > 0)
+	while (remainingLength > 0)
 	{
-		Q_strncpyz(buffer, p, sizeof (buffer) );
+		// Take as much characters as possible from the string without splitting words between buffers
+		// This avoids the client console splitting a word up when one half fits on the current line,
+		// but the second half would have to be written on a new line
+		int charsToTake = sizeof(buffer) - 1;
+		if (remainingLength > charsToTake) {
+			while (p[charsToTake - 1] > ' ' && p[charsToTake] > ' ') {
+				charsToTake--;
+				if (charsToTake == 0) {
+					charsToTake = sizeof(buffer) - 1;
+					break;
+				}
+			}
+		} else if (remainingLength < charsToTake) {
+			charsToTake = remainingLength;
+		}
+
+		Q_strncpyz( buffer, p, charsToTake + 1 );
 		ri.Printf( PRINT_ALL, "%s", buffer );
-		p += 1023;
-		size -= 1023;
+		remainingLength -= charsToTake;
+		p += charsToTake;
 	}
 }
 

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -1004,18 +1004,34 @@ R_PrintLongString
 Workaround for ri.Printf's 1024 characters buffer limit.
 ================
 */
-void R_PrintLongString(const char *string) {
+void R_PrintLongString(const char *string)
+{
 	char buffer[1024];
-	const char *p;
-	int size = strlen(string);
+	const char *p = string;
+	int remainingLength = strlen(string);
 
-	p = string;
-	while(size > 0)
+	while (remainingLength > 0)
 	{
-		Q_strncpyz(buffer, p, sizeof (buffer) );
+		// Take as much characters as possible from the string without splitting words between buffers
+		// This avoids the client console splitting a word up when one half fits on the current line,
+		// but the second half would have to be written on a new line
+		int charsToTake = sizeof(buffer) - 1;
+		if (remainingLength > charsToTake) {
+			while (p[charsToTake - 1] > ' ' && p[charsToTake] > ' ') {
+				charsToTake--;
+				if (charsToTake == 0) {
+					charsToTake = sizeof(buffer) - 1;
+					break;
+				}
+			}
+		} else if (remainingLength < charsToTake) {
+			charsToTake = remainingLength;
+		}
+
+		Q_strncpyz( buffer, p, charsToTake + 1 );
 		ri.Printf( PRINT_ALL, "%s", buffer );
-		p += 1023;
-		size -= 1023;
+		remainingLength -= charsToTake;
+		p += charsToTake;
 	}
 }
 


### PR DESCRIPTION
CL_ConsolePrint treats text at the end of a message given to it as a complete word for purposes of word-wrapping. When one half of a word in the first buffer from R_PrintLongString is given to it and this can fit on the current line, the first half will be printed on that line. However, when the second half of the word in the second buffer from R_PrintLongString is given to it and it can't fit on the current line, this second half will be printed on the line underneath. By ensuring R_PrintLongString only passes complete words to be printed, the client console is able to word-wrap properly.

This is quite a small cosmetic change and screenshots do the explanation more justice:

**Before**
![r_printlongstring_before](https://cloud.githubusercontent.com/assets/844245/14582244/9dd698f6-03f7-11e6-8280-fb7cd9394bb8.png)

**After**
![r_printlongstring_after](https://cloud.githubusercontent.com/assets/844245/14582247/a3ccbeca-03f7-11e6-97f6-c919df6c674e.png)

Upstream: JACoders/OpenJK@84978e733f2e3139e4c6496fe63d4d733553b960
