### PR TITLE
Fix removing stale pid from baseq3

### DIFF
--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -2153,7 +2153,7 @@ void R_SubdividePatchToGrid( srfBspSurface_t *grid, int width, int height,
 								srfVert_t points[MAX_PATCH_SIZE*MAX_PATCH_SIZE] );
 void R_GridInsertColumn( srfBspSurface_t *grid, int column, int row, vec3_t point, float loderror );
 void R_GridInsertRow( srfBspSurface_t *grid, int row, int column, vec3_t point, float loderror );
-void R_FreeSurfaceGridMesh( srfBspSurface_t *grid );
+void R_FreeSurfaceGridMeshData( srfBspSurface_t *grid );
 
 /*
 ============================================================

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -184,7 +184,12 @@ Sys_RemovePIDFile
 */
 void Sys_RemovePIDFile( const char *gamedir )
 {
-	char *pidFile = Sys_PIDFileName( gamedir );
+	char *pidFile;
+
+	if ( gamedir[0] == '\0' )
+		pidFile = Sys_PIDFileName( BASEGAME );
+	else
+		pidFile = Sys_PIDFileName( gamedir );
 
 	if( pidFile != NULL )
 		remove( pidFile );


### PR DESCRIPTION
Commit 755b2f3 leaves a stale pid file in baseq3 when connecting to a mod server from the in-game browser because lastValidGame is not set to anything on startup.