### PR TITLE
[code/botlib/l_precomp.c] Fix string buffer overflow

### DIFF
--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -1323,7 +1323,7 @@ define_t *PC_DefineFromString(char *string)
 	script = LoadScriptMemory(string, strlen(string), "*extern");
 	//create a new source
 	Com_Memset(&src, 0, sizeof(source_t));
-	strncpy(src.filename, "*extern", MAX_PATH);
+	strncpy(src.filename, "*extern", sizeof(src.filename) - 1);
 	src.scriptstack = script;
 #if DEFINEHASHING
 	src.definehash = GetClearedMemory(DEFINEHASHSIZE * sizeof(define_t *));


### PR DESCRIPTION
See also @TTimo's corresponding fix in BSPC: https://github.com/TTimo/bspc/commit/2c8407838398608cb9c52abae046987bb7a39c08

@timangus: For your consideration.