### PR TITLE
Fix timelimit causing an infinite map ending loop.

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1356,9 +1356,19 @@ void CheckExitRules( void ) {
 		return;
 	}
 
+	if ( g_timelimit.integer < 0 ) {
+		trap_SendServerCommand( -1, "print \"Timelimit is negative.\n\"" );
+		trap_Cvar_Set( "timelimit", "0" );
+		trap_Cvar_Update( &g_timelimit );
+	} else if ( g_timelimit.integer > INT_MAX / 60000 ) {
+		trap_SendServerCommand( -1, "print \"Timelimit is too large.\n\"" );
+		trap_Cvar_Set( "timelimit", "0" );
+		trap_Cvar_Update( &g_timelimit );
+	}
+
 	if ( g_timelimit.integer && !level.warmupTime ) {
-		if ( level.time - level.startTime >= g_timelimit.integer*60000 ) {
-			trap_SendServerCommand( -1, "print \"Timelimit hit.\n\"");
+		if ( level.time - level.startTime >= g_timelimit.integer * 60000 ) {
+			trap_SendServerCommand( -1, "print \"Timelimit hit.\n\"" );
 			LogExit( "Timelimit hit." );
 			return;
 		}


### PR DESCRIPTION
This patch fixes some timelimit issue caused by either a negative timelimit value or a value that would overflow the multiplication by 60000 causing an endless map change/reload. If that kind of value is met, we set it to 0 automatically and update it.

I was reported a player joining empty servers with votes enabled and voting a timelimit of 99999999.
