### PR TITLE
[be_aas_route.c] Fix invalid access to cluster 0

### DIFF
--- a/code/botlib/be_aas_route.c
+++ b/code/botlib/be_aas_route.c
@@ -1486,6 +1486,8 @@ void AAS_UpdatePortalRoutingCache(aas_routingcache_t *portalcache)
 		updateliststart = curupdate->next;
 		//current update is removed from the list
 		curupdate->inlist = qfalse;
+		// cluster 0 is a dummy, cf. be_aas_cluster.c:AAS_InitClustering.
+		if (curupdate->cluster == 0) continue;
 		//
 		cluster = &aasworld.clusters[curupdate->cluster];
 		//
@@ -1661,6 +1663,11 @@ int AAS_AreaRouteToGoalArea(int areanum, vec3_t origin, int goalareanum, int tra
 		{
 			goalclusternum = clusternum;
 		} //end if
+	} //end if
+	// cluster 0 is a dummy, cf. be_aas_cluster.c:AAS_InitClustering.
+	else if (clusternum == 0 || goalclusternum == 0)
+	{
+		return qfalse;
 	} //end if
 	//if both areas are in the same cluster
 	//NOTE: there might be a shorter route via another cluster!!! but we don't care


### PR DESCRIPTION
I believe I have found a bug in the pathfindling logic in `be_aas_route.c`. The problem is that the code sometimes attempts to access the area cache for cluster 0. However, cluster 0 is a special "dummy" cluster (see comments in `AAS_InitClustering` in `be_aas_cluster.c`) and doesn't have any associated areas, and thus all accesses to the area cache for cluster 0 are out of bounds.

The convention is that cluster *n* is a regular cluster for *n* > 0, or &minus;*n* is a portal for *n* < 0, and *n* = 0 is the dummy cluster. There is logic that only tests for portals via `if (clusternum > 0) ... else ...` and just *assumes* that you don't call it for cluster 0.

The bug causes rare crashes due to access violations, but if you instrument the array accesses and check the bounds, you see erroneous accesses almost immediately even for very simple maps.

Could you please double-check my reasoning and confirm? @TTimo: I believe there is a copy of this logic in BSPC, which may also be affected.