### PR TITLE
Move enum definition into separate header file

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -185,12 +185,9 @@ typedef int intptr_t;
 
 
 #include "q_platform.h"
+#include "q_types.h"
 
 //=============================================================
-
-typedef unsigned char 		byte;
-
-typedef enum {qfalse, qtrue}	qboolean;
 
 typedef union {
 	float f;

--- a/code/qcommon/q_types.h
+++ b/code/qcommon/q_types.h
@@ -1,0 +1,30 @@
+/*
+===========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+
+This file is part of Quake III Arena source code.
+
+Quake III Arena source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Quake III Arena source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Quake III Arena source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+// q_types.h -- common types
+#ifndef __Q_TYPES_H
+#define __Q_TYPES_H
+
+typedef unsigned char 		byte;
+
+typedef enum {qfalse, qtrue}	qboolean;
+
+#endif


### PR DESCRIPTION
Having the `qboolean` definition available separately makes the bspc integration a bit easier.