### PR TITLE
Fix a small bug with with ordering teammates to kill enemies (fix by zturtleman)

### DIFF
--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -573,11 +573,10 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			bs->teammessage_time = 0;
 		}
 		//
-		if (bs->lastkilledplayer == bs->teamgoal.entitynum) {
+		if (bs->killedenemy_time > bs->teamgoal_time - TEAM_KILL_SOMEONE && bs->lastkilledplayer == bs->teamgoal.entitynum) {
 			EasyClientName(bs->teamgoal.entitynum, buf, sizeof(buf));
 			BotAI_BotInitialChat(bs, "kill_done", buf, NULL);
 			trap_BotEnterChat(bs->cs, bs->decisionmaker, CHAT_TELL);
-			bs->lastkilledplayer = -1;
 			bs->ltgtype = 0;
 		}
 		//


### PR DESCRIPTION
This is able to fix the "PlayerName: playernum out of range" error, although the error could be slightly different due to this being ioq3 & not Spearmint.  It also, according to zturtleman, fixes the bot dropping this order if the bot is still killing someone that it just killed. Take a look at https://github.com/zturtleman/spearmint/issues/272 for more details.