### PR TITLE
Fix removal of stale pid file from baseq3

### DIFF
--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -184,7 +184,12 @@ Sys_RemovePIDFile
 */
 void Sys_RemovePIDFile( const char *gamedir )
 {
-	char *pidFile = Sys_PIDFileName( gamedir );
+	char *pidFile;
+
+	if ( gamedir[0] == '\0' )
+		pidFile = Sys_PIDFileName( BASEGAME );
+	else
+		pidFile = Sys_PIDFileName( gamedir );
 
 	if( pidFile != NULL )
 		remove( pidFile );


### PR DESCRIPTION
A stale pid file is left in baseq3 when connecting to a mod server from the in-game browser.
This is because lastValidGame is not set to anything on startup.