### PR TITLE
Fix array underflow compiler warnings

### DIFF
--- a/code/client/snd_wavelet.c
+++ b/code/client/snd_wavelet.c
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 void daub4(float b[], unsigned long n, int isign)
 {
 	float wksp[4097] = { 0.0f };
-	float	*a=b-1;						// numerical recipies so a[1] = b[0]
+#define a(x) b[(x)-1]					// numerical recipies so a[1] = b[0]
 
 	unsigned long nh,nh1,i,j;
 
@@ -39,22 +39,23 @@ void daub4(float b[], unsigned long n, int isign)
 	nh1=(nh=n >> 1)+1;
 	if (isign >= 0) {
 		for (i=1,j=1;j<=n-3;j+=2,i++) {
-			wksp[i]	   = C0*a[j]+C1*a[j+1]+C2*a[j+2]+C3*a[j+3];
-			wksp[i+nh] = C3*a[j]-C2*a[j+1]+C1*a[j+2]-C0*a[j+3];
+			wksp[i]	   = C0*a(j)+C1*a(j+1)+C2*a(j+2)+C3*a(j+3);
+			wksp[i+nh] = C3*a(j)-C2*a(j+1)+C1*a(j+2)-C0*a(j+3);
 		}
-		wksp[i   ] = C0*a[n-1]+C1*a[n]+C2*a[1]+C3*a[2];
-		wksp[i+nh] = C3*a[n-1]-C2*a[n]+C1*a[1]-C0*a[2];
+		wksp[i   ] = C0*a(n-1)+C1*a(n)+C2*a(1)+C3*a(2);
+		wksp[i+nh] = C3*a(n-1)-C2*a(n)+C1*a(1)-C0*a(2);
 	} else {
-		wksp[1] = C2*a[nh]+C1*a[n]+C0*a[1]+C3*a[nh1];
-		wksp[2] = C3*a[nh]-C0*a[n]+C1*a[1]-C2*a[nh1];
+		wksp[1] = C2*a(nh)+C1*a(n)+C0*a(1)+C3*a(nh1);
+		wksp[2] = C3*a(nh)-C0*a(n)+C1*a(1)-C2*a(nh1);
 		for (i=1,j=3;i<nh;i++) {
-			wksp[j++] = C2*a[i]+C1*a[i+nh]+C0*a[i+1]+C3*a[i+nh1];
-			wksp[j++] = C3*a[i]-C0*a[i+nh]+C1*a[i+1]-C2*a[i+nh1];
+			wksp[j++] = C2*a(i)+C1*a(i+nh)+C0*a(i+1)+C3*a(i+nh1);
+			wksp[j++] = C3*a(i)-C0*a(i+nh)+C1*a(i+1)-C2*a(i+nh1);
 		}
 	}
 	for (i=1;i<=n;i++) {
-		a[i]=wksp[i];
+		a(i)=wksp[i];
 	}
+#undef a
 }
 
 void wt1(float a[], unsigned long n, int isign)

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -4135,7 +4135,7 @@ static void UI_BuildFindPlayerList(qboolean force) {
 	else {
 		// add a line that shows the number of servers found
 		if (!uiInfo.numFoundPlayerServers) {
-			Com_sprintf(uiInfo.foundPlayerServerNames[uiInfo.numFoundPlayerServers-1], sizeof(uiInfo.foundPlayerServerAddresses[0]), "no servers found");
+			Com_sprintf(uiInfo.foundPlayerServerNames[0], sizeof(uiInfo.foundPlayerServerNames[0]), "no servers found");
 		}
 		else {
 			Com_sprintf(uiInfo.foundPlayerServerNames[uiInfo.numFoundPlayerServers-1], sizeof(uiInfo.foundPlayerServerAddresses[0]),

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -4138,7 +4138,7 @@ static void UI_BuildFindPlayerList(qboolean force) {
 			Com_sprintf(uiInfo.foundPlayerServerNames[0], sizeof(uiInfo.foundPlayerServerNames[0]), "no servers found");
 		}
 		else {
-			Com_sprintf(uiInfo.foundPlayerServerNames[uiInfo.numFoundPlayerServers-1], sizeof(uiInfo.foundPlayerServerAddresses[0]),
+			Com_sprintf(uiInfo.foundPlayerServerNames[uiInfo.numFoundPlayerServers-1], sizeof(uiInfo.foundPlayerServerNames[0]),
 						"%d server%s found with player %s", uiInfo.numFoundPlayerServers-1,
 						uiInfo.numFoundPlayerServers == 2 ? "":"s", uiInfo.findPlayerName);
 		}


### PR DESCRIPTION
gcc 6 warns about some array underflows while compiling ioquake3. Please see the individual commit messages for more details.