### PR TITLE
Downloads and mod servers. Need Advice

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -2217,6 +2217,7 @@ void CL_NextDownload(void)
 		remoteName = s;
 		
 		if ( (s = strchr(s, '@')) == NULL ) {
+            Com_GameRestart(clc.checksumFeed, qfalse);
 			CL_DownloadsComplete();
 			return;
 		}
@@ -2266,6 +2267,7 @@ void CL_NextDownload(void)
 				return;	
 			}
 			else {
+                Com_GameRestart(clc.checksumFeed, qfalse);
 				CL_BeginDownload( localName, remoteName );
 			}
 		}
@@ -2277,6 +2279,7 @@ void CL_NextDownload(void)
 		return;
 	}
 
+    Com_GameRestart(clc.checksumFeed, qfalse);
 	CL_DownloadsComplete();
 }
 

--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -542,11 +542,11 @@ void CL_ParseGamestate( msg_t *msg ) {
 		Q_strncpyz(cl_oldGame, oldGame, sizeof(cl_oldGame));
 	}
 
-	FS_ConditionalRestart(clc.checksumFeed, qfalse);
-
 	// This used to call CL_StartHunkUsers, but now we enter the download state before loading the
 	// cgame
 	CL_InitDownloads();
+
+	//FS_ConditionalRestart(clc.checksumFeed, qfalse);
 
 	// make sure the game starts
 	Cvar_Set( "cl_paused", "0" );


### PR DESCRIPTION
# Dowloads and mod servers
I've been looking at this bug for the last 3 weeks in Tremulous- It's been a rough ride and I require some assistance.

This PR is likely missing something from my Tremulous tree (😩) but It's pretty much the relevant bit.

## So the problem: 
1. Clean client, only default installed paks
2. Run a server that causes fs_game/basedir(?) AND hosts it's own modified qvm's

## Actual results:
ERR_FATAL, "VM_Create on UI failed"

## Expected 
Download of the missing paks

---

# Explanation

The _primary_ issue which I've identified is in `CL_ParseGameState`:
[see cl_parse.c:545](https://github.com/ioquake/ioq3/blob/master/code/client/cl_parse.c?L=544#L545)
```
	FS_ConditionalRestart(clc.checksumFeed, qfalse);

	// This used to call CL_StartHunkUsers, but now we enter the download state before loading
	// the cgame
	CL_InitDownloads();
```

Calling `FS_ConditionalRestart` will result in a call to `Hunk_Clear` and subsequently, `CL_ShutdownUI` etc.. 

Then a chained return back upto `FS_ConditionalRestart` and into `Com_GameRestart` which tries to load UI from the new base path. 

## Call trace

Here is a trace i put together by hand-

```yaml
# Path to FS_ConditionalFree
src/qcommon/common.c: Com_Frame()
  src/qcommon/common: Com_EventLoop() # Looping over NET_GetLoopPacket( NS_CLIENT ..)
    src/qcommon/common: CL_PacketEvent() # There are 3 direct paths into Conditional restart from Com_Frame
  src/qcommon/net_ip.c: NET_Sleep() # Net_Sleep(0) or NET_Sleep(timeVal - 1)
    src/qcommon/net_ip.c: NET_Event() # This reads packets from NET_GetPacket()
      src/client/cl_main.c: CL_PacketEvent()
        src/client/cl_parse.c: CL_ParseServerMessage()
          src/client/cl_parse.c: CL_ParseGamestate()
# Path to VM_Free
          src/client/cl_parse.c: CL_ParseGamestate()
            src/qcommon/files.c: FS_ConditionalRestart()
              src/qcommon/common.c: Com_GameRestart()
                src/client/cl_main.c: CL_Shutdown("Game directory changed")
                  src/client/cl_main.c: CL_ClearMemory(X?)
                    src/qcommon/common.c: Hunk_Clear()
                      src/client/cl_ui.c: CL_ShutdownUI();
                        src/qcommon/vm.c: VM_Free(uivm);
# Return Path
                        src/client/cl_ui.c: CL_ShutdownUI();
                      src/qcommon/common.c: Hunk_Clear()
                    src/client/cl_main.c: CL_ClearMemory(X?)
                  src/client/cl_main.c: CL_Shutdown("Game directory changed")
                src/qcommon/common.c: Com_GameRestart()
              src/qcommon/files.c: FS_ConditionalRestart()
# Path to VM_Load
                src/qcommon/common.c: Com_GameRestart();
                  src/client/cl_main.c: CL_StartHunkUsers()
                    src/client/cl_ui.c: CL_InitUI();
                      src/qcommon/vm.c: VM_Load(uivm); 
                        src/qcommon/common.c: Com_Error() # This use to just FATAL but I changed the code
# Here is where I've changed it
                          libc.dylib: longjmp(abortframe, -1) # Jumps to Com_Frame
                            src/qcommon/common.c: Com_Frame()
                              src/client/cl_main.c: CL_Frame()
                                src/client/cl_main.c: CL_NextDownload()

```
---

# Pull request explanation

As mentioned above, I'm likely missing some key pieces as going from Tremulous -> ioq3 is not so simple (I'm limited to doing it by hand). 

Ok so the PR flips the call order of InitDownloads <-> FS_ConditionalRestart, the intent is to do the download _prior_ to unloading the VM's etc.. incase the modded server provides its own.

The changes here do "work" a little bit, but introduce new problems.  Specifically, After changing the order of the DL's/FS Restart, The FS restart still needs to occur. As a result, this change results in downloads occuring "every time" you connect to a modded server, creating duplicate paks in the mod folder.

^^^ Specifically, this last point is one of the things I need help understanding. AFAICT I need a to sort them in server order so that checksums are compared in the correct order?

Additionally, this is far from the only bug of this nature- changing the base path causes several problems since the game state/cvar states/etc.. are all re-initialized (many of which wrongly so [cl_guid without cl_guidServerUniq for instance]). 