### PR TITLE
Fix mis-spellings of "separating" as "seperating"

### DIFF
--- a/code/botlib/aasfile.h
+++ b/code/botlib/aasfile.h
@@ -65,8 +65,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define FACE_LADDER					2		//ladder
 #define FACE_GROUND					4		//standing on ground when in this face
 #define FACE_GAP					8		//gap in the ground
-#define FACE_LIQUID					16		//face seperating two areas with liquid
-#define FACE_LIQUIDSURFACE			32		//face seperating liquid and air
+#define FACE_LIQUID					16		//face separating two areas with liquid
+#define FACE_LIQUIDSURFACE			32		//face separating liquid and air
 #define FACE_BRIDGE					64		//can walk over this face if bridge is closed
 
 //area contents

--- a/code/botlib/be_aas_cluster.c
+++ b/code/botlib/be_aas_cluster.c
@@ -152,7 +152,7 @@ int AAS_UpdatePortal(int areanum, int clusternum)
 	{
 		//remove the cluster portal flag contents
 		aasworld.areasettings[areanum].contents &= ~AREACONTENTS_CLUSTERPORTAL;
-		Log_Write("portal area %d is seperating more than two clusters\r\n", areanum);
+		Log_Write("portal area %d is separating more than two clusters\r\n", areanum);
 		return qfalse;
 	} //end else
 	if (aasworld.portalindexsize >= AAS_MAX_PORTALINDEXSIZE)

--- a/code/qcommon/cm_trace.c
+++ b/code/qcommon/cm_trace.c
@@ -1053,7 +1053,7 @@ void CM_TraceThroughTree( traceWork_t *tw, int num, float p1f, float p2f, vec3_t
 	}
 
 	//
-	// find the point distances to the seperating plane
+	// find the point distances to the separating plane
 	// and the offset for the size of the box
 	//
 	node = cm.nodes + num;

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -411,7 +411,7 @@ void Com_ParseCommandLine( char *commandLine ) {
         if (*commandLine == '"') {
             inq = !inq;
         }
-        // look for a + seperating character
+        // look for a + separating character
         // if commandLine came from a file, we might have real line seperators
         if ( (*commandLine == '+' && !inq) || *commandLine == '\n'  || *commandLine == '\r' ) {
             if ( com_numConsoleLines == MAX_CONSOLE_LINES ) {


### PR DESCRIPTION
Found by Debian's Lintian tool.