### PR TITLE
Eliminate undefined behaviour for amd64 builds

### DIFF
--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -601,7 +601,7 @@ static unsigned int yuv_to_rgb24( long y, long u, long v )
 	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
 	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
 	
-	return LittleLong ((r)|(g<<8)|(b<<16)|(255<<24));
+	return LittleLong ((unsigned long)((r)|(g<<8)|(b<<16))|(255UL<<24));
 }
 
 /******************************************************************************

--- a/code/client/snd_mem.c
+++ b/code/client/snd_mem.c
@@ -139,7 +139,7 @@ static int ResampleSfx( sfx_t *sfx, int channels, int inrate, int inwidth, int s
 			if( inwidth == 2 ) {
 				sample = ( ((short *)data)[srcsample+j] );
 			} else {
-				sample = (int)( (unsigned char)(data[srcsample+j]) - 128) << 8;
+				sample = (unsigned int)( (unsigned char)(data[srcsample+j]) - 128) << 8;
 			}
 			part = (i*channels+j)&(SND_CHUNK_SIZE-1);
 			if (part == 0) {

--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -900,7 +900,8 @@ static void S_AL_NewLoopMaster(src_t *rmSource, qboolean iskilled)
 				S_AL_SaveLoopPos(rmSource, rmSource->alSource);
 			}
 		}
-		else if(rmSource == &srcList[curSfx->masterLoopSrc])
+		else if(curSfx->masterLoopSrc != -1 &&
+		        rmSource == &srcList[curSfx->masterLoopSrc])
 		{
 			int firstInactive = -1;
 

--- a/code/jpeg-8c/jdhuff.c
+++ b/code/jpeg-8c/jdhuff.c
@@ -527,7 +527,7 @@ jpeg_fill_bit_buffer (bitread_working_state * state,
       }
 
       /* OK, load c into get_buffer */
-      get_buffer = (get_buffer << 8) | c;
+      get_buffer = ((unsigned long)get_buffer << 8) | c;
       bits_left += 8;
     } /* end while */
   } else {

--- a/code/jpeg-8c/jidctint.c
+++ b/code/jpeg-8c/jidctint.c
@@ -206,7 +206,7 @@ jpeg_idct_islow (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 	inptr[DCTSIZE*5] == 0 && inptr[DCTSIZE*6] == 0 &&
 	inptr[DCTSIZE*7] == 0) {
       /* AC terms all zero */
-      int dcval = DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]) << PASS1_BITS;
+      int dcval = (unsigned int)DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]) << PASS1_BITS;
 
       wsptr[DCTSIZE*0] = dcval;
       wsptr[DCTSIZE*1] = dcval;
@@ -233,10 +233,8 @@ jpeg_idct_islow (j_decompress_ptr cinfo, jpeg_component_info * compptr,
     tmp2 = z1 + MULTIPLY(z2, FIX_0_765366865);
     tmp3 = z1 - MULTIPLY(z3, FIX_1_847759065);
 
-    z2 = DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]);
-    z3 = DEQUANTIZE(inptr[DCTSIZE*4], quantptr[DCTSIZE*4]);
-    z2 <<= CONST_BITS;
-    z3 <<= CONST_BITS;
+    z2 = (unsigned long)DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]) << CONST_BITS;
+    z3 = (unsigned long)DEQUANTIZE(inptr[DCTSIZE*4], quantptr[DCTSIZE*4]) << CONST_BITS;
     /* Add fudge factor here for final descale. */
     z2 += ONE << (CONST_BITS-PASS1_BITS-1);
 
@@ -344,8 +342,8 @@ jpeg_idct_islow (j_decompress_ptr cinfo, jpeg_component_info * compptr,
     z2 = (INT32) wsptr[0] + (ONE << (PASS1_BITS+2));
     z3 = (INT32) wsptr[4];
 
-    tmp0 = (z2 + z3) << CONST_BITS;
-    tmp1 = (z2 - z3) << CONST_BITS;
+    tmp0 = (unsigned long)(z2 + z3) << CONST_BITS;
+    tmp1 = (unsigned long)(z2 - z3) << CONST_BITS;
     
     tmp10 = tmp0 + tmp2;
     tmp13 = tmp0 - tmp2;
@@ -448,8 +446,7 @@ jpeg_idct_7x7 (j_decompress_ptr cinfo, jpeg_component_info * compptr,
   for (ctr = 0; ctr < 7; ctr++, inptr++, quantptr++, wsptr++) {
     /* Even part */
 
-    tmp13 = DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]);
-    tmp13 <<= CONST_BITS;
+    tmp13 = (unsigned long)DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]) << CONST_BITS;
     /* Add fudge factor here for final descale. */
     tmp13 += ONE << (CONST_BITS-PASS1_BITS-1);
 
@@ -2582,8 +2579,7 @@ jpeg_idct_16x16 (j_decompress_ptr cinfo, jpeg_component_info * compptr,
   for (ctr = 0; ctr < 8; ctr++, inptr++, quantptr++, wsptr++) {
     /* Even part */
 
-    tmp0 = DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]);
-    tmp0 <<= CONST_BITS;
+    tmp0 = (unsigned long)DEQUANTIZE(inptr[DCTSIZE*0], quantptr[DCTSIZE*0]) << CONST_BITS;
     /* Add fudge factor here for final descale. */
     tmp0 += 1 << (CONST_BITS-PASS1_BITS-1);
 
@@ -2685,7 +2681,7 @@ jpeg_idct_16x16 (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 
     /* Add fudge factor here for final descale. */
     tmp0 = (INT32) wsptr[0] + (ONE << (PASS1_BITS+2));
-    tmp0 <<= CONST_BITS;
+    tmp0 = (unsigned long)tmp0 << CONST_BITS;
 
     z1 = (INT32) wsptr[4];
     tmp1 = MULTIPLY(z1, FIX(1.306562965));      /* c4[16] = c2[8] */

--- a/code/qcommon/cm_polylib.c
+++ b/code/qcommon/cm_polylib.c
@@ -276,7 +276,7 @@ winding_t	*CopyWinding (winding_t *w)
 	winding_t	*c;
 
 	c = AllocWinding (w->numpoints);
-	size = (intptr_t) ((winding_t *)0)->p[w->numpoints];
+	size = (intptr_t)&(w->p[w->numpoints]) - (intptr_t)w;
 	Com_Memcpy (c, w, size);
 	return c;
 }

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -1378,7 +1378,7 @@ Touch all known used data to make sure it is paged in
 void Com_TouchMemory( void ) {
 	int		start, end;
 	int		i, j;
-	int		sum;
+	unsigned int	sum;
 	memblock_t	*block;
 
 	Z_CheckHeap();
@@ -1389,20 +1389,20 @@ void Com_TouchMemory( void ) {
 
 	j = hunk_low.permanent >> 2;
 	for ( i = 0 ; i < j ; i+=64 ) {			// only need to touch each page
-		sum += ((int *)s_hunkData)[i];
+		sum += ((unsigned int *)s_hunkData)[i];
 	}
 
 	i = ( s_hunkTotal - hunk_high.permanent ) >> 2;
 	j = hunk_high.permanent >> 2;
 	for (  ; i < j ; i+=64 ) {			// only need to touch each page
-		sum += ((int *)s_hunkData)[i];
+		sum += ((unsigned int *)s_hunkData)[i];
 	}
 
 	for (block = mainzone->blocklist.next ; ; block = block->next) {
 		if ( block->tag ) {
 			j = block->size >> 2;
 			for ( i = 0 ; i < j ; i+=64 ) {				// only need to touch each page
-				sum += ((int *)block)[i];
+				sum += ((unsigned int *)block)[i];
 			}
 		}
 		if ( block->next == &mainzone->blocklist ) {

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -3432,10 +3432,10 @@ static void FS_CheckPak0( void )
 
 	for( path = fs_searchpaths; path; path = path->next )
 	{
-		const char* pakBasename = path->pack->pakBasename;
-
 		if(!path->pack)
 			continue;
+
+		const char* pakBasename = path->pack->pakBasename;
 
 		curpack = path->pack;
 

--- a/code/qcommon/md4.c
+++ b/code/qcommon/md4.c
@@ -106,8 +106,8 @@ static void copy64(uint32_t *M, byte *in)
 	int i;
 
 	for (i=0;i<16;i++)
-		M[i] = (in[i*4+3]<<24) | (in[i*4+2]<<16) |
-			(in[i*4+1]<<8) | (in[i*4+0]<<0);
+		M[i] = ((uint32_t)in[i*4+3]<<24) | ((uint32_t)in[i*4+2]<<16) |
+			((uint32_t)in[i*4+1]<<8) | ((uint32_t)in[i*4+0]<<0);
 }
 
 static void copy4(byte *out,uint32_t x)

--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -214,7 +214,7 @@ int MSG_ReadBits( msg_t *msg, int bits ) {
 			for(i=0;i<bits;i+=8) {
 				Huff_offsetReceive (msgHuff.decompressor.tree, &get, msg->data, &msg->bit);
 //				fwrite(&get, 1, 1, fp);
-				value |= (get<<(i+nbits));
+				value = (unsigned int)value | ((unsigned int)get<<(i+nbits));
 			}
 //			fclose(fp);
 		}

--- a/code/qcommon/vm_interpreted.c
+++ b/code/qcommon/vm_interpreted.c
@@ -816,9 +816,6 @@ nextInstruction2:
 			opStack[opStackOfs] = ((unsigned) r1) % ((unsigned) r0);
 			goto nextInstruction;
 		case OP_MULI:
-			opStackOfs--;
-			opStack[opStackOfs] = r1 * r0;
-			goto nextInstruction;
 		case OP_MULU:
 			opStackOfs--;
 			opStack[opStackOfs] = ((unsigned) r1) * ((unsigned) r0);

--- a/code/qcommon/vm_x86.c
+++ b/code/qcommon/vm_x86.c
@@ -103,7 +103,8 @@ static int isu8(uint32_t v)
 
 static int NextConstant4(void)
 {
-	return (code[pc] | (code[pc+1]<<8) | (code[pc+2]<<16) | (code[pc+3]<<24));
+	return ((unsigned int)code[pc] | ((unsigned int)code[pc+1]<<8) |
+	       ((unsigned int)code[pc+2]<<16) | ((unsigned int)code[pc+3]<<24));
 }
 
 static int	Constant4( void ) {

--- a/code/renderercommon/tr_font.c
+++ b/code/renderercommon/tr_font.c
@@ -303,7 +303,7 @@ static int fdOffset;
 static byte	*fdFile;
 
 int readInt( void ) {
-	int i = fdFile[fdOffset]+(fdFile[fdOffset+1]<<8)+(fdFile[fdOffset+2]<<16)+(fdFile[fdOffset+3]<<24);
+	int i = fdFile[fdOffset]+((unsigned int)fdFile[fdOffset+1]<<8)+((unsigned int)fdFile[fdOffset+2]<<16)+((unsigned int)fdFile[fdOffset+3]<<24);
 	fdOffset += 4;
 	return i;
 }

--- a/code/renderergl1/tr_bsp.c
+++ b/code/renderergl1/tr_bsp.c
@@ -330,7 +330,7 @@ static void ParseFace( dsurface_t *ds, drawVert_t *verts, msurface_t *surf, int 
 	numIndexes = LittleLong( ds->numIndexes );
 
 	// create the srfSurfaceFace_t
-	sfaceSize = ( size_t ) &((srfSurfaceFace_t *)0)->points[numPoints];
+	sfaceSize = sizeof(srfSurfaceFace_t) + sizeof(float[numPoints - 1][VERTEXSIZE]);
 	ofsIndexes = sfaceSize;
 	sfaceSize += sizeof( int ) * numIndexes;
 

--- a/code/renderergl1/tr_marks.c
+++ b/code/renderergl1/tr_marks.c
@@ -414,7 +414,7 @@ int R_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projectio
 			indexes = (int *)( (byte *)surf + surf->ofsIndices );
 			for ( k = 0 ; k < surf->numIndices ; k += 3 ) {
 				for ( j = 0 ; j < 3 ; j++ ) {
-					v = surf->points[0] + VERTEXSIZE * indexes[k+j];;
+					v = &surf->points[0][0] + VERTEXSIZE * indexes[k+j];
 					VectorMA( v, MARKER_OFFSET, surf->plane.normal, clipPoints[0][j] );
 				}
 

--- a/code/renderergl1/tr_shade_calc.c
+++ b/code/renderergl1/tr_shade_calc.c
@@ -929,8 +929,8 @@ void RB_CalcTurbulentTexCoords( const waveForm_t *wf, float *st )
 		float s = st[0];
 		float t = st[1];
 
-		st[0] = s + tr.sinTable[ ( ( int ) ( ( ( tess.xyz[i][0] + tess.xyz[i][2] )* 1.0/128 * 0.125 + now ) * FUNCTABLE_SIZE ) ) & ( FUNCTABLE_MASK ) ] * wf->amplitude;
-		st[1] = t + tr.sinTable[ ( ( int ) ( ( tess.xyz[i][1] * 1.0/128 * 0.125 + now ) * FUNCTABLE_SIZE ) ) & ( FUNCTABLE_MASK ) ] * wf->amplitude;
+		st[0] = s + tr.sinTable[ ( int ) fmod( ( ( tess.xyz[i][0] + tess.xyz[i][2] )* 1.0/128 * 0.125 + now ) * FUNCTABLE_SIZE, FUNCTABLE_SIZE ) ] * wf->amplitude;
+		st[1] = t + tr.sinTable[ ( int ) fmod( ( tess.xyz[i][1] * 1.0/128 * 0.125 + now ) * FUNCTABLE_SIZE, FUNCTABLE_SIZE ) ] * wf->amplitude;
 	}
 }
 

--- a/code/renderergl2/tr_bsp.c
+++ b/code/renderergl2/tr_bsp.c
@@ -1813,7 +1813,9 @@ static void R_CreateWorldVaos(void)
 				coverage *= right - left + 1.0f/256.0f;
 			}
 
-			iCoverage = coverage * 256;
+			// coverage * 256 can go above INT_MAX
+			coverage *= 256;
+			iCoverage = coverage < (float)INT_MAX ? (int)coverage : INT_MAX;
 
 			if (iCoverage > s_worldData.surfacesDlightBits[surfaceNum])
 			{


### PR DESCRIPTION
I used clang to build with canaries for undefined behaviour and eliminated all instances triggered, with opengl1, opengl1, vm_*=0, vm_*=1 and vm_*=2.

Note e52d30e, this has apparently never worked as intended, so it actually fixes the functionality and the undefined behaviour.