### PR TITLE
Prevent CL_RunCinematic from reading cinTable[-1]

### DIFF
--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -1286,7 +1286,6 @@ static void RoQShutdown( void ) {
 		CL_handle = -1;
 	}
 	cinTable[currentHandle].fileName[0] = 0;
-	currentHandle = -1;
 }
 
 /*


### PR DESCRIPTION
Nothing to magical.

FYI: this was reported by Address Sanitizer `-fsanitize=address`