### PR TITLE
[botlib/be_aas_def.h] Fix struct aas_s layout in terms of MAX_QPATH

### DIFF
--- a/code/botlib/be_aas_def.h
+++ b/code/botlib/be_aas_def.h
@@ -39,10 +39,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define DF_AASENTCLIENT(x)		(x - aasworld.entities - 1)
 #define DF_CLIENTAASENT(x)		(&aasworld.entities[x + 1])
 
-#ifndef MAX_PATH
-	#define MAX_PATH				MAX_QPATH
-#endif
-
 //structure to link entities to areas and areas to entities
 typedef struct aas_link_s
 {
@@ -187,8 +183,8 @@ typedef struct aas_s
 	float time;
 	int numframes;
 	//name of the aas file
-	char filename[MAX_PATH];
-	char mapname[MAX_PATH];
+	char filename[MAX_QPATH];
+	char mapname[MAX_QPATH];
 	//bounding boxes
 	int numbboxes;
 	aas_bbox_t *bboxes;


### PR DESCRIPTION
This change was suggested by @TTimo. It allows us to reuse the ioq3 code to build the BSPC tool. (The BSPC tool may wish to define `MAX_PATH` differently, but that shouldn't affect the layout of `struct aas_s`.)