### PR TITLE
Don't use mostly obsolete 'register' keyword

### DIFF
--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -548,7 +548,7 @@ void PC_PrintDefineHashTable(define_t **definehash)
 
 int PC_NameHash(char *name)
 {
-	int register hash, i;
+	int hash, i;
 
 	hash = 0;
 	for (i = 0; name[i] != '\0'; i++)

--- a/code/game/bg_lib.c
+++ b/code/game/bg_lib.c
@@ -53,10 +53,10 @@ static void	 swapfunc(char *, char *, int, int);
  */
 #define swapcode(TYPE, parmi, parmj, n) { 		\
 	long i = (n) / sizeof (TYPE); 			\
-	register TYPE *pi = (TYPE *) (parmi); 		\
-	register TYPE *pj = (TYPE *) (parmj); 		\
+	TYPE *pi = (TYPE *) (parmi); 			\
+	TYPE *pj = (TYPE *) (parmj); 			\
 	do { 						\
-		register TYPE	t = *pi;		\
+		TYPE	t = *pi;			\
 		*pi++ = *pj;				\
 		*pj++ = t;				\
         } while (--i > 0);				\

--- a/code/qcommon/md5.c
+++ b/code/qcommon/md5.c
@@ -78,7 +78,7 @@ static void MD5Init(struct MD5Context *ctx)
 static void MD5Transform(uint32_t buf[4],
 	uint32_t const in[16])
 {
-    register uint32_t a, b, c, d;
+    uint32_t a, b, c, d;
 
     a = buf[0];
     b = buf[1];

--- a/code/qcommon/vm_interpreted.c
+++ b/code/qcommon/vm_interpreted.c
@@ -317,8 +317,8 @@ locals from sp
 
 int	VM_CallInterpreted( vm_t *vm, int *args ) {
 	byte		stack[OPSTACK_SIZE + 15];
-	register int		*opStack;
-	register uint8_t 	opStackOfs;
+	int		*opStack;
+	uint8_t 	opStackOfs;
 	int		programCounter;
 	int		programStack;
 	int		stackOnEntry;

--- a/code/renderergl1/tr_surface.c
+++ b/code/renderergl1/tr_surface.c
@@ -563,8 +563,8 @@ static void VectorArrayNormalize(vec4_t *normals, unsigned int count)
         
 #if idppc
     {
-        register float half = 0.5;
-        register float one  = 1.0;
+        float half = 0.5;
+        float one  = 1.0;
         float *components = (float *)normals;
         
         // Vanilla PPC code, but since PPC has a reciprocal square root estimate instruction,

--- a/code/ui/ui_shared.c
+++ b/code/ui/ui_shared.c
@@ -4366,7 +4366,7 @@ typedef struct keywordHash_s
 } keywordHash_t;
 
 int KeywordHash_Key(char *keyword) {
-	int register hash, i;
+	int hash, i;
 
 	hash = 0;
 	for (i = 0; keyword[i] != '\0'; i++) {


### PR DESCRIPTION
gcc 6 with -Wall -Wextra warns:

code/botlib/l_precomp.c: In function ‘PC_NameHash’:
code/botlib/l_precomp.c:551:2: warning: ‘register’ is not at beginning of declaration [-Wold-style-declaration]
  int register hash, i;
  ^~~
