### PR TITLE
Fix gcc -Wmisleading-indentation warnings

### DIFF
--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -577,8 +577,18 @@ static unsigned short yuv_to_rgb( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 8;
 	b = (YY + ROQ_UB_tab[u]) >> 9;
 	
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 31) r = 31; if (g > 63) g = 63; if (b > 31) b = 31;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 31)
+		r = 31;
+	if (g > 63)
+		g = 63;
+	if (b > 31)
+		b = 31;
 
 	return (unsigned short)((r<<11)+(g<<5)+(b));
 }
@@ -598,8 +608,18 @@ static unsigned int yuv_to_rgb24( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 6;
 	b = (YY + ROQ_UB_tab[u]) >> 6;
 	
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 255)
+		r = 255;
+	if (g > 255)
+		g = 255;
+	if (b > 255)
+		b = 255;
 	
 	return LittleLong ((r)|(g<<8)|(b<<16)|(255<<24));
 }

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1694,8 +1694,8 @@ static void PM_Weapon( void ) {
 	else
 	if( bg_itemlist[pm->ps->stats[STAT_PERSISTANT_POWERUP]].giTag == PW_AMMOREGEN ) {
 		addTime /= 1.3;
-  }
-  else
+	}
+	else
 #endif
 	if ( pm->ps->powerups[PW_HASTE] ) {
 		addTime /= 1.3;


### PR DESCRIPTION
gcc 6 warns by default about indentation that could mislead a reader into misinterpreting what the code does. There are no actual logic errors detected here, but it seems worthwhile to silence the warnings so that if genuinely misleading indentations are warned about in future, they will be noticed.

I have not fixed a remaining warning in the bundled libopus - if people want to fix that one, it should be done by sending a fix upstream to libopus, then updating the bundled libopus to a version with the fix.