### PR TITLE
Correct test for GL_EXT_texture_env_add support

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -627,7 +627,7 @@ static void GLimp_InitExtensions( void )
 
 	// GL_EXT_texture_env_add
 	glConfig.textureEnvAddAvailable = qfalse;
-	if ( SDL_GL_ExtensionSupported( "EXT_texture_env_add" ) )
+	if ( SDL_GL_ExtensionSupported( "GL_EXT_texture_env_add" ) )
 	{
 		if ( r_ext_texture_env_add->integer )
 		{


### PR DESCRIPTION
The test string is missing the initial "GL_" so it is always failing the test even when supported on newer hardware.

This was caused by the original 'string compare against the ENTIRE extension string' test that was mass-converted to using proper extension-testing functioins during commit c923872ca2e5387f359c4d95c293e5900f91a36c

Should a separate test for GL_ARB_texture_env_add be added as well? No changes to the interface, the existing GL_EXT was promoted to full ARB status many years ago; I'm unsure if any video cards only advertise the ARB but not the EXT string.