### PR TITLE
[botlib/be_aas_def.h] Change array size from MAX_PATH to MAX_QPATH

### DIFF
--- a/code/botlib/be_aas_def.h
+++ b/code/botlib/be_aas_def.h
@@ -39,10 +39,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define DF_AASENTCLIENT(x)		(x - aasworld.entities - 1)
 #define DF_CLIENTAASENT(x)		(&aasworld.entities[x + 1])
 
-#ifndef MAX_PATH
-	#define MAX_PATH				MAX_QPATH
-#endif
-
 //structure to link entities to areas and areas to entities
 typedef struct aas_link_s
 {
@@ -187,8 +183,8 @@ typedef struct aas_s
 	float time;
 	int numframes;
 	//name of the aas file
-	char filename[MAX_PATH];
-	char mapname[MAX_PATH];
+	char filename[MAX_QPATH];
+	char mapname[MAX_QPATH];
 	//bounding boxes
 	int numbboxes;
 	aas_bbox_t *bboxes;


### PR DESCRIPTION
The array is part of a structure and should have a fixed size that does not depend on inclusion order.

The use of the conditional `MAX_PATH` macro is causing real havoc with the integration of the BSPC code, which defines that macro for its own uses, independent of this `aas_t` structure.

Was there ever any value in making the `aas_t` field size dependent on an external macro like that?

Credits to @TTimo, who suggested a modification of this kind.
