### PR TITLE
Server side demos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1608,6 +1608,8 @@ Q3OBJ = \
   $(B)/client/sv_net_chan.o \
   $(B)/client/sv_snapshot.o \
   $(B)/client/sv_world.o \
+  $(B)/client/sv_demo.o \
+  $(B)/client/sv_demo_ext.o \
   \
   $(B)/client/q_math.o \
   $(B)/client/q_shared.o \
@@ -2129,6 +2131,8 @@ Q3DOBJ = \
   $(B)/ded/sv_net_chan.o \
   $(B)/ded/sv_snapshot.o \
   $(B)/ded/sv_world.o \
+  $(B)/ded/sv_demo.o \
+  $(B)/ded/sv_demo_ext.o \
   \
   $(B)/ded/cm_load.o \
   $(B)/ded/cm_patch.o \

--- a/README-serverside-demos.md
+++ b/README-serverside-demos.md
@@ -1,0 +1,269 @@
+
+Server-side demos patch (entities/events oriented) for ioquake3
+===============================================================================================
+
+
+DESCRIPTION
+-----------
+Fully working server-side demos for ioquake3 are now a reality!
+
+This patch provide a full server-side demos facility for ioquake3 github commit of 2017-03-04. For the original patch for OpenArena with full commit history, see https://github.com/lrq3000/openarena_engine_serversidedemos .
+
+This patch was done by Stephen Larroque and is based on the original patch by Amanieu d'Antras for Tremfusion (Tremulous).
+
+The approach used here is entity/event oriented demo recording, which means that each event and entity change is recorded in the demo. At playback, the whole game state is replayed every frame. In other words, a server-side demo is a simulation of a real game, with "ghost" entities and players.
+
+This implementation has been made as generic as possible, and so it should work for any mod based on ioquake3 or Quake 3 Arena. It was also cleaned up and separated as much as possible from the core code, leaving a minimum of changes to the core files, so it should be easily portable to any version of ioquake3 >= r1910 (maybe also with a few prior versions).
+
+NOTE: this is a port from OpenArena v0.8.8 to OA+ioquake3, this should be even more close to the original ioquake3 code.
+
+NOTE2: an alternative is to record multiview demos (which is not what this patch does), but server-side. A multiview demo records each players stream (= network snapshot packets), and just replays them. This is even more generic than this patch's approach, as it should work with virtually any mod and any configuration possible (since it would be agnostic to the network snapshots content, it would just replay them!). If you are interested by this approach, see TheDoctor's patch (see github releases/TheDoctor-serverside-demo_v0.4.patch.zip) or better the [eDawn patch](http://edawn-mod.org/forum/viewtopic.php?f=5&t=7) ([more info here](http://edawn-mod.org/binaries/quake3e-mv.txt)) (see github releases/q3e-multiview-patch-edawn.zip). This approach could be extended to provide a full replacement to GTV (ie, to rebroadcast matchs in realtime using a man-in-the-middle server).
+
+
+FEATURES
+--------
+
+* Allows to record full server-side demos
+* Can autorecord, with meaningful automatically generated filename (format: hostname-date-time-map.sv_dmxx)
+* Can record demos in mods
+* Privacy checking: filters out privacy data (not even recorded in the demo file)
+* Save meta-data of the demo (infos about the demo, like the UTC datetime)
+* Automatically switch the correct gametype/mod/map/limits when replaying a demo
+* Can play demos on a server
+* Can be used as an alternative to GTV by rebroadcasting a demo (can be done in realtime as the demo is being written)
+
+
+
+INSTALL
+-------
+
+Simply compile the code into a binary, and use these binaries. You do not need to add any .pk3 nor make your server unpure, this will be totally transparent.
+
+Servers obviously need these binaries to record and play demos.
+
+Clients also need these binaries to play demos locally, unless they connect to a server replaying the demos, in this case they don't need anything.
+
+Indeed, a server issuing `/demo_play <filename>` will be accessible to spectators. This can be useful to replay a big event. This can also be used as a replacement to GTV, since you can read a demo at the same time as it is being written.
+USAGE
+-----
+
+Commands:
+
+* `demo_play <filename>` : playback a server-side demo (to be found, the demo must be in the current mod folder, even if it was recorded with another mod). Note that clients need to go back to the main menu before issuing the `/demo_play <filename>` command, else the demo won't be found. The demo will automatically switch mods if necessary, and load the correct map.
+* `demo_record <filename>` : record a server-side demo with the given filename (will be saved in mod/svdemos folder). For automated demo recording, see sv_autoDemo cvar below.
+* `demo_stop` : stop any playback/recording (will automatically restore any previous setting on the server/client). Note that shutting down the server/quitting the game will not break the demo, the demo will still be readable.
+* `status` : as with normal clients, when a demo is replaying, democlients will also be shown in the status (with ping DEMO).
+
+Special cvars:
+
+* `sv_autoDemo 1` : enable automatic recording of server-side demos (will start at the next map change/map_restart).
+* `sv_demoTolerant 1` : enable demo playback compatibility mode. If you have an old server-side demo, or a bit broken, this can maybe allow you to playback this demo nevertheless.
+* `sv_democlients` : show number of democlients (automatically managed, this is a read-only cvar).
+* `sv_demoState` : show the current demo state (0: none, 1: waiting to play a demo, 2: demo playback, 3: waiting to stop a demo, 4: demo recording).
+
+
+
+UPDATE ON GIT
+-------------
+
+Just like the openarena_engine repo, this one was rebased onto the latest openarena_engine repo (ioquake3+OA088), so that all changes from ioquake3 to openarena are on top of the latest ioquake3 changes, and all the changes from openarena to this sv_demo patch are on top of the openarena commits. Thus, you have a linear commit graph which is easy to rebase against new versions, and the history is more human readable.
+
+To update this repo, you can:
+
+    # First clone the git repo locally on your computer
+    git clone git://github.com/lrq3000/openarena_engine_serversidedemos.git
+    
+    # Then either sync with openarena_engine
+    git remote add upstream git://github.com/lrq3000/openarena_engine.git
+    
+    # Or directly with ioquake3
+    # git://github.com/ioquake/ioq3.git
+    
+    AUTO-PROCEDURE
+    ##############
+    # Then try to pull + rebase the changes automatically
+    git pull --rebase upstream master
+    
+    # If it works, then all is done! You have an updated version on your computer. You can stop here and just compile the engine using the tutorials in the ioq3 wiki: http://wiki.ioquake3.org/Building_ioquake3
+    # PS: for Windows, use the cygwin tutorial, don't try mingw unless you are very experienced and have got a lot of spare time to mess with the weird errors you will get.
+    
+    MANUAL PROCEDURE
+    ################
+    # Else, you have to redo the process but manually this time. Following steps:
+    
+    # First, you have to reinitialize you repo, else it won't accept you do anything:
+    $ git rebase --abort
+    $ git reset --hard origin/master
+    
+    # Git rebase interactive so that you get the list of the last commits. This will open you a text file in your default text editor program. What you have to do here is to cut all the lines that concerns commits about the sv_demo patch. Then paste these lines in a temporary text file for you (we will later use the SHA code of the commmits).
+    git rebase HEAD~10 --interactive
+    
+    # Now you should have a clean repo without the sv_demo commits, only an old revision of the openarena_engine.
+    
+    # We will now sync to the latest changes of openarena_engine or ioquake3:
+    git pull -s recursive -X theirs upstream master
+    # This will pull all remote changes and accept them automatically.
+    
+    # Now, you should have a clean repo synced to the latest revision of the engine. We just have now to reapply the sv_demo commits one by one.
+    
+    # Reopen the text file where you pasted those sv_demo commits lines before (when we did rebase --interactive), and follow the commits in the natural order: from the top to the bottom. The top commit being the oldest one, and the lowest the latest.
+    # You have to pick the oldest commit first, then to the more recent and so on. Look at the SHA code (the second column after the command "pick"), and copy this SHA code below in place of 617a:
+    git cherry-pick 617a
+    # This command will pick this very specific commit and will try to reapply it.
+    # It will try to automatically merge the conflicts.
+    
+    # In the case there are some unresolved conflicts, you can resolve them manually by doing:
+    git mergetool
+    
+    # If you resolved manually the conflicts, then you have to do:
+    git commit
+    
+    # And then, you can continue onto the next sv_demo commit:
+    git cherry-pick ...
+    
+    # Until you reapplied all the commits, and voila, you have an up-to-date engine with the sv_demo patch!
+
+
+DEV NOTES
+---------
+
+* In msg.c: if ( cl_shownet && ...  IS necessary for the patch to work, else without this consistency check the engine will crash when trying to replay a demo on a server (but it will still work on a client!)
+  NOTE: This was merged in a patch in the ioquake3 project, and this fix is now officially part of the engine.
+
+* usercmd_t management (players movement commands simulation) is implemented but commented out. It fully works, but it's not necessary for the demo functionnalities, and it adds a LOT of data to the demo file, so demo files take a lot more harddrive space when this function is enabled. If you want to do demo analysis, it is advised to turn on this feature, else you should probably not.
+
+
+
+TODO
+----
+
+* Update to latest OpenArena v3.0.0a (don't expect this to be done anytime soon, but it should be easy using the [ioquake3 patch](https://github.com/lrq3000/ioq3/tree/server-side-demo), if you want to give it a shot!).
+
+
+
+SHOULD DO (but not now)
+-----------------------
+
+* please wait before switching teams should not be printed (but it's a standard gameCommand, fixing it would be very unelegant and add a lot of complexity to the code for such a special case - or maybe just move SV_GameSendServerCommand() hook into clientNum == -1 only? Wouldn't that prevent the recording of some other important command strings?)
+
+* Delagsimulation when replaying a demo to see in the "eye of the beholder". Probably should be done as a gamecode modification, either at recording by storing the client-side world state after delag, or by simulating the delag at replaying from demo and pings infos (already recorded normally).
+
+* Fix usercmds_t replaying (by fixing command time, I think it's not set correctly and so the commands are dropped), see g_active.c ClientThink_real():
+  msec = ucmd->serverTime - client->ps.commandTime;
+  // following others may result in bad times, but we still want
+  // to check for follow toggles
+  if ( msec < 1 && client->sess.spectatorState != SPECTATOR_FOLLOW ) {
+  	return;
+  }
+
+* When demo replaying a demo client-side with mod switching, sv_cheats is disabled (prevent timescale and other commands to be used)
+
+
+
+KNOWN BUGS (WONT FIX FOR NOW)
+-----------------------------
+Below is a list of known bugs or wished features, but if you encounter them, please report anyway. If a bug is reported to be too hampering, it may get fixed in the future.
+
+* save the minimum correct value for sv_democlients when recording: count the total number of clients (>= CS_ZOMBIE) per frame, and the highest number count will be the good number (or just look at the highest clientid reached since client slots are filled in ascending order).
+
+* entityShared_t, entityState_t and playerState_t could be normalized with the other functions to put in write functions and use a marker per entity instead of a marker for a whole lot of entities (but maybe this would require more space? but would maybe be better to read the demo, more coherent: one marker, one event). Because for now, these are the only functions that write ALL data for ALL entities at once, instead of one entity per call, and thus, these functions are managed in a special way compared to others.
+
+* team0 bug at demo start/end: when the server change sv_democlients and sv_maxclients, some data aren't copied over, or the gamecode is not notified of the change. Anyway, all my tries to fix that broke completely the engine (see SV_ChangeMaxClients() in sv_init.c if you want to give it a try). WORKAROUND: now the patch automatically force real clients to spectator, so this should not be an issue anymore (and in fact it happens when the gamecode thinks it's not a team-based gametype, so it makes the clients auto join in, but it's weird that sometimes it does the same thing when its >= GT_TEAM !).
+
+* NOT POSSIBLE: save all client_t (and clientState_t), player_t (and playerState_t), and gentity_t (sv.gentities) fields (and subfields) in demos. Advantage: theoretically 100% faitful demo. Cons: a big space hog and some fields should NOT be saved or they will cause a weird behaviour of the engine (such as netchan or download management fields).
+  the best would be a polymorphic recursive function that would automatically read the specification of the object given or subobjects and automatically create the good fields, and when reading back the recording it would automatically know how to read the data based on the specification too).
+  currently: only gentity_t->entityShared_t and gentity_t->entityState_t and playerState_t are recorded. Other fields (except health and speed) are NOT recorded (eg: gclient_s *client, gitem_t *item, etc..).
+  Please note that we already save a maximum of data, in fact all the data that will ever be needed. But this is not generic (we pick each info we want), maybe it would be better to have a generic save function for the whole data structure, easily adaptable to any game that adds more data fields?
+
+* SendConsoleCommand save in demos (will record postgame data and teamtask) G_SEND_CONSOLE_COMMAND and reproduce with Cbuf_ExecuteText( args[1], VMA(2) ); - not a good idea because there are map_restart commands that may be catched, and we don't want that (and without this hook, the patch really works pretty well).
+
+* Prevent all recorded sv_game.c commands to be accepted when demo_playback? Bad idea I think.
+
+* Store and replay network messages, similarly to TheDoctor's patch, but redirect them to all the real players who are spectating the client? Could be nice, but hard to combine with the current infrastructure. And in fact, replaying demomessages can't replay all events when free flying. NO: in fact this method should be implemented in a separate patch and could lead to a full GTV-like alternative (and also to low CPU server-side demos).
+
+* scoreboard is not ordered in descending order of score (except when a player dies, it forces the engine to refresh with the demo's infos) - problem linked to the same cause that produces the ping problem.
+
+* Sometimes (not that it's not _always_, if it happens _always_ then that's another bug you should report) print or cp messages are issued more than once. This is a bug caused by the fact that the engine automatically issue messages after some events (such as ClientBegin), but they are also recorded in the demo file. When replaying, there's a check function that tries to avoid duplicates, but sometimes a few cases will slip in: to be more precise, when a game command from the demo file is issued before the event happening in the demo triggers the engine to issue a game command. The other way around (engine game command then demo game command) is already handled, but the other way around not, because we don't want to prevent the engine to issue its messages in any way.
+
+* clients cid is recorded on a Byte, so it supports only a value between 0 and 255 (can easily change that to long if necessary).
+
+* When loading a demo on a server that was recorded on another mod than the one currently loaded, when the server will switch automatically the mod, it will disconnect all connected players with the message "Game Directory Changed". This is normal and unavoidable (except if you find a genius way to keep the server running while hotswapping the mod, then submit your patch to ioquake3).
+
+* Non-player entities health is NOT recorded. It could be, now that a get function was done, but it would complexify the code and I'm not sure if this would really benefit something. When entities run out of health, they are anyway destroyed (since their state is recorded), but their health not. This means that the health that is shown in the crosshair when aiming at an entity will not be updated in a demo.
+
+* set_cvar too? and at startup just like configstrings (will avoid timelimit)? Bad idea too.
+
+* Cvars changed in the demo aren't set when replayed, but if they affect an aspect of the gameplay (such as changing g_gravity), it will be reflected in the demo because the whole entities states are recorded, so it will be faithfully reproduced even if the cvars aren't set (if you have a demo where that's not the case, please post it and describe).
+
+* ExcessivePlus: when replaying a demo, democlients whose initial team was spectator can be spectated (but subsequent team change will make them unspectatable if they go to spec).
+
+
+
+CHANGELOG (newest to the bottom)
+--------------------------------
+
+* Map not issued after game_restart, either fix or delay a bit
+  because after game_restart need to change again sv_democlients and sv_maxclients (add a delay if that doesn't work directly with cbuf_addtext)
+* excessiveplus map_restart nonstop (because of vars checking!) - no because of gamecommand setting system reserved configstrings.
+* demo messages are too much repeated with excessiveplus. This is because of GameCommands, which are repeated per client connected (weird behaviour, normally only commands broadcasted to everybody, so just sent once, are recorded, so E+ sends multiple times the same command when it shouldn't).
+* bots away bug?
+* demostop, when from baseoa to excessiveplus demo, then play again and it crashes (was just the last savedFsGame affectation that wasn't right, was not using strcpy).
+* bots team joining bug: maybe the strcpy is not right? (see the thing that happened with fs_game - maybe userinfo? when it will be fixed?). SOLUTION: was just g_doWarmup, nothing to do with bots in fact, it just waited for enough players to be playing (and democlients ARE considered to be playing) to start the warmup, without announcing it.
+* autorecord doesn't work anymore. look at the log and try old versions. Probably there's a command that is recorded and that shouldn't at the beginning of a map. Solution: forgot to move the check to avoid recording system configstrings.
+* Filtering sv_hostname to disallow bad characters such as ":" on Windows OSes. It will still record a demo, but everything behind this name will be dropped. That's why the hostname is set last, to workaround this problem meanwhile.
+* demo is already replaying... add message: use demo_stop to stop any recording/replaying and retry
+* timelimit, fraglimit, capturelimit store and replay too?
+* health gamecode update (set a g_demoPlaying var and from the server I can Cvar_SetValue very easily).
+* forceteam spec only if player is connected
+* move these writeframe if to functions
+* move switch readframe to functions
+* auto sv_democlients 0 at startup
+* fix writestring warning for configstrings index
+* messages again repeated...
+* broadcast message cp when demo starts
+* g_autoDemo auto disable on demo launching after a certain point (after corruptions and such, just before a map_restart)
+* save hostname and restore it after? No because player won't know where they are. We save it, but that's all (can be printed as a demo info like: Demo infos: demo was recorded on server ... at date-time, map, gametype, sv_fps and ...)
+* Can't replay a demo when launched by client launcher (can't find the file???)
+* team bug set (see current qconsole10.log)
+* special variable sv_demoTolerant 1 to enable faults tolerance mode (will be tolerant to parsing errors: 1- pass if illegible message error when reading frames 2- when reading a demo headers, new format: string for the variable name to set, then value, and in a if until string "END" continue to read and set all cvars. This means that by enabling this mode, you can probably read all demos recorded from this version up to any version. So in the future, you will still be able to replay demos recorded with previous versions of this patch (if version >= v0.9.4.3). Concretely, with sv_demoTolerant 1, new demo messages and missing new meta data (meta data implemented later) will just be skipped.
+* events messages support for coloured strings (such as coloured names)
+* what happens if a cvar is changed during the demo such as gravity? It's ok, if it affects the gameplay, it's reproduced in the demo (and if it does not, then we don't have to care anyway).
+* g_gametype not necessarily set back if game_restart (latched but needs another map_restart)
+* normal client demo e+ bug -> due to bad refreshing of democlients and svmaxclients (svmaxclients is not refreshed after game_restart). This was because of game_restart mod switch, sv_maxclients nor sv_democlients was set at the right time, so another delay command was issued, which cumulated with previously issued delay commands, and at the end it gave an infinite loop of map_restart (since all delay would trigger non-stop).
+* MAJOR BUG: sv_autoDemo 1 and real clients disconnected because of wrong guid at each map change. Was because when filtering userinfo string, it rewritten over the client userinfo string instead of copying it over to another var (so the guid and ip was removed from the client's infos! And the server dropped the clients at the next time they tried to reconnect, such as map change).
+* support timescale change when replaying a demo (still a bit buggy with very low values or very high, but it works)
+* support for cl_freezeDemo to freeze the demo (works but the camera can't move when in spectator! That's normal since we block the time and so it blocks any movement. This is in fact the same behaviour as in standard demos.)
+* sometimes the name is not refreshed, maybe client_t name or netname field is not updated?
+* Demo recorded during the warmup ARE buggy (most of the time can't even be replayed!). This is normal (because of the warmup, produces a lot of weird issues), so maybe just detect when it's warmup time and disable auto recording?
+  was because of demo initial time that was too small (400) and sv.time too high, even if we just have restarted the map (at least 440 in practice...), so the solution was to let some demo frames replay in the void, so that we can artificially adjust the demo to the current sv.time and then play normally.
+* SHA demo stops after a few seconds? lol why?
+* dm not working... like SHA, stops after a few seconds
+* tourney: demo file is corrupted or quit like dm
+* tdm like dm
+* overload infinite loop like warmup
+* if tourney mode: should NOT issue /team because it will set the player at the end of the list (and cannot be spectated!)
+* overload entities bug?
+* NET_CompareBaseAdr: bad address type error?
+* new players at connection in DM automatically goes to the game
+* free malloc'ed strings
+* strpy -> Q_strncpyz
+* test with other mods
+* warmup still recording problem with demo and excessiveplus... - yes but no problem, the demo continues to play
+* fix issues with very low timescale (the game speeds up! the rounding in the calculation must be producing a big rounding error somewhere).
+* Generations Arena: team management does not work (when a player switch team, he is not affected to the right team)
+* E+ now real players join the game...
+* E+ democlients are not spectatable, userinfo is not reliable - now update, specs are spectatable...
+* cleaned FIXME
+* clean code
+* Fix inactivity timers (simulate UserMove or just send a fake usercmd_t) - had to craft a remoteAddress with NET_StringToAdr, because else if we just use Info_SetValueForKey(userinfo, "ip", "localhost") the server would remove the ip key in the userinfo because no real address can be found for democlients.
+* SV_DemoChangeMaxClients() does not consider privateclients reserved slots when moving clients (eg: with 2 privateslots: 2 -> 12 -> 0)
+* many "A demo is already being recorded/played. Use demo_stop and retry." messages printed when playing a demo client-side.
+* remove developer prints
+* ExcessivePlus: when replaying a demo, democlients are not spectatable anymore after a variable amount of time, and are set to Away state. This is because of xp_inactivitySpectator timer. This was fixed by setting an appropriate localhost remote addr for the demo clients.
+* when recording a demo and stopping it, the demo file is still left open and locked until the game/server is closed.
+* port to the latest openarena engine based on the latest ioquake3 (should change the demoExt management in files.c).
+* fix: big memory leaks, Z_Free pointer errors and removed a few useless mallocs. Thank's to Valgrind (use +set vm_game 1 to use Valgrind with OA, else with any other value it won't work).
+* fix: svdemo filenames were truncated, now they should have more length to spare
+* fix: Compatibility with OA 0.8.8: fix: fixed "FIXING ENT->S.NUMBER!!!" error, crashing demo playback with OA > 0.8.5. Now, the patch is compatible with OA 0.8.8
+* fix: compatibility with maps containing mover objects (like moving platforms of Kaos2): "Reached_BinaryMover: bad moverState" error. Fixed by stopping ent->reached from being called by setting entity->s.pos.trType = TR_LINEAR when entity->s.pos.trType == TR_LINEAR_STOP.
+* add: Compiled for ioquake3 latest version (but not yet merged in OA v3): https://github.com/lrq3000/ioq3/tree/server-side-demo

--- a/code/qcommon/cmd.c
+++ b/code/qcommon/cmd.c
@@ -353,6 +353,41 @@ static	char		cmd_cmd[BIG_INFO_STRING]; // the original command we received (no t
 
 static	cmd_function_t	*cmd_functions;		// possible commands to execute
 
+typedef struct cmdContext_s
+{
+	int		argc;
+	char	*argv[ MAX_STRING_TOKENS ];	// points into cmd.tokenized
+	char	tokenized[ BIG_INFO_STRING + MAX_STRING_TOKENS ];	// will have 0 bytes inserted
+	char	cmd[ BIG_INFO_STRING ]; // the original command we received (no token processing)
+} cmdContext_t;
+
+static cmdContext_t		cmd;
+static cmdContext_t		savedCmd;
+
+/*
+============
+Cmd_SaveCmdContext
+
+Save the tokenized strings and cmd so that later we can restore them and the engine will continue its usual processing normally
+============
+*/
+void Cmd_SaveCmdContext( void )
+{
+	Com_Memcpy( &savedCmd, &cmd, sizeof( cmdContext_t ) );
+}
+
+/*
+============
+Cmd_RestoreCmdContext
+
+Restore the tokenized strings and cmd saved previously so that the engine can continue its usual processing
+============
+*/
+void Cmd_RestoreCmdContext( void )
+{
+	Com_Memcpy( &cmd, &savedCmd, sizeof( cmdContext_t ) );
+}
+
 /*
 ============
 Cmd_Argc

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -1077,7 +1077,7 @@ qboolean FS_IsDemoExt(const char *filename, int namelen)
 	int index, protocol;
 
 	ext_test = strrchr(filename, '.');
-	if(ext_test && !Q_stricmpn(ext_test + 1, DEMOEXT, ARRAY_LEN(DEMOEXT) - 1))
+	if(ext_test && (!Q_stricmpn(ext_test + 1, DEMOEXT, ARRAY_LEN(DEMOEXT) - 1) || !Q_stricmpn(ext_test + 1, SVDEMOEXT, ARRAY_LEN(SVDEMOEXT) - 1)) )
 	{
 		protocol = atoi(ext_test + ARRAY_LEN(DEMOEXT));
 

--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "q_shared.h"
 #include "qcommon.h"
 
+#include "../game/g_public.h" // FIXME: necessary for entityShared_t management to work (since we need the definitions...), which is a very necessary function for server-side demos recording. It would be better if this functionality would be separated in an _ext.c file, but I could not find a way to make it work (because it also needs the definitions in msg.c, and since it's not a header, these are being redefined when included, producing a lot of recursive declarations errors...)
+
 static huffman_t		msgHuff;
 
 static qboolean			msgInit = qfalse;
@@ -1052,6 +1054,224 @@ void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to,
 			endBit = ( msg->readcount - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
 		}
 		Com_Printf( " (%i bits)\n", endBit - startBit  );
+	}
+}
+
+
+/*
+============================================================================
+
+entityShared_t communication
+
+============================================================================
+*/
+
+// using the stringizing operator to save typing...
+#define	ESF(x) #x,(size_t)&((entityShared_t*)0)->x
+
+/*
+ * Return (v ? floor(log2(v)) : 0) when 0 <= v < 1<<[8, 16, 32, 64].
+ * Inefficient algorithm, intended for compile-time constants.
+ * Courtesy of Hallvard B Furuseth
+ */
+#define LOG2_8BIT(v)  (8 - 90/(((v)/4+14)|1) - 2/((v)/2+1))
+#define LOG2_16BIT(v) (8*((v)>255) + LOG2_8BIT((v) >>8*((v)>255)))
+#define LOG2_32BIT(v) \
+    (16*((v)>65535L) + LOG2_16BIT((v)*1L >>16*((v)>65535L)))
+#define LOG2_64BIT(v)\
+    (32*((v)/2L>>31 > 0) \
+     + LOG2_32BIT((v)*1L >>16*((v)/2L>>31 > 0) \
+                         >>16*((v)/2L>>31 > 0)))
+
+// Compute the number of clients bits at compile-time (this is necessary else the compiler will throw an error because this is not a constant)
+#define	CLIENTNUM_BITS	LOG2_8BIT(MAX_CLIENTS)
+
+netField_t	entitySharedFields[] =
+{
+{ ESF(linked), 1 },
+{ ESF(linkcount), 8 }, // enough to see whether the linkcount has changed
+                       // (assuming it doesn't change 256 times in 1 frame)
+{ ESF(bmodel), 1 },
+{ ESF(svFlags), 12 },
+{ ESF(singleClient), CLIENTNUM_BITS },
+{ ESF(contents), 32 },
+{ ESF(ownerNum), GENTITYNUM_BITS },
+{ ESF(mins[0]), 0 },
+{ ESF(mins[1]), 0 },
+{ ESF(mins[2]), 0 },
+{ ESF(maxs[0]), 0 },
+{ ESF(maxs[1]), 0 },
+{ ESF(maxs[2]), 0 },
+{ ESF(absmin[0]), 0 },
+{ ESF(absmin[1]), 0 },
+{ ESF(absmin[2]), 0 },
+{ ESF(absmax[0]), 0 },
+{ ESF(absmax[1]), 0 },
+{ ESF(absmax[2]), 0 },
+{ ESF(currentOrigin[0]), 0 },
+{ ESF(currentOrigin[1]), 0 },
+{ ESF(currentOrigin[2]), 0 },
+{ ESF(currentAngles[0]), 0 },
+{ ESF(currentAngles[1]), 0 },
+{ ESF(currentAngles[2]), 0 }
+};
+
+
+/*
+==================
+MSG_WriteDeltaSharedEntity
+==================
+*/
+void MSG_WriteDeltaSharedEntity( msg_t *msg, void *from, void *to,
+						   qboolean force, int number ) {
+	int			i, lc;
+	int			numFields;
+	netField_t	*field;
+	int			trunc;
+	float		fullFloat;
+	int			*fromF, *toF;
+
+	numFields = sizeof(entitySharedFields)/sizeof(entitySharedFields[0]);
+
+	// all fields should be 32 bits to avoid any compiler packing issues
+	// if this assert fails, someone added a field to the entityShared_t
+	// struct without updating the message fields
+	assert( numFields == (sizeof( entityShared_t )-sizeof( entityState_t ))/4 );
+
+	lc = 0;
+	// build the change vector as bytes so it is endien independent
+	for ( i = 0, field = entitySharedFields ; i < numFields ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		if ( *fromF != *toF ) {
+			lc = i+1;
+		}
+	}
+
+	if ( lc == 0 ) {
+		// nothing at all changed
+		if ( !force ) {
+			return;		// nothing at all
+		}
+		// write a bits for no change
+		MSG_WriteBits( msg, number, GENTITYNUM_BITS );
+		MSG_WriteBits( msg, 0, 1 );		// no delta
+		return;
+	}
+
+	MSG_WriteBits( msg, number, GENTITYNUM_BITS );
+	MSG_WriteBits( msg, 1, 1 );			// we have a delta
+
+	MSG_WriteByte( msg, lc );	// # of changes
+
+	oldsize += numFields;
+
+	for ( i = 0, field = entitySharedFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( *fromF == *toF ) {
+			MSG_WriteBits( msg, 0, 1 );	// no change
+			continue;
+		}
+
+		MSG_WriteBits( msg, 1, 1 );	// changed
+
+		if ( field->bits == 0 ) {
+			// float
+			fullFloat = *(float *)toF;
+			trunc = (int)fullFloat;
+
+			if (fullFloat == 0.0f) {
+					MSG_WriteBits( msg, 0, 1 );
+					oldsize += FLOAT_INT_BITS;
+			} else {
+				MSG_WriteBits( msg, 1, 1 );
+				if ( trunc == fullFloat && trunc + FLOAT_INT_BIAS >= 0 &&
+					trunc + FLOAT_INT_BIAS < ( 1 << FLOAT_INT_BITS ) ) {
+					// send as small integer
+					MSG_WriteBits( msg, 0, 1 );
+					MSG_WriteBits( msg, trunc + FLOAT_INT_BIAS, FLOAT_INT_BITS );
+				} else {
+					// send as full floating point value
+					MSG_WriteBits( msg, 1, 1 );
+					MSG_WriteBits( msg, *toF, 32 );
+				}
+			}
+		} else {
+			if (*toF == 0) {
+				MSG_WriteBits( msg, 0, 1 );
+			} else {
+				MSG_WriteBits( msg, 1, 1 );
+				// integer
+				MSG_WriteBits( msg, *toF, field->bits );
+			}
+		}
+	}
+}
+
+/*
+==================
+MSG_ReadDeltaSharedEntity
+==================
+*/
+void MSG_ReadDeltaSharedEntity( msg_t *msg, void *from, void *to,
+						 int number) {
+	int			i, lc;
+	int			numFields;
+	netField_t	*field;
+	int			*fromF, *toF;
+	int			trunc;
+
+	// check for no delta
+	if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+		*(entityShared_t*)to = *(entityShared_t*)from;
+		return;
+	}
+
+	numFields = sizeof(entitySharedFields)/sizeof(entitySharedFields[0]);
+	lc = MSG_ReadByte(msg);
+
+	for ( i = 0, field = entitySharedFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( ! MSG_ReadBits( msg, 1 ) ) {
+			// no change
+			*toF = *fromF;
+		} else {
+			if ( field->bits == 0 ) {
+				// float
+				if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+						*(float *)toF = 0.0f;
+				} else {
+					if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+						// integral float
+						trunc = MSG_ReadBits( msg, FLOAT_INT_BITS );
+						// bias to allow equal parts positive and negative
+						trunc -= FLOAT_INT_BIAS;
+						*(float *)toF = trunc;
+					} else {
+						// full floating point value
+						*toF = MSG_ReadBits( msg, 32 );
+					}
+				}
+			} else {
+				if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+					*toF = 0;
+				} else {
+					// integer
+					*toF = MSG_ReadBits( msg, field->bits );
+				}
+			}
+//			pcount[i]++;
+		}
+	}
+	for ( i = lc, field = &entitySharedFields[lc] ; i < numFields ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		// no change
+		*toF = *fromF;
 	}
 }
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -80,6 +80,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define MAX_MASTER_SERVERS      5	// number of supported master servers
 
 #define DEMOEXT	"dm_"			// standard demo extension
+#define SVDEMOEXT	"svdm_"		// server-side demo extension
 
 #ifdef _MSC_VER
 
@@ -1407,6 +1408,18 @@ typedef enum _flag_status {
 	FLAG_TAKEN_BLUE,	// One Flag CTF
 	FLAG_DROPPED
 } flagStatus_t;
+
+typedef enum {
+	DS_NONE,
+
+	DS_WAITINGPLAYBACK, // demo will play after map_restart)
+	DS_PLAYBACK, // a demo is playing
+	DS_WAITINGSTOP, // demo is stopped but we must move clients over their normal slots
+
+	DS_RECORDING, // a demo is being recorded
+
+	DS_NUM_DEMO_STATES
+} demoState_t;
 
 
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -103,6 +103,11 @@ void MSG_WriteDeltaEntity( msg_t *msg, struct entityState_s *from, struct entity
 void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, 
 						 int number );
 
+void MSG_WriteDeltaSharedEntity( msg_t *msg, void *from, void *to
+								   , qboolean force, int number );
+void MSG_ReadDeltaSharedEntity( msg_t *msg, void *from, void *to,
+								 int number );
+
 void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct playerState_s *to );
 void MSG_ReadDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct playerState_s *to );
 
@@ -470,6 +475,9 @@ void	Cmd_TokenizeStringIgnoreQuotes( const char *text_in );
 void	Cmd_ExecuteString( const char *text );
 // Parses a single line of text into arguments and tries to execute it
 // as if it was typed at the console
+
+void Cmd_SaveCmdContext( void );
+void Cmd_RestoreCmdContext( void );
 
 
 /*

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -93,6 +93,15 @@ typedef struct {
 
 	int				restartTime;
 	int				time;
+
+	// serverside demo recording
+	fileHandle_t		demoFile;
+	demoState_t	demoState;
+	char			demoName[MAX_QPATH];
+
+	// serverside demo recording - previous frame for delta compression
+	sharedEntity_t	demoEntities[MAX_GENTITIES];
+	playerState_t	demoPlayerStates[MAX_CLIENTS];
 } server_t;
 
 
@@ -199,6 +208,8 @@ typedef struct client_s {
 #ifdef LEGACY_PROTOCOL
 	qboolean		compat;
 #endif
+
+	qboolean            demoClient; // is this a demoClient?
 } client_t;
 
 //=============================================================================
@@ -269,6 +280,7 @@ extern	cvar_t	*sv_rconPassword;
 extern	cvar_t	*sv_privatePassword;
 extern	cvar_t	*sv_allowDownload;
 extern	cvar_t	*sv_maxclients;
+extern	cvar_t	*sv_democlients; // number of democlients: this should always be set to 0, and will be automatically adjusted when needed by the demo facility. ATTENTION: if sv_maxclients = sv_democlients then server will be full! sv_democlients consume clients slots even if there are no democlients recorded nor replaying for this slot!
 
 extern	cvar_t	*sv_privateClients;
 extern	cvar_t	*sv_hostname;
@@ -293,6 +305,11 @@ extern	cvar_t	*sv_lanForceRate;
 extern	cvar_t	*sv_strictAuth;
 #endif
 extern	cvar_t	*sv_banFile;
+
+extern	cvar_t	*sv_demoState;
+extern	cvar_t	*sv_autoDemo;
+extern	cvar_t	*cl_freezeDemo;
+extern	cvar_t	*sv_demoTolerant;
 
 extern	serverBan_t serverBans[SERVER_MAXBANS];
 extern	int serverBansCount;
@@ -376,6 +393,8 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd );
 void SV_FreeClient(client_t *client);
 void SV_DropClient( client_t *drop, const char *reason );
 
+void SV_UpdateUserinfo_f( client_t *cl );
+
 void SV_ExecuteClientCommand( client_t *cl, const char *s, qboolean clientOK );
 void SV_ClientThink (client_t *cl, usercmd_t *cmd);
 
@@ -411,6 +430,60 @@ void		SV_InitGameProgs ( void );
 void		SV_ShutdownGameProgs ( void );
 void		SV_RestartGameProgs( void );
 qboolean	SV_inPVS (const vec3_t p1, const vec3_t p2);
+void SV_GameSendServerCommand( int clientNum, const char *text );
+
+//
+// sv_demo.c
+//
+void SV_DemoStartRecord(void);
+void SV_DemoStopRecord(void);
+void SV_DemoStartPlayback(void);
+void SV_DemoStopPlayback(void);
+void SV_DemoAutoDemoRecord(void);
+void SV_DemoRestartPlayback(void);
+
+void SV_DemoReadFrame(void);
+void SV_DemoReadClientCommand( msg_t *msg );
+void SV_DemoReadServerCommand( msg_t *msg );
+void SV_DemoReadGameCommand( msg_t *msg );
+void SV_DemoReadConfigString( msg_t *msg );
+void SV_DemoReadClientConfigString( msg_t *msg );
+void SV_DemoReadClientUserinfo( msg_t *msg );
+//void SV_DemoReadClientUsercmd( msg_t *msg );
+void SV_DemoReadAllPlayerState( msg_t *msg );
+void SV_DemoReadAllEntityState( msg_t *msg );
+void SV_DemoReadAllEntityShared( msg_t *msg );
+void SV_DemoReadRefreshEntities( void );
+
+void SV_DemoWriteFrame(void);
+void SV_DemoWriteClientCommand( client_t *client, const char *cmd );
+void SV_DemoWriteServerCommand( const char *cmd );
+void SV_DemoWriteGameCommand( int clientNum, const char *cmd );
+void SV_DemoWriteConfigString( int cs_index, const char *cs_string );
+void SV_DemoWriteClientConfigString( int clientNum, const char *cs_string );
+void SV_DemoWriteClientUserinfo( client_t *client, const char *userinfo );
+//void SV_DemoWriteClientUsercmd( client_t *cl, qboolean delta, int cmdCount, usercmd_t *cmds, int key );
+void SV_DemoWriteAllPlayerState(void);
+void SV_DemoWriteAllEntityState(void);
+void SV_DemoWriteAllEntityShared(void);
+
+qboolean SV_CheckClientCommand( client_t *client, const char *cmd );
+qboolean SV_CheckServerCommand( const char *cmd );
+qboolean SV_CheckGameCommand( const char *cmd );
+qboolean SV_CheckConfigString( int cs_index, const char *cs_string );
+qboolean SV_CheckLastCmd( const char *cmd, qboolean onlyStore );
+void SV_DemoFilterClientUserinfo( const char *userinfo );
+char *SV_CleanFilename( char *string );
+char *SV_CleanStrCmd( char *string );
+char *SV_GenerateDateTime(void);
+
+//
+// sv_demo_ext.c
+//
+
+int SV_GentityGetHealthField( sharedEntity_t * gent );
+void SV_GentitySetHealthField( sharedEntity_t * gent, int value );
+void SV_GentityUpdateHealthField( sharedEntity_t * gent, playerState_t *player );
 
 //
 // sv_bot.c

--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -200,6 +200,12 @@ static void SV_Map_f( void ) {
 		}
 	}
 
+    // stop any demos
+	if (sv.demoState == DS_RECORDING)
+		SV_DemoStopRecord();
+	if (sv.demoState == DS_PLAYBACK)
+		SV_DemoStopPlayback();
+
 	// save the map name here cause on a map restart we reload the q3config.cfg
 	// and thus nuke the arguments of the map command
 	Q_strncpyz(mapname, map, sizeof(mapname));
@@ -272,6 +278,12 @@ static void SV_MapRestart_f( void ) {
 		SV_SpawnServer( mapname, qfalse );
 		return;
 	}
+
+	// stop any demos
+	if (sv.demoState == DS_RECORDING)
+		SV_DemoStopRecord();
+	if (sv.demoState == DS_PLAYBACK)
+		SV_DemoStopPlayback();
 
 	// toggle the server bit so clients can detect that a
 	// map_restart has happened
@@ -353,6 +365,11 @@ static void SV_MapRestart_f( void ) {
 	VM_Call (gvm, GAME_RUN_FRAME, sv.time);
 	sv.time += 100;
 	svs.time += 100;
+
+	// start recording a demo
+    if ( sv_autoDemo->integer ) {
+        SV_DemoAutoDemoRecord();
+    }
 }
 
 //===============================================================
@@ -1184,13 +1201,15 @@ static void SV_Status_f( void ) {
 	Com_Printf ("-- ----- ---- --------------- --------------------------------------- -----\n");
 	for (i=0,cl=svs.clients ; i < sv_maxclients->integer ; i++,cl++)
 	{
-		if (!cl->state)
+		if (!cl->state && !cl->demoClient)
 			continue;
 		Com_Printf ("%2i ", i);
 		ps = SV_GameClientNum( i );
 		Com_Printf ("%5i ", ps->persistant[PERS_SCORE]);
 
-		if (cl->state == CS_CONNECTED)
+		if (cl->demoClient) // if it's a democlient, we show DEMO instead of the ping (which would be 999 anyway - which is not the case in the scoreboard which show the real ping that had the player because commands are replayed!)
+			Com_Printf ("DEMO ");
+		else if (cl->state == CS_CONNECTED)
 			Com_Printf ("CON ");
 		else if (cl->state == CS_ZOMBIE)
 			Com_Printf ("ZMB ");
@@ -1459,6 +1478,131 @@ static void SV_KillServer_f( void ) {
 	SV_Shutdown( "killserver" );
 }
 
+
+/*
+=================
+SV_Demo_Record_f
+=================
+*/
+static void SV_Demo_Record_f( void ) {
+        // make sure server is running
+        if (!com_sv_running->integer) {
+                Com_Printf("Server is not running.\n");
+                return;
+        }
+
+        if (Cmd_Argc() > 2) {
+                Com_Printf("Usage: demo_record <demoname>\n");
+                return;
+        }
+
+        if (sv.demoState != DS_NONE) {
+                Com_Printf("A demo is already being recorded/played. Use demo_stop and retry.\n");
+                return;
+        }
+
+        if (sv_maxclients->integer == MAX_CLIENTS) {
+                Com_Printf("DEMO: ERROR: Too many client slots, reduce sv_maxclients and retry.\n");
+                return;
+        }
+
+        if (Cmd_Argc() == 2)
+                sprintf(sv.demoName, "svdemos/%s.%s%d", Cmd_Argv(1), SVDEMOEXT, PROTOCOL_VERSION);
+        else {
+                int     number;
+                // scan for a free demo name
+                for (number = 0 ; number >= 0 ; number++) {
+                        Com_sprintf(sv.demoName, sizeof(sv.demoName), "svdemos/%d.%s%d", number, SVDEMOEXT, PROTOCOL_VERSION);
+                        if (!FS_FileExists(sv.demoName))
+                                break;  // file doesn't exist
+                }
+                if (number < 0) {
+                        Com_Printf("DEMO: ERROR: Couldn't generate a filename for the demo, try deleting some old ones.\n");
+                        return;
+                }
+        }
+
+        sv.demoFile = FS_FOpenFileWrite(sv.demoName);
+        if (!sv.demoFile) {
+                Com_Printf("DEMO: ERROR: Couldn't open %s for writing.\n", sv.demoName);
+                return;
+        }
+        SV_DemoStartRecord();
+}
+
+
+/*
+=================
+SV_Demo_Play_f
+=================
+*/
+static void SV_Demo_Play_f( void ) {
+        char *arg;
+
+        if (Cmd_Argc() != 2) {
+                Com_Printf("Usage: demo_play <demoname>\n");
+                return;
+        }
+
+        if (sv.demoState != DS_NONE && sv.demoState != DS_WAITINGPLAYBACK) {
+                Com_Printf("A demo is already being recorded/played. Use demo_stop and retry.\n");
+                return;
+        }
+
+        // check for an extension .svdm_?? (?? is protocol)
+        arg = Cmd_Argv(1);
+        if (!strcmp(arg + strlen(arg) - 6, va(".%s%d", SVDEMOEXT, PROTOCOL_VERSION)))
+                Com_sprintf(sv.demoName, sizeof(sv.demoName), "svdemos/%s", arg);
+        else
+                Com_sprintf(sv.demoName, sizeof(sv.demoName), "svdemos/%s.%s%d", arg, SVDEMOEXT, PROTOCOL_VERSION);
+
+
+        //FS_FileExists(sv.demoName);
+	FS_FOpenFileRead(sv.demoName, &sv.demoFile, qtrue);
+        if (!sv.demoFile) {
+                Com_Printf("ERROR: Couldn't open %s for reading.\n", sv.demoName);
+                return;
+        }
+
+        SV_DemoStartPlayback();
+}
+
+
+/*
+=================
+SV_Demo_Stop_f
+=================
+*/
+static void SV_Demo_Stop_f( void ) {
+        if (sv.demoState == DS_NONE) {
+                Com_Printf("No demo is currently being recorded or played.\n");
+                return;
+        }
+
+        // Close the demo file
+        if (sv.demoState == DS_PLAYBACK || sv.demoState == DS_WAITINGPLAYBACK)
+                SV_DemoStopPlayback();
+        else
+                SV_DemoStopRecord();
+}
+
+
+/*
+====================
+SV_CompleteDemoName
+====================
+*/
+static void SV_CompleteDemoName( char *args, int argNum )
+{
+	if( argNum == 2 )
+	{
+		char demoExt[ 16 ];
+
+		Com_sprintf( demoExt, sizeof( demoExt ), ".%s%d", SVDEMOEXT, PROTOCOL_VERSION );
+		Field_CompleteFilename( "svdemos", demoExt, qtrue, qtrue );
+	}
+}
+
 //===========================================================
 
 /*
@@ -1566,6 +1710,11 @@ void SV_AddOperatorCommands( void ) {
 	Cmd_AddCommand("bandel", SV_BanDel_f);
 	Cmd_AddCommand("exceptdel", SV_ExceptDel_f);
 	Cmd_AddCommand("flushbans", SV_FlushBans_f);
+
+	Cmd_AddCommand ("demo_record", SV_Demo_Record_f);
+	Cmd_AddCommand ("demo_play", SV_Demo_Play_f);
+	Cmd_SetCommandCompletionFunc( "demo_play", SV_CompleteDemoName );
+	Cmd_AddCommand ("demo_stop", SV_Demo_Stop_f);
 }
 
 /*

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -489,10 +489,10 @@ void SV_DirectConnect( netadr_t from ) {
 	// check for privateClient password
 	password = Info_ValueForKey( userinfo, "password" );
 	if ( *password && !strcmp( password, sv_privatePassword->string ) ) {
-		startIndex = 0;
+		startIndex = sv_democlients->integer;
 	} else {
 		// skip past the reserved slots
-		startIndex = sv_privateClients->integer;
+		startIndex = sv_privateClients->integer + sv_democlients->integer;
 	}
 
 	newcl = NULL;
@@ -644,7 +644,7 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 		return;		// already dropped
 	}
 
-	if ( !isBot ) {
+	if ( !isBot && !drop->demoClient ) { // Don't drop bots nor democlients (will make the server crash since there's no network connection to manage with these clients!)
 		// see if we already have a challenge for this ip
 		challenge = &svs.challenges[0];
 
@@ -681,7 +681,7 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 	if ( isBot ) {
 		// bots shouldn't go zombie, as there's no real net connection.
 		drop->state = CS_FREE;
-	} else {
+	} else { // democlients and real clients should go through CS_ZOMBIE before CS_FREE
 		Com_DPrintf( "Going to CS_ZOMBIE for %s\n", drop->name );
 		drop->state = CS_ZOMBIE;		// become free in a few seconds
 	}
@@ -691,7 +691,7 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 	// send a heartbeat now so the master will get up to date info
 	// if there is already a slot for this ip, reuse it
 	for (i=0 ; i < sv_maxclients->integer ; i++ ) {
-		if ( svs.clients[i].state >= CS_CONNECTED ) {
+		if ( svs.clients[i].state >= CS_CONNECTED && !svs.clients[i].demoClient ) { // we check real players slots: if real players slots are all empty (not counting democlients), we send an heartbeat to update
 			break;
 		}
 	}
@@ -787,6 +787,12 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 
 	Com_DPrintf( "Going from CS_PRIMED to CS_ACTIVE for %s\n", client->name );
 	client->state = CS_ACTIVE;
+
+	// server-side demo playback: prevent players from joining the game when a demo is replaying (particularly if the gametype is non-team based, by default the gamecode force players to join in)
+	if (sv.demoState == DS_PLAYBACK &&
+	    ( (client - svs.clients) >= sv_democlients->integer ) && ( (client - svs.clients) < sv_maxclients->integer ) ) { // check that it's a real player
+		SV_ExecuteClientCommand(client, "team spectator", qtrue);
+	}
 
 	// resend all configstrings using the cs commands since these are
 	// no longer sent when the client is CS_PRIMED
@@ -1491,7 +1497,13 @@ void SV_UserinfoChanged( client_t *cl ) {
 SV_UpdateUserinfo_f
 ==================
 */
-static void SV_UpdateUserinfo_f( client_t *cl ) {
+void SV_UpdateUserinfo_f( client_t *cl ) {
+
+	// Save userinfo changes to demo (also in SV_SetUserinfo() in sv_init.c)
+	if ( sv.demoState == DS_RECORDING ) {
+		SV_DemoWriteClientUserinfo( cl, Cmd_Argv(1) );
+	}
+
 	Q_strncpyz( cl->userinfo, Cmd_Argv(1), sizeof(cl->userinfo) );
 
 	SV_UserinfoChanged( cl );
@@ -1578,8 +1590,18 @@ void SV_ExecuteClientCommand( client_t *cl, const char *s, qboolean clientOK ) {
 
 	if (clientOK) {
 		// pass unknown strings to the game
-		if (!u->name && sv.state == SS_GAME && (cl->state == CS_ACTIVE || cl->state == CS_PRIMED)) {
-			Cmd_Args_Sanitize();
+		if (!u->name && sv.state == SS_GAME && (cl->state == CS_ACTIVE || cl->state == CS_PRIMED || cl->demoClient)) { // accept democlients, else you won't be able to make democlients join teams nor say messages!
+			if ( sv.demoState == DS_RECORDING ) { // if demo is recording, we store this command and clientid
+				SV_DemoWriteClientCommand( cl, s );
+			} else if ( sv.demoState == DS_PLAYBACK &&
+				   ( (cl - svs.clients) >= sv_democlients->integer ) && ( (cl - svs.clients) < sv_maxclients->integer ) && // preventing only real clients commands (not democlients commands replayed)
+				   ( !Q_stricmp(Cmd_Argv(0), "team") && Q_stricmp(Cmd_Argv(1), "s") && Q_stricmp(Cmd_Argv(1), "spectator") ) ) { // if there is a demo playback, we prevent any real client from doing a team change, if so, we issue a chat messsage (except if the player join team spectator again)
+				SV_SendServerCommand(cl, "chat \"^3Can't join a team when a demo is replaying!\""); // issue a chat message only to the player trying to join a team
+				SV_SendServerCommand(cl, "cp \"^3Can't join a team when a demo is replaying!\""); // issue a chat message only to the player trying to join a team
+				return;
+			}
+			if(strcmp(Cmd_Argv(0), "say") && strcmp(Cmd_Argv(0), "say_team") )
+				Cmd_Args_Sanitize(); //remove \n, \r and ; from string. We don't do that for say-commands because it makes people mad (understandebly)
 			VM_Call( gvm, GAME_CLIENT_COMMAND, cl - svs.clients );
 		}
 	}
@@ -1714,6 +1736,12 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 		MSG_ReadDeltaUsercmdKey( msg, key, oldcmd, cmd );
 		oldcmd = cmd;
 	}
+
+	// save the data to the server-side demo if recording
+	/*
+	if (sv.demoState == DS_RECORDING)
+			SV_DemoWriteClientUsercmd(cl, delta, cmdCount, cmds, key);
+	*/
 
 	// save time for ping calculation
 	cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = svs.time;

--- a/code/server/sv_demo.c
+++ b/code/server/sv_demo.c
@@ -1,16 +1,16 @@
 /*
 ===========================================================================
 Copyright (C) 2008 Amanieu d'Antras
-Copyright (C) 2012 Stephen Larroque <lrq3000@gmail.com>
+Copyright (C) 2012-2017 Stephen Larroque <lrq3000@gmail.com>
 
-This file is part of OpenArena.
+This file is part of ioquake3.
 
-OpenArena is free software; you can redistribute it
+ioquake3 is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-OpenArena is distributed in the hope that it will be
+ioquake3 is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
@@ -957,13 +957,33 @@ void SV_DemoReadAllEntityState( msg_t *msg )
 	sharedEntity_t *entity;
 	int num;
 
+    // For each state in this message (because we store a concatenation of all entities states in a single message, we could do otherwise, but that's the design)
 	while (1)
 	{
+        // Get entity num
 		num = MSG_ReadBits(msg, GENTITYNUM_BITS);
+        // Reached the end of the message, stop here
 		if (num == ENTITYNUM_NONE)
 			break;
+        // Create a blank entity
 		entity = SV_GentityNum(num);
+        // Interpolate the new entity state from previous state in sv.demoEntities
 		MSG_ReadDeltaEntity(msg, &sv.demoEntities[num].s, &entity->s, num);
+
+        // Fix mover movements, (avoid the "bad moverstate" error)
+        if (entity->s.eType == ET_MOVER) {
+            // 1st way to fix: completely disable movers (but not their displacement effects, so they will be invisible, but players are still moved by movers)
+            //entity->s.eType = ET_GENERAL;
+
+            // 2nd way to fix (better): only binarymovers are producing the bug, because the game will be confused about the moverState since we cannot have access nor set it...
+            // the solution: avoid changing the moverState, only change the position. To do this, avoid calls to ent->reached, so in other words never allow s.pot.trType to be TR_LINEAR_STOP (other types of movers are not affected since they don't have a stop/reached state, they are just looping over and over)
+            if (entity->s.pos.trType == TR_LINEAR_STOP) { // mover reached end of movement? change it...
+                entity->s.pos.trType = TR_LINEAR;  // ... to always set movers in a moving linear state.
+                //entity->s.apos.trType = TR_LINEAR; // should apos be also set?
+            }
+        }
+
+        // Save new entity state (in sv.demoEntities, which in other words display the new state)
 		sv.demoEntities[num].s = entity->s;
 	}
 }
@@ -980,12 +1000,16 @@ void SV_DemoReadAllEntityShared( msg_t *msg )
 	sharedEntity_t *entity;
 	int num;
 
-	while (1)
+	while (1) // loop until we read the whole message (which is storing several states)
 	{
+        // Get entity num
 		num = MSG_ReadBits(msg, GENTITYNUM_BITS);
+        // Reached end of message, stop here
 		if (num == ENTITYNUM_NONE)
 			break;
+        // Load an empty entity
 		entity = SV_GentityNum(num);
+        // Interpolate the new entity state from previous state in sv.demoEntities
 		MSG_ReadDeltaSharedEntity(msg, &sv.demoEntities[num].r, &entity->r, num);
 
 		entity->r.svFlags &= ~SVF_BOT; // fix bots camera freezing issues - because since now the engine will consider these democlients just as normal players, it won't be using anymore special bots fields and instead just use the standard viewangles field to replay the camera movements
@@ -997,6 +1021,7 @@ void SV_DemoReadAllEntityShared( msg_t *msg )
 		else if (!entity->r.linked && sv.demoEntities[num].r.linked)
 			SV_UnlinkEntity(entity);
 
+        // Save the new state in sv.demoEntities (ie, display current entity state)
 		sv.demoEntities[num].r = entity->r;
 		if (num > sv.num_entities)
 			sv.num_entities = num;

--- a/code/server/sv_demo.c
+++ b/code/server/sv_demo.c
@@ -1,0 +1,1755 @@
+/*
+===========================================================================
+Copyright (C) 2008 Amanieu d'Antras
+Copyright (C) 2012 Stephen Larroque <lrq3000@gmail.com>
+
+This file is part of OpenArena.
+
+OpenArena is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenArena is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Tremulous; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+// sv_demo.c -- Server side demo recording
+
+#include "server.h"
+
+#define Q_IsColorStringGameCommand(p)      ((p) && *(p) == Q_COLOR_ESCAPE && *((p)+1)) // ^[anychar]
+
+#define CEIL(VARIABLE) ( (VARIABLE - (int)VARIABLE)==0 ? (int)VARIABLE : (int)VARIABLE+1 ) // UNUSED but can be useful
+
+/***********************************************
+ * VARIABLES
+ *
+ ***********************************************/
+
+// Headers/markers for demo messages (events)
+typedef enum {
+	demo_endDemo, // end of demo (close the demo)
+	demo_EOF, // end of file/flux (end of event, separator, notify the demo parser to iterate to the next event of the _same_ frame)
+	demo_endFrame, // player and gentity state marker (recorded each end of frame, hence the name) - at the same time marks the end of the demo frame
+
+	demo_configString, // config string setting event
+	demo_clientConfigString, // client config string setting event
+	demo_clientCommand, // client command event
+	demo_serverCommand, // server command event
+	demo_gameCommand, // game command event
+	demo_clientUserinfo, // client userinfo event (client_t management)
+	demo_entityState, // gentity_t->entityState_t management
+	demo_entityShared, // gentity_t->entityShared_t management
+	demo_playerState, // players game state event (playerState_t management)
+
+	//demo_clientUsercmd, // players commands/movements packets (usercmd_t management)
+} demo_ops_e;
+
+/*** STATIC VARIABLES ***/
+// We set them as static so that they are global only for this file, this limit a bit the side-effect
+
+// Big fat buffer to store all our stuff
+static byte buf[0x400000];
+
+// Save maxclients and democlients and restore them after the demo
+static int savedMaxClients = -1;
+static int savedBotMinPlayers = -1;
+static int savedFPS = -1;
+static int savedGametype = -1;
+
+static int savedDoWarmup = -1;
+static int savedAllowVote = -1;
+static int savedTeamAutoJoin = -1;
+
+static int savedTimelimit = -1;
+static int savedFraglimit = -1;
+static int savedCapturelimit = -1;
+
+static char savedFsGameVal[MAX_QPATH] = "";
+static char *savedFsGame = savedFsGameVal;
+
+static char savedPlaybackDemonameVal[MAX_QPATH] = "";
+static char *savedPlaybackDemoname = savedPlaybackDemonameVal;
+
+static qboolean keepSaved = qfalse; // var that memorizes if we keep the new maxclients and democlients values (in the case that we restart the map/server for these cvars to be affected since they are latched, we need to stop the playback meanwhile we restart, and using this var we can know if the stop is a restart procedure or a real demo end) or if we can restore them (at the end of the demo)
+
+static int demoTeamAutoJoin = -1; // load the g_teamAutoJoin value from the demo recording
+
+
+/***********************************************
+ * AUXILIARY FUNCTIONS: CHECKING, FILTERING AND CLEANING
+ *
+ * Functions used to either trim unnecessary or privacy concerned data, or to just check if the data should be written in the demo, relayed to a more specialized function or just dropped.
+ ***********************************************/
+
+/*
+====================
+SV_CheckClientCommand
+
+Check that the clientCommand is OK (if not we either continue with a more specialized function, or drop it altogether if there's a privacy concern)
+====================
+*/
+qboolean SV_CheckClientCommand( client_t *client, const char *cmd )
+{
+	if ( strlen(cmd) > 9 && !Q_strncmp(cmd, "userinfo", 8) ) { // If that's a userinfo command, we directly handle that with a specialized function (and we check that it contains at least 10 characters so that when we copy the string we don't end up copying a random address in memory)
+		char	*userinfo = malloc( MAX_INFO_STRING * sizeof *userinfo);
+		Q_strncpyz(userinfo, cmd+9, MAX_INFO_STRING); // trimming out the "userinfo " substring (because we only need the userinfo string)
+		SV_DemoWriteClientUserinfo(client, (const char*)userinfo); // passing relay to the specialized function for this job
+		free( userinfo );
+
+		return qfalse; // we return false if the check wasn't right (meaning that this function does not need to process anything)
+	} else if( !Q_strncmp(cmd, "tell", 4) || !Q_strncmp(cmd, "say_team", 8) ) { // Privacy check: if the command is tell or say_team, we just drop it
+		return qfalse;
+	}
+	return qtrue; // else, the check is OK and we continue to process with the original function
+}
+
+/*
+====================
+SV_CheckServerCommand
+
+Check that the serverCommand is OK to save (or if we drop it because already handled somewhere else)
+====================
+*/
+qboolean SV_CheckServerCommand( const char *cmd )
+{
+	if ( !Q_strncmp(cmd, "print", 5) || !Q_strncmp(cmd, "cp", 2) || !Q_strncmp(cmd, "disconnect", 10) ) { // If that's a print/cp command, it's already handled by gameCommand (here it's a redundancy). FIXME? possibly some print/cp are not handled by gameCommand? From my tests it was ok, but if someday a few prints are missing, try to delete this check... For security, we also drop disconnect (even if it should not be recorded anyway in the first place), because server commands will be sent to every connected clients, and so it will disconnect everyone.
+		return qfalse; // we return false if the check wasn't right
+	}
+	return qtrue; // else, the check is OK and we continue to process with the original function
+}
+
+/*
+====================
+SV_CheckLastCmd
+
+Check and store the last command and compare it with the current one, to avoid duplicates.
+If onlyStore is true, it will only store the new cmd, without checking.
+====================
+*/
+qboolean SV_CheckLastCmd( const char *cmd, qboolean onlyStore )
+{
+	static char prevcmddata[MAX_STRING_CHARS];
+	static char *prevcmd = prevcmddata;
+    char *cleanedprevcmd = malloc ( MAX_STRING_CHARS * sizeof * cleanedprevcmd );
+    char *cleanedcmd = malloc ( MAX_STRING_CHARS * sizeof * cleanedcmd );
+
+	Q_strncpyz(cleanedprevcmd, SV_CleanStrCmd(va("%s", (char *)prevcmd)), MAX_STRING_CHARS);
+	Q_strncpyz(cleanedcmd, SV_CleanStrCmd(va("%s", (char *)cmd)), MAX_STRING_CHARS);
+
+	if ( !onlyStore && // if we only want to store, we skip any checking
+	    strlen(prevcmd) > 0 && !Q_stricmp(cleanedprevcmd, cleanedcmd) ) { // check that the previous cmd was different from the current cmd.
+	    // Clean the vars before exiting the func
+	    free(cleanedprevcmd);
+	    free(cleanedcmd);
+		return qfalse; // drop this command, it's a repetition of the previous one
+	} else {
+		Q_strncpyz(prevcmd, cmd, MAX_STRING_CHARS); // memorize the current cmd for the next check (clean the cmd before, because sometimes the same string is issued by the engine with some empty colors?)
+	    // Clean the vars before exiting the func
+	    free(cleanedprevcmd);
+	    free(cleanedcmd);
+		return qtrue;
+	}
+}
+
+/*
+====================
+SV_CheckGameCommand
+
+Check that the gameCommand is OK and that we can save it (or if we drop it for privacy concerns and/or because it's handled somewhere else already)
+====================
+*/
+qboolean SV_CheckGameCommand( const char *cmd )
+{
+	if ( !SV_CheckLastCmd( cmd, qfalse ) ) { // check that the previous cmd was different from the current cmd. The engine may send the same command to every client by their cid (one command per client) instead of just sending one command to all using NULL or -1.
+		return qfalse; // drop this command, it's a repetition of the previous one
+	} else {
+		if ( !Q_strncmp(cmd, "chat", 4) || !Q_strncmp(cmd, "tchat", 5) ) { // we filter out the chat and tchat commands which are recorded and handled directly by clientCommand (which is easier to manage because it makes a difference between say, say_team and tell, which we don't have here in gamecommands: we either have chat(for say and tell) or tchat (for say_team) and the other difference is that chat/tchat messages directly contain the name of the player, while clientCommand only contains the clientid, so that it itself fetch the name from client->name
+			return qfalse; // we return false if the check wasn't right
+		} else if ( !Q_strncmp(cmd, "cs", 2) ) { // if it's a configstring command, we handle that with the specialized function
+			Cmd_SaveCmdContext();
+			Cmd_TokenizeString(cmd);
+			SV_DemoWriteConfigString(atoi(Cmd_Argv(1)), Cmd_Argv(2)); // relay to the specialized write configstring function
+			Cmd_RestoreCmdContext();
+			return qfalse; // drop it with the processing of the game command
+		}
+		return qtrue; // else, the check is OK and we continue to process with the original function
+	}
+}
+
+/*
+====================
+SV_CheckConfigString
+
+Check that the configstring is OK (or if we relay to ClientConfigString)
+====================
+*/
+qboolean SV_CheckConfigString( int cs_index, const char *cs_string )
+{
+	if ( cs_index >= CS_PLAYERS && cs_index < CS_PLAYERS + sv_maxclients->integer ) { // if this is a player, we save the configstring as a clientconfigstring
+		SV_DemoWriteClientConfigString( cs_index - CS_PLAYERS, cs_string );
+		return qfalse; // we return false if the check wasn't right (meaning that we stop the normal configstring processing since the clientconfigstring function will handle that)
+	} else if ( cs_index < CS_MOTD ) { // if the configstring index is below 4 (the motd), we don't save it (these are systems configstrings and will make an infinite loop for real clients at connection when the demo is played back, their management must be left to the system even at replaying)
+		return qfalse; // just drop this configstring
+	}
+	return qtrue; // else, the check is OK and we continue to process to save it as a normal configstring (for capture scores CS_SCORES1/2, for CS_FLAGSTATUS, etc..)
+}
+
+/*
+====================
+SV_DemoFilterClientUserinfo
+
+Filters privacy keys from a client userinfo to later write in a demo file
+====================
+*/
+void SV_DemoFilterClientUserinfo( const char *userinfo )
+{
+	char *buf;
+
+	buf = (char *)userinfo;
+	Info_RemoveKey(buf, "cl_guid");
+	Info_RemoveKey(buf, "ip");
+	Info_SetValueForKey(buf, "cl_voip", "0");
+
+	userinfo = (const char*)buf;
+}
+
+/*
+====================
+SV_CleanFilename
+
+Attempts to clean invalid characters from a filename that may prevent the demo to be stored on the filesystem
+====================
+*/
+char *SV_CleanFilename( char *string ) {
+	char*	d;
+	char*	s;
+	int		c;
+
+	s = string;
+	d = string;
+	while ((c = *s) != 0 ) {
+		if ( Q_IsColorString( s ) ) {
+			s++; // skip if it's a color
+		}
+		else if ( c == 0x2D || c == 0x2E || c == 0x5F || // - . _
+			 (c >= 0x30 && c <= 0x39) || // numbers
+			 (c >= 0x41 && c <= 0x5A) || // uppercase letters
+			 (c >= 0x61 && c <= 0x7A) // lowercase letters
+			 ) {
+			*d++ = c; // keep if this character is not forbidden (contained inside the above whitelist)
+		}
+		s++; // go to next character
+	}
+	*d = '\0';
+
+	return string;
+}
+
+/*
+====================
+SV_CleanStrCmd
+
+Same as Q_CleanStr but also remove any ^s or special empty color created by the engine in a gamecommand.
+====================
+*/
+char *SV_CleanStrCmd( char *string ) {
+	char*	d;
+	char*	s;
+	int		c;
+
+	s = string;
+	d = string;
+	while ((c = *s) != 0 ) {
+		if ( Q_IsColorStringGameCommand( s ) ) {
+			s++;
+		}
+		else if ( c >= 0x20 && c <= 0x7E ) {
+			*d++ = c;
+		}
+		s++;
+	}
+	*d = '\0';
+
+	return string;
+}
+
+/*
+====================
+SV_GenerateDateTime
+
+Generate a full datetime (local and utc) from now
+====================
+*/
+char *SV_GenerateDateTime(void)
+{
+	// Current local time
+	qtime_t now;
+	Com_RealTime( &now );
+
+	// UTC time
+	time_t  utcnow = time(NULL);
+	struct tm tnow = *gmtime(&utcnow);
+	char    buff[1024];
+
+	strftime( buff, sizeof buff, "timezone %Z (UTC timezone: %Y-%m-%d %H:%M:%S W%W)", &tnow );
+
+	// Return local time and utc time
+	return va( "%04d-%02d-%02d %02d:%02d:%02d %s",
+				1900 + now.tm_year,
+				1 + now.tm_mon,
+				now.tm_mday,
+				now.tm_hour,
+				now.tm_min,
+				now.tm_sec,
+				buff);
+}
+
+
+/***********************************************
+ * DEMO WRITING FUNCTIONS
+ *
+ * Functions used to construct and write demo events
+ ***********************************************/
+
+/*
+====================
+SV_DemoWriteMessage
+
+Write a message/event to the demo file
+====================
+*/
+static void SV_DemoWriteMessage(msg_t *msg)
+{
+	int len;
+
+	// Write the entire message to the file, prefixed by the length
+	MSG_WriteByte(msg, demo_EOF); // append EOF (end-of-file or rather end-of-flux) to the message so that it will tell the demo parser when the demo will be read that the message ends here, and that it can proceed to the next message
+	len = LittleLong(msg->cursize);
+	FS_Write(&len, 4, sv.demoFile);
+	FS_Write(msg->data, msg->cursize, sv.demoFile);
+	MSG_Clear(msg);
+}
+
+/*
+====================
+SV_DemoWriteClientCommand
+
+Write a client command to the demo file
+====================
+*/
+void SV_DemoWriteClientCommand( client_t *client, const char *cmd )
+{
+	msg_t msg;
+
+	if ( !SV_CheckClientCommand(client, cmd) ) { // check that this function really needs to store the command (or if another more specialized function should do it instead, eg: userinfo)
+		return;
+	}
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_clientCommand);
+	MSG_WriteByte(&msg, client - svs.clients);
+	MSG_WriteString(&msg, cmd);
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteServerCommand
+
+Write a server command to the demo file
+Note: we record only server commands that are meant to be sent to everyone in the first place, that's why we don't even bother to store the clientnum. For commands that were only intended to specifically one player, we only record them if they were game commands (see below the specialized function), else we do not because it may be unsafe (such as "disconnect" command)
+====================
+*/
+void SV_DemoWriteServerCommand( const char *cmd )
+{
+	msg_t msg;
+
+	if ( !SV_CheckServerCommand( cmd ) ) { // check that this function really needs to store the command
+		return;
+	}
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_serverCommand);
+	MSG_WriteString(&msg, cmd);
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteGameCommand
+
+Write a game command to the demo file
+Note: game commands are sent to server commands, but we record them separately because game commands are safe to be replayed to everyone (even if at recording time it was only intended to one player), while server commands may be unsafe if it was dedicated only to one player (such as "disconnect")
+====================
+*/
+void SV_DemoWriteGameCommand( int clientNum, const char *cmd )
+{
+	msg_t msg;
+
+	if ( !SV_CheckGameCommand( cmd ) ) { // check that this function really needs to store the command
+		return;
+	}
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_gameCommand);
+	MSG_WriteByte(&msg, clientNum);
+	MSG_WriteString(&msg, cmd);
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteConfigString
+
+Write a configstring to the demo file
+cs_index = index of the configstring (see bg_public.h)
+cs_string = content of the configstring to set
+====================
+*/
+void SV_DemoWriteConfigString( int cs_index, const char *cs_string )
+{
+	msg_t msg;
+	char cindex[MAX_CONFIGSTRINGS];
+
+	if ( !SV_CheckConfigString( cs_index, cs_string ) ) { // check that this function really needs to store the configstring (or if it's a client configstring we relay to the specialized function)
+		return;
+	} // else we save it below as a normal configstring (for capture scores CS_SCORES1/2, for CS_FLAGSTATUS, etc..)
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_configString);
+	sprintf(cindex, "%i", cs_index); // convert index to a string since we don't have any other way to store values that are greater than a byte (and max_configstrings is 1024 currently) - FIXME: try to replace by a WriteLong instead of WriteString? Or WriteData (with length! and it uses WriteByte)
+	MSG_WriteString(&msg, (const char*)cindex);
+	MSG_WriteString(&msg, cs_string);
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteClientConfigString
+
+Write a client configstring to the demo file
+Note: this is a bit redundant with SV_DemoWriteUserinfo, because clientCommand userinfo sets the new userinfo for a democlient, and clients configstrings are always derived from userinfo string. But this function is left for security purpose (so we make sure the configstring is set right).
+====================
+*/
+void SV_DemoWriteClientConfigString( int clientNum, const char *cs_string )
+{
+	msg_t msg;
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_clientConfigString);
+	MSG_WriteByte(&msg, clientNum);
+	MSG_WriteString(&msg, cs_string);
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteClientUserinfo
+
+Write a client userinfo to the demo file (client_t fields can almost all be filled from the userinfo string)
+Note: in practice, clients userinfo should be loaded before their configstrings (because configstrings derive from userinfo in a real game)
+====================
+*/
+void SV_DemoWriteClientUserinfo( client_t *client, const char *userinfo )
+{
+	msg_t msg;
+	static char fuserinfodata[MAX_STRING_CHARS];
+	static char *fuserinfo = fuserinfodata;
+
+	Q_strncpyz(fuserinfo, userinfo, sizeof(fuserinfodata)); // copy the client's userinfo to another storage var, so that we don't modify the client's userinfo (else the filtering will clean its infos such as cl_guid and ip, and next map change the client will be disconnected because of a wrong guid/ip!)
+
+	if (strlen(userinfo) > 0) { // do the filtering only if the string is not empty
+		SV_DemoFilterClientUserinfo( fuserinfo ); // filters out privacy keys such as ip, cl_guid, cl_voip
+	}
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_clientUserinfo); // write the event marker
+	MSG_WriteByte(&msg, client - svs.clients); // write the client number (client_t - svs.clients = client num int)
+	MSG_WriteString(&msg, fuserinfo); // write the (filtered) userinfo string
+	SV_DemoWriteMessage(&msg); // commit this demo event in the demo file
+}
+
+/*
+====================
+SV_DemoWriteClientUsercmd
+
+Write a client usercmd_t for the current packet (called from sv_client.c SV_UserMove) which contains the movements commands for the player
+Note: this is unnecessary to make players move, this is handled by entities management. This is only used to add more data to the dama for data analysis AND avoid inactivity timer activation
+Note2: enabling this feature will use a LOT more storage space, so enable it only if you will really use it. Generally, you're probably better off leaving it disabled.
+====================
+*/
+/*
+void SV_DemoWriteClientUsercmd( client_t *cl, qboolean delta, int cmdCount, usercmd_t *cmds, int key )
+{
+	msg_t msg;
+	usercmd_t nullcmd;
+	usercmd_t *cmd, *oldcmd;
+	int i;
+
+	//Com_Printf("DebugGBOWriteusercmd: %i\n", cl - svs.clients);
+
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_clientUsercmd);
+	MSG_WriteByte(&msg, cl - svs.clients);
+	if (delta)
+		MSG_WriteByte(&msg, 1);
+	else
+		MSG_WriteByte(&msg, 0);
+	MSG_WriteByte(&msg, cmdCount);
+
+	Com_Memset( &nullcmd, 0, sizeof(nullcmd) );
+	oldcmd = &nullcmd;
+	for ( i = 0 ; i < cmdCount ; i++ ) {
+		cmd = &cmds[i];
+		MSG_WriteDeltaUsercmdKey( &msg, key, oldcmd, cmd );
+		oldcmd = cmd;
+	}
+	SV_DemoWriteMessage(&msg);
+}
+*/
+
+/*
+====================
+SV_DemoWriteAllEntityShared
+
+Write all active clients playerState (playerState_t)
+Note: this is called at every game's endFrame.
+Note2: Contrary to the other DemoWrite functions, this one writes all entities at once in one message, instead of one entity/command per message.
+====================
+*/
+void SV_DemoWriteAllPlayerState(void)
+{
+	msg_t msg;
+	playerState_t *player;
+	int i;
+
+	// Initiliaze msg
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Write clients playerState (playerState_t)
+	for (i = 0; i < sv_maxclients->integer; i++)
+	{
+		if (svs.clients[i].state < CS_ACTIVE)
+			continue;
+		player = SV_GameClientNum(i);
+		MSG_WriteByte(&msg, demo_playerState);
+		MSG_WriteByte(&msg, i);
+		MSG_WriteDeltaPlayerstate(&msg, &sv.demoPlayerStates[i], player);
+		sv.demoPlayerStates[i] = *player;
+	}
+
+	// Commit all these datas to the demo file
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteAllEntityState
+
+Write all entities state (gentity_t->entityState_t)
+Note: this is called at every game's endFrame.
+Note2: Contrary to the other DemoWrite functions, this one writes all entities at once in one message, instead of one entity/command per message. This could be easily changed, but I'm not sure it would be beneficial for the CPU time and demo storage.
+====================
+*/
+void SV_DemoWriteAllEntityState(void)
+{
+	msg_t msg;
+	sharedEntity_t *entity;
+	int i;
+
+	// Initiliaze msg
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Write entities (gentity_t->entityState_t or concretely sv.gentities[num].s, in gamecode level. instead of sv.)
+	MSG_WriteByte(&msg, demo_entityState);
+	for (i = 0; i < sv.num_entities; i++)
+	{
+		if (i >= sv_maxclients->integer && i < MAX_CLIENTS)
+			continue;
+		entity = SV_GentityNum(i);
+		entity->s.number = i;
+		MSG_WriteDeltaEntity(&msg, &sv.demoEntities[i].s, &entity->s, qfalse);
+		sv.demoEntities[i].s = entity->s;
+	}
+	MSG_WriteBits(&msg, ENTITYNUM_NONE, GENTITYNUM_BITS); // End marker/Condition to break: since we don't know prior how many entities we store, when reading  the demo we will use an empty entity to break from our while loop
+
+	// Commit all these datas to the demo file
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteAllEntityShared
+
+Write all entities (gentity_t->entityShared_t)
+Note: this is called at every game's endFrame.
+Note2: Contrary to the other DemoWrite functions, this one writes all entities at once in one message, instead of one entity/command per message.
+====================
+*/
+void SV_DemoWriteAllEntityShared(void)
+{
+	msg_t msg;
+	sharedEntity_t *entity;
+	int i;
+
+	// Initiliaze msg
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Write entities (gentity_t->entityShared_t or concretely sv.gentities[num].r, in gamecode level. instead of sv.)
+	MSG_WriteByte(&msg, demo_entityShared);
+	for (i = 0; i < sv.num_entities; i++)
+	{
+		if (i >= sv_maxclients->integer && i < MAX_CLIENTS)
+			continue;
+		entity = SV_GentityNum(i);
+		MSG_WriteDeltaSharedEntity(&msg, &sv.demoEntities[i].r, &entity->r, qfalse, i);
+		sv.demoEntities[i].r = entity->r;
+	}
+	MSG_WriteBits(&msg, ENTITYNUM_NONE, GENTITYNUM_BITS); // End marker/Condition to break: since we don't know prior how many entities we store, when reading  the demo we will use an empty entity to break from our while loop
+
+	// Commit all these datas to the demo file
+	SV_DemoWriteMessage(&msg);
+}
+
+/*
+====================
+SV_DemoWriteFrame
+
+Record all the entities (gentities fields) and players (player_t fields) at the end of every frame (this is the only write function to be called in every frame for sure)
+Will be called once per server's frame
+Called in the main server's loop SV_Frame() in sv_main.c
+Note that this function could be called DemoWriteEndFrame, because it writes once at the end of every frame (the other events are written whenever they happen using hooks)
+====================
+*/
+void SV_DemoWriteFrame(void)
+{
+	msg_t msg;
+
+	// STEP1: write all entities states at the end of the frame
+
+	// Write entities (gentity_t->entityState_t or concretely sv.gentities[num].s, in gamecode level. instead of sv.)
+	SV_DemoWriteAllEntityState();
+
+	// Write entities (gentity_t->entityShared_t or concretely sv.gentities[num].r, in gamecode level. instead of sv.)
+	SV_DemoWriteAllEntityShared();
+
+	// Write clients playerState (playerState_t)
+	SV_DemoWriteAllPlayerState();
+
+	//-----------------------------------------------------
+
+	// STEP2: write the endFrame marker and server time
+
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Write end of frame marker: this will commit every demo entity change (and it's done at the very end of every server frame to overwrite any change the gamecode/engine may have done)
+	MSG_WriteByte(&msg, demo_endFrame);
+
+	// Write server time (will overwrite the server time every end of frame)
+	MSG_WriteLong(&msg, sv.time);
+
+	// Commit data to the demo file
+	SV_DemoWriteMessage(&msg);
+}
+
+
+
+/***********************************************
+ * DEMO READING FUNCTIONS
+ *
+ * Functions to read demo events
+ ***********************************************/
+
+/*
+====================
+SV_DemoReadClientCommand
+
+Replay a client command
+Client command management (generally automatic, such as tinfo for HUD team overlay status, team selection, etc.) - except userinfo command that is managed by another event
+====================
+*/
+void SV_DemoReadClientCommand( msg_t *msg )
+{
+	char	*cmd;
+	int num;
+
+	Cmd_SaveCmdContext(); // Save the context (tokenized strings) so that the engine can continue its usual processing normally just after this function
+	num = MSG_ReadByte(msg);
+	cmd = MSG_ReadString(msg);
+
+	SV_ExecuteClientCommand(&svs.clients[num], cmd, qtrue); // 3rd arg = clientOK, and it's necessarily true since we saved the command in the demo (else it wouldn't be saved)
+
+	Cmd_RestoreCmdContext(); // Restore the context (tokenized strings)
+}
+
+/*
+====================
+SV_DemoReadServerCommand
+
+Replay a server command
+Server command management - except print/cp (dropped at recording because already handled by gameCommand),
+====================
+*/
+void SV_DemoReadServerCommand( msg_t *msg )
+{
+	char	*cmd;
+
+	Cmd_SaveCmdContext();
+	cmd = MSG_ReadString(msg);
+	SV_SendServerCommand(NULL, "%s", cmd);
+	Cmd_RestoreCmdContext();
+}
+
+/*
+====================
+SV_DemoReadGameCommand
+
+Replay a game command (only game commands sent to all clients)
+Game command management - such as prints/centerprint (cp) scores command - except chat/tchat (handled by clientCommand) - basically the same as demo_serverCommand (because sv_GameSendServerCommand uses SV_SendServerCommand, but game commands are safe to be replayed to everyone, while server commands may be unsafe such as disconnect)
+====================
+*/
+void SV_DemoReadGameCommand( msg_t *msg )
+{
+	char	*cmd;
+
+	Cmd_SaveCmdContext();
+
+	MSG_ReadByte(msg); // clientNum, useless here so we don't save it, but we need to read it in order to move the msg cursor
+	cmd = MSG_ReadString(msg);
+
+	if ( SV_CheckLastCmd( cmd, qfalse ) ) { // check for duplicates: check that the engine did not already send this very same message resulting from an event (this means that engine gamecommands are never filtered, only demo gamecommands)
+		SV_GameSendServerCommand( -1, cmd ); // send this game command to all clients (-1)
+	}
+
+	Cmd_RestoreCmdContext();
+}
+
+/*
+====================
+SV_DemoReadConfigString
+
+Read a configstring from a message and load it into memory
+====================
+*/
+void SV_DemoReadConfigString( msg_t *msg )
+{
+	char	*configstring;
+	int num;
+
+	//num = MSG_ReadLong(msg, MAX_CONFIGSTRINGS); FIXME: doesn't work, dunno why, but it would be better than a string to store a long int!
+	num = atoi(MSG_ReadString(msg));
+	configstring = MSG_ReadString(msg);
+
+	if ( num < CS_PLAYERS + sv_democlients->integer || num >= CS_PLAYERS + sv_maxclients->integer ) { // we make sure to not overwrite real client configstrings (else when the demo starts, normal players will have no name, no model and no status!) - this cannot be done at recording time because we can't know how many sv_maxclients will be set at replaying time
+		SV_SetConfigstring(num, configstring);
+	}
+}
+
+/*
+====================
+SV_DemoReadClientConfigString
+
+Read a demo client configstring from a message, load it into memory and broadcast changes to gamecode and clients
+This function also manages demo clientbegin at connections and teamchange (which are normally totally handled by the gamecode, so we can't directly access nor store these events in the demo, we must use clever ways to reproduce them at the right time)
+====================
+*/
+void SV_DemoReadClientConfigString( msg_t *msg )
+{
+	client_t *client;
+	char	*configstring;
+	int num;
+
+	num = MSG_ReadByte(msg);
+	configstring = MSG_ReadString(msg);
+
+	/**** DEMOCLIENTS CONNECTION MANAGEMENT  ****/
+	// This part manages when a client should begin or be dropped based on the configstrings. This is a workaround because begin and disconnect events are managed in the gamecode, so we here use a clever way to know when these events happen (this is based on a careful reading of how work the mechanisms that manage players in a real game, so this should be OK in any case).
+	// Note: this part could also be used in userinfo instead of client configstrings (but since DropClient automatically sets userinfo to null, which is not the case the other way around, this way was preferred)
+	if ( Q_stricmp(sv.configstrings[CS_PLAYERS + num], configstring) && configstring && strlen(configstring) ) { // client begin or just changed team: previous configstring and new one are different, and the new one is not null
+
+		client = &svs.clients[num];
+
+		int svdoldteam;
+		int svdnewteam;
+		svdoldteam = strlen(Info_ValueForKey(sv.configstrings[CS_PLAYERS + num], "t")) ? atoi(Info_ValueForKey(sv.configstrings[CS_PLAYERS + num], "t")) : -1; // affect the new team if detected, else if an empty string is returned, just set -1 (will allow us to detect that there's really no team change instead of having 0 which is TEAM_FREE)
+		svdnewteam = strlen(Info_ValueForKey(configstring, "t")) ? atoi(Info_ValueForKey(configstring, "t")) : -1;
+
+		// Set the client configstring (using a standard Q3 function)
+		SV_SetConfigstring(CS_PLAYERS + num, configstring);
+
+		// Set some infos about this user:
+		svs.clients[num].demoClient = qtrue; // to check if a client is a democlient, you can either rely on this variable, either you can check if num (index of client) is >= CS_PLAYERS + sv_democlients->integer && < CS_PLAYERS + sv_maxclients->integer (if it's not a configstring, remove CS_PLAYERS from your if)
+		Q_strncpyz( svs.clients[num].name, Info_ValueForKey( configstring, "n" ), MAX_NAME_LENGTH ); // set the name (useful for internal functions such as status_f). Anyway userinfo will automatically set both name (server-side) and netname (gamecode-side).
+
+
+		// DEMOCLIENT INITIAL TEAM MANAGEMENT
+		// Note: needed only to set the initial team of the democlients, subsequent team changes are directly handled by their clientCommands
+		// DEPRECATED: moved to userinfo, more interoperable (because here team is an int, while in userinfo the full team name string is stored and can be directly replayed)
+		if ( sv_gametype->integer != GT_TOURNAMENT ) {
+			if ( !strlen(Info_ValueForKey(svs.clients[num].userinfo, "team")) ) {
+				if (configstring && strlen(configstring) &&
+				    ( svdoldteam == -1 || (svdoldteam != svdnewteam && svdnewteam != -1) ) // if there was no team for this player before or if the new team is different
+				    ) {
+					// If the client changed team, we manually issue a team change (workaround by using a clientCommand team)
+					char *svdnewteamstr = malloc( 10 * sizeof *svdnewteamstr );
+
+					if (svdnewteam == TEAM_SPECTATOR) {
+						strcpy(svdnewteamstr, "spectator");
+					} else {
+						strcpy(svdnewteamstr, "o"); // random string, we just want the server to considerate the democlient in a team, whatever the team is. It will be automatically adjusted later with a clientCommand or userinfo string.
+					}
+
+					SV_ExecuteClientCommand(&svs.clients[num], va("team %s", svdnewteamstr), qtrue); // workaround to force the server's gamecode and clients to update the team for this client - note: in fact, setting any team (except spectator) will make the engine set the client to a random team, but it's only sessionTeam! so the democlients will still be shown in the right team on the scoreboard, but the engine will consider them in a random team (this has no concrete adverse effect to the demo to my knowledge)
+
+					free( svdnewteamstr );
+				}
+			}
+		}
+
+		// Set the remoteAddress of this client to localhost (this will set "ip\localhost" in the userinfo, which will in turn force the gamecode to set this client as a localClient, which avoids inactivity timers and some other stuffs to be triggered)
+		if (strlen(configstring)) // we check that the client isn't being dropped
+			NET_StringToAdr( "localhost", &client->netchan.remoteAddress, NA_LOOPBACK );
+
+		// Make sure the gamecode consider the democlients (this will allow to show them on the scoreboard and make them spectatable with a standard follow) - does not use argv (directly fetch client infos from userinfo) so no need to tokenize with Cmd_TokenizeString()
+		// Note: this also triggers the gamecode refreshing of the client's userinfo
+		VM_Call( gvm, GAME_CLIENT_BEGIN, num );
+	} else if ( Q_stricmp(sv.configstrings[CS_PLAYERS + num], configstring) && strlen(sv.configstrings[CS_PLAYERS + num]) && (!configstring || !strlen(configstring)) ) { // client disconnect: different configstrings and the new one is empty, so the client is not there anymore, we drop him (also we check that the old config was not empty, else we would be disconnecting a player who is already dropped)
+		client = &svs.clients[num];
+		SV_DropClient( client, "disconnected" ); // same as SV_Disconnect_f(client);
+		SV_SetConfigstring(CS_PLAYERS + num, configstring); // empty the configstring
+	} else { // In any other case (should there be?), we simply set the client configstring (which should not produce any error)
+		SV_SetConfigstring(CS_PLAYERS + num, configstring);
+	}
+}
+
+/*
+====================
+SV_DemoReadClientUserinfo
+
+Read a demo client userinfo string from a message, load it into memory, fills client_t fields by parsing the userinfo and broacast the change to the gamecode and clients
+Note: this function also manage the initial team of democlients when demo recording has started. Subsequent team changes will be directly handled by clientCommands "team"
+====================
+*/
+void SV_DemoReadClientUserinfo( msg_t *msg )
+{
+	client_t *client;
+	char	*userinfo; // = malloc( MAX_INFO_STRING * sizeof *userinfo);
+	int num;
+
+	// Save context
+	Cmd_SaveCmdContext();
+	// Get client
+	num = MSG_ReadByte(msg);
+	client = &svs.clients[num];
+	// Get userinfo
+	userinfo = MSG_ReadString(msg);
+
+	// Get the old and new team for the client
+	char *svdoldteam = malloc( MAX_NAME_LENGTH * sizeof *svdoldteam );
+	char *svdnewteam = malloc( MAX_NAME_LENGTH * sizeof *svdnewteam );
+	Q_strncpyz(svdoldteam, Info_ValueForKey(client->userinfo, "team"), MAX_NAME_LENGTH);
+	Q_strncpyz(svdnewteam, Info_ValueForKey(userinfo, "team"), MAX_NAME_LENGTH);
+
+	// Set the remoteAddress of this client to localhost (this will set "ip\localhost" in the userinfo, which will in turn force the gamecode to set this client as a localClient, which avoids inactivity timers and some other stuffs to be triggered)
+	if (strlen(userinfo)) // we check that the client isn't being dropped (in which case we shouldn't set an address)
+		NET_StringToAdr( "localhost", &client->netchan.remoteAddress, NA_LOOPBACK );
+
+	// Update the userinfo for both the server and gamecode
+	Cmd_TokenizeString( va("userinfo %s", userinfo) ); // we need to prepend the userinfo command (or in fact any word) to tokenize the userinfo string to the second index because SV_UpdateUserinfo_f expects to fetch it with Argv(1)
+	SV_UpdateUserinfo_f(client); // will update the server userinfo, automatically fill client_t fields and then transmit to the gamecode and call ClientUserinfoChanged() which will also update the gamecode's client_t from the new userinfo (eg: name [server-side] and netname [gamecode-side] will be both updated)
+
+
+	// DEMOCLIENT INITIAL TEAM MANAGEMENT
+	// Note: it is more interoperable to do team management here than in configstrings because here we have the team name as a string, so we can directly issue it in a "team" clientCommand
+	// Note2: this function is only necessary to set the initial team for democlients (the team they were at first when the demo started), for all the latter team changes, the clientCommands are recorded and will be replayed
+	if ( sv_gametype->integer != GT_TOURNAMENT ) { // if it's tournament, playing democlients shouldn't send a team command, else they will be set back to spectator waiting queue (and so they won't be spectatable anymore)!) FIXME: all democlients (even spec) will be spectatable, but how to fix that when clients can have an empty team (at connection, until they issue a team clientCommand)?
+		if (userinfo && strlen(userinfo) && strlen(svdnewteam) &&
+		    ( !strlen(svdoldteam) || (Q_stricmp(svdoldteam, svdnewteam) && strlen(svdnewteam)) ) // if there was no team for this player before OR if the new team is different
+		    ) {
+			// If the democlient changed team, we manually issue a team change (workaround by using a clientCommand team)
+			SV_ExecuteClientCommand(client, va("team %s", svdnewteam), qtrue); // workaround to force the server's gamecode and clients to update the team for this client
+
+		} else if (!strlen(svdoldteam) && !strlen(svdnewteam) && strlen(userinfo) &&
+			   !strlen(Info_ValueForKey(sv.configstrings[CS_PLAYERS + num], "t"))
+			   ) { // old and new team are not specified in the previous and current userinfo, but a userinfo is present
+			// Else if the democlient has no team specified, it's probably because he just has connected and so he is set to the default team by the gamecode depending on the gamecode: for >= GT_TEAM it's spectator, for all the others non-team based gametypes it's direcly in-game
+			// FIXME? If you are trying to port this patch and weirdly some democlients are visible in scoreboard but can't be followed, try to uncomment these lines
+			if (sv_gametype->integer >= GT_TEAM && demoTeamAutoJoin <= 0) { // if it's a team-based gametype, by default players are spectators (unless g_teamAutoJoin was set)
+				SV_ExecuteClientCommand(client, "team spectator", qtrue); // send to spectator the client (prevent the democlient from being followed)
+			} else { // else by default they join the game
+				SV_ExecuteClientCommand(client, "team o", qtrue);
+			}
+		}
+	}
+
+	// Free memory
+	//free( userinfo ); // automatically freed by glibc, if uncommented will produce a crash
+	free( svdoldteam );
+	free( svdnewteam );
+
+	// Restore context
+	Cmd_RestoreCmdContext();
+}
+
+/*
+====================
+SV_DemoReadClientUsercmd
+
+Read the usercmd_t for a democlient and restituate the movements - this is NOT needed to make democlients move, this is handled by entities management, but it should avoid inactivity timer to activate and can be used for demo analysis
+FIXME: should set ucmd->serverTime = client->ps.commandTime + 2 to avoid the dropping of the usercmds_t packets, see g_active.c
+====================
+*/
+/*
+void SV_DemoReadClientUsercmd( msg_t *msg )
+{
+	int num, deltaint;
+	qboolean delta;
+
+	Cmd_SaveCmdContext(); // Save the context (tokenized strings) so that the engine can continue its usual processing normally just after this function
+	num = MSG_ReadByte(msg);
+	deltaint = MSG_ReadByte(msg);
+	if (deltaint)
+		delta = qtrue;
+	else
+		delta = qfalse;
+	//Com_Printf("DebugGBOReadusercmd: %i\n", num);
+	SV_UserMove(&svs.clients[num], msg, delta);
+	Cmd_RestoreCmdContext(); // Restore the context (tokenized strings)
+}
+*/
+
+/*
+====================
+SV_DemoReadAllPlayerState
+
+Read all democlients playerstate (playerState_t) from a message and store them in a demoPlayerStates array (it will be loaded in memory later when SV_DemoReadRefresh() is called)
+====================
+*/
+void SV_DemoReadAllPlayerState( msg_t *msg )
+{
+	playerState_t *player;
+	int num;
+
+	num = MSG_ReadByte(msg);
+	player = SV_GameClientNum(num);
+	MSG_ReadDeltaPlayerstate(msg, &sv.demoPlayerStates[num], player);
+	sv.demoPlayerStates[num] = *player;
+}
+
+/*
+====================
+SV_DemoReadAllEntityState
+
+Read all entities state (gentity_t or sharedEntity_t->entityState_t) from a message and store them in a demoEntities[num].s array (it will be loaded in memory later when SV_DemoReadRefresh() is called)
+====================
+*/
+void SV_DemoReadAllEntityState( msg_t *msg )
+{
+	sharedEntity_t *entity;
+	int num;
+
+	while (1)
+	{
+		num = MSG_ReadBits(msg, GENTITYNUM_BITS);
+		if (num == ENTITYNUM_NONE)
+			break;
+		entity = SV_GentityNum(num);
+		MSG_ReadDeltaEntity(msg, &sv.demoEntities[num].s, &entity->s, num);
+		sv.demoEntities[num].s = entity->s;
+	}
+}
+
+/*
+====================
+SV_DemoReadAllEntityShared
+
+Read all shared entities (gentity_t or sharedEntity_t->entityShared_t - NOTE: sharedEntity_t = gentity_t != entityShared_t which is a subfield of gentity_t) from a message and store them in a demoEntities[num].r array (it will be loaded in memory later when SV_DemoReadRefresh() is called)
+====================
+*/
+void SV_DemoReadAllEntityShared( msg_t *msg )
+{
+	sharedEntity_t *entity;
+	int num;
+
+	while (1)
+	{
+		num = MSG_ReadBits(msg, GENTITYNUM_BITS);
+		if (num == ENTITYNUM_NONE)
+			break;
+		entity = SV_GentityNum(num);
+		MSG_ReadDeltaSharedEntity(msg, &sv.demoEntities[num].r, &entity->r, num);
+
+		entity->r.svFlags &= ~SVF_BOT; // fix bots camera freezing issues - because since now the engine will consider these democlients just as normal players, it won't be using anymore special bots fields and instead just use the standard viewangles field to replay the camera movements
+
+		// Link/unlink the entity
+		if (entity->r.linked && (!sv.demoEntities[num].r.linked ||
+		    entity->r.linkcount != sv.demoEntities[num].r.linkcount))
+			SV_LinkEntity(entity);
+		else if (!entity->r.linked && sv.demoEntities[num].r.linked)
+			SV_UnlinkEntity(entity);
+
+		sv.demoEntities[num].r = entity->r;
+		if (num > sv.num_entities)
+			sv.num_entities = num;
+	}
+}
+
+/*
+====================
+SV_DemoReadRefreshEntities
+
+Load into memory all stored demo players states and entities (which effectively overwrites the one that were previously written by the game since SV_ReadFrame is called at the very end of every game's frame iteration).
+====================
+*/
+void SV_DemoReadRefreshEntities( void )
+{
+	int i;
+
+	// Overwrite anything the game may have changed
+	for (i = 0; i < sv.num_entities; i++)
+	{
+		if (i >= sv_democlients->integer && i < MAX_CLIENTS) // FIXME? shouldn't MAX_CLIENTS be sv_maxclients->integer?
+			continue;
+		*SV_GentityNum(i) = sv.demoEntities[i]; // Overwrite entities
+	}
+	for (i = 0; i < sv_democlients->integer; i++)
+		*SV_GameClientNum(i) = sv.demoPlayerStates[i]; // Overwrite player states
+}
+
+/*
+====================
+SV_DemoReadRefreshPlayersHealth
+
+Update all demoplayers health (will be reflected on the HUD when spectated - for team overlay see tinfo clientcommand)
+Note: this function should always be called after SV_DemoReadRefreshEntities() (or you can also change SV_GameClientNum(i) to sv.demoPlayerStates[i], but make sure the entity already has updated its health state...)
+====================
+*/
+void SV_DemoReadRefreshPlayersHealth( void )
+{
+	int i;
+
+	// Update all players' health in HUD
+	for (i = 0; i < sv_democlients->integer; i++)
+	{
+		SV_GentityUpdateHealthField( SV_GentityNum(i), SV_GameClientNum(i) ); // Update the health with the value of playerState_t->stats[STAT_HEALTH]
+	}
+}
+
+/*
+====================
+SV_DemoReadFrame
+
+Play a frame from the demo file
+This function will read one frame per call, and will process every events contained (switch to the next event when meeting the demo_EOF marker) until it meets the end of the frame (demo_endDemo marker)
+Called in the main server's loop SV_Frame() in sv_main.c (it's called after any other event processing, so that it overwrites anything the game may have loaded into memory, but before the entities are broadcasted to the clients)
+====================
+*/
+void SV_DemoReadFrame(void)
+{
+	msg_t msg;
+	int cmd, r;
+
+	static int memsvtime;
+	static int currentframe = -1;
+
+read_next_demo_frame: // used to read another whole demo frame
+
+	// Demo freezed? Just stop reading the demo frames
+	if (Cvar_VariableIntegerValue("cl_freezeDemo")) {
+		sv.time = memsvtime; // reset server time to the same time as the previous frame, to avoid the time going backward when resuming the demo (which will disconnect every players)
+		return;
+	}
+
+	// Update timescale
+	currentframe++; // update the current frame number
+
+	if (com_timescale->value < 1.0) { // Check timescale: if slowed timescale (below 1.0), then we check that we pass one frame on 1.0/com_timescale (eg: timescale = 0.5, 1.0/0.5=2, so we pass one frame on two)
+		if (currentframe % (int)(1.0/com_timescale->value) != 0) { // if it's not yet the right time to read the frame, we just pass and wait for the next server frame to read this demo frame
+			return;
+		}
+	}
+
+	// Initialize / reinitialize the msg buffer
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	while (1)
+	{
+read_next_demo_event: // used to read next demo event
+
+		// Get a message
+		r = FS_Read(&msg.cursize, 4, sv.demoFile);
+		if (r != 4)
+		{
+			Com_Error(ERR_DROP, "DEMOERROR: SV_DemoReadFrame: Demo file is corrupted\n");
+			SV_DemoStopPlayback();
+			return;
+		}
+		msg.cursize = LittleLong(msg.cursize); // get the size of the next demo message
+		if (msg.cursize > msg.maxsize) // if the size is too big, we throw an error
+			Com_Error(ERR_DROP, "DEMOERROR: SV_DemoReadFrame: demo message too long\n");
+		r = FS_Read(msg.data, msg.cursize, sv.demoFile); // fetch the demo message (using the length we got) from the demo file sv.demoFile, and store it into msg.data (will be accessed automatically by MSG_thing() functions), and store in r the length of the data returned (used to check that it's correct)
+		if (r != msg.cursize) // if the returned length of the read demo message is not the same as the length we expected (the one that was stored just prior to the demo message), we return an error because we miss the demo message, and the only reason is that the file is truncated, so there's nothing to read after
+		{
+			Com_Printf("DEMOERROR: Demo file was truncated.\n");
+			SV_DemoStopPlayback();
+			return;
+		}
+
+		// Parse the message
+		while (1)
+		{
+			cmd = MSG_ReadByte(&msg); // Read the demo message marker
+			switch (cmd) // switch to the right processing depending on the type of the marker
+			{
+				default:
+					if ( sv_demoTolerant->integer ) { // Error tolerance mode: if we encounter an unknown demo message, we just skip to the next (this may allow for retrocompatibility)
+						MSG_Clear(&msg);
+						goto read_next_demo_event;
+					} else { // else we just drop the demo and throw a big fat error
+						Com_Error(ERR_DROP, "SV_DemoReadFrame: Illegible demo message\n");
+						return;
+					}
+				case demo_EOF: // end of a demo event (the loop will continue to real the next event)
+					MSG_Clear(&msg);
+					goto read_next_demo_event;
+				case demo_configString: // general configstrings setting (such as capture scores CS_SCORES1/2, etc.) - except clients configstrings
+					SV_DemoReadConfigString( &msg );
+					break;
+				case demo_clientConfigString: // client configstrings setting and clients status management
+					SV_DemoReadClientConfigString( &msg );
+					break;
+				case demo_clientUserinfo: // client userinfo setting and client_t fields management
+					SV_DemoReadClientUserinfo( &msg );
+					break;
+				case demo_clientCommand: // client command management (generally automatic, such as tinfo for HUD team overlay status, team selection, etc.) - except userinfo command that is managed by another event
+					SV_DemoReadClientCommand( &msg );
+					break;
+				case demo_serverCommand: // server command management - except print/cp (already handled by gameCommand),
+					SV_DemoReadServerCommand( &msg );
+					break;
+				case demo_gameCommand: // game command management - such as prints/centerprint (cp) scores command - except chat/tchat (handled by clientCommand) - basically the same as demo_serverCommand (because sv_GameSendServerCommand uses SV_SendServerCommand, but game commands are safe to be replayed to everyone, while server commands may be unsafe such as disconnect)
+					SV_DemoReadGameCommand( &msg );
+					break;
+				case demo_playerState: // manage playerState_t (some more players game status management, see demo_endFrame)
+					SV_DemoReadAllPlayerState( &msg );
+					break;
+				case demo_entityState: // manage gentity->entityState_t (some more gentities game status management, see demo_endFrame)
+					SV_DemoReadAllEntityState( &msg );
+					break;
+				case demo_entityShared: // gentity_t->entityShared_t management (see g_local.h for more infos)
+					SV_DemoReadAllEntityShared( &msg );
+					break;
+				/*
+				case demo_clientUsercmd:
+					SV_DemoReadClientUsercmd( &msg );
+					break;
+				*/
+				case demo_endFrame: // end of the frame - players and entities game status update: we commit every demo entity to the server, update the server time, then release the demo frame reading here to the next server (and demo) frame
+					// Update entities
+					SV_DemoReadRefreshEntities(); // load into memory the demo entities (overwriting any change the game may have done)
+					// Update all players' health in HUD
+					SV_DemoReadRefreshPlayersHealth();
+					// Set the server time
+					sv.time = MSG_ReadLong(&msg); // refresh server in-game time (overwriting any change the game may have done)
+					memsvtime = sv.time; // keep memory of the last server time, in case we want to freeze the demo
+
+					if (com_timescale->value > 1.0) { // Check for timescale: if timescale is faster (above 1.0), we read more frames at once (eg: timescale=2, we read 2 frames for one call of this function)
+						if (currentframe % (int)(com_timescale->value) != 0) { // Check that we've read all the frames we needed
+							goto read_next_demo_frame; // if not true, we read another frame
+						}
+					}
+
+					return; // else we end the current demo frame
+				case demo_endDemo: // end of the demo file - just stop playback and restore saved cvars
+					SV_DemoStopPlayback();
+					return;
+			}
+		}
+	}
+}
+
+
+
+/***********************************************
+ * DEMO MANAGEMENT FUNCTIONS
+ *
+ * Functions to start/stop the recording/playback of a demo file
+ ***********************************************/
+
+/*
+====================
+SV_DemoAutoDemoRecord
+
+Generates a meaningful demo filename and automatically starts the demo recording.
+This function is used in conjunction with the variable sv_autoDemo 1
+Note: be careful, if the hostname contains bad characters, the demo may not be able to be saved at all! There's a small filtering in place but a bad filename may pass through!
+Note2: this function is called at MapRestart and SpawnServer (called in Map func), but in no way it's called right at the time it's set.
+====================
+*/
+void SV_DemoAutoDemoRecord(void)
+{
+	qtime_t now;
+	Com_RealTime( &now );
+    char *demoname = malloc ( MAX_QPATH * sizeof * demoname );
+    
+
+	Q_strncpyz(demoname, va( "%s_%04d-%02d-%02d-%02d-%02d-%02d_%s",
+			SV_CleanFilename(va("%s", sv_hostname->string)),
+                        1900 + now.tm_year,
+                        1 + now.tm_mon,
+                        now.tm_mday,
+                        now.tm_hour,
+                        now.tm_min,
+                        now.tm_sec,
+                        SV_CleanFilename(Cvar_VariableString( "mapname" )) ),
+                        MAX_QPATH);
+
+	Com_Printf("DEMO: recording a server-side demo to: %s/svdemos/%s.%s%d\n",  strlen(Cvar_VariableString("fs_game")) ?  Cvar_VariableString("fs_game") : BASEGAME, demoname, SVDEMOEXT, PROTOCOL_VERSION);
+
+	Cbuf_AddText( va("demo_record %s\n", demoname ) );
+
+	free(demoname);
+}
+
+/*
+====================
+SV_DemoStartRecord
+
+Start the recording of a demo by saving some headers data (such as the number of clients, mapname, gametype, etc..)
+sv.demo* have already been set and the demo file opened, start writing gamestate info
+====================
+*/
+void SV_DemoStartRecord(void)
+{
+	msg_t msg;
+	int i;
+
+	// Set democlients to 0 since it's only used for replaying demo
+	Cvar_SetValue("sv_democlients", 0);
+
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Write number of clients (sv_maxclients < MAX_CLIENTS or else we can't playback)
+	MSG_WriteString(&msg, "clients"); // for each demo meta data (infos about the demo), we prepend the name of the var (this allows for fault tolerance and retrocompatibility) - FIXME? We could also use MSG_LookaheadByte() to read a byte, instead of a string, this would save a tiny bit of storage space
+	MSG_WriteByte(&msg, sv_maxclients->integer);
+	// Write current server in-game time
+	MSG_WriteString(&msg, "time");
+	MSG_WriteLong(&msg, sv.time);
+	// Write sv_fps
+	MSG_WriteString(&msg, "sv_fps");
+	MSG_WriteLong(&msg, sv_fps->integer);
+	// Write g_gametype
+	MSG_WriteString(&msg, "g_gametype");
+	MSG_WriteLong(&msg, sv_gametype->integer);
+	// Write fs_game (mod name)
+	MSG_WriteString(&msg, "fs_game");
+	MSG_WriteString(&msg, Cvar_VariableString("fs_game"));
+	// Write map name
+	MSG_WriteString(&msg, "map");
+	MSG_WriteString(&msg, sv_mapname->string);
+	// Write timelimit
+	MSG_WriteString(&msg, "timelimit");
+	MSG_WriteLong(&msg, Cvar_VariableIntegerValue("timelimit"));
+	// Write fraglimit
+	MSG_WriteString(&msg, "fraglimit");
+	MSG_WriteLong(&msg, Cvar_VariableIntegerValue("fraglimit"));
+	// Write capturelimit
+	MSG_WriteString(&msg, "capturelimit");
+	MSG_WriteLong(&msg, Cvar_VariableIntegerValue("capturelimit"));
+	// Write g_teamAutoJoin (will allow to know what was the default initial team for newly connected players)
+	MSG_WriteString(&msg, "g_teamAutoJoin");
+	MSG_WriteLong(&msg, Cvar_VariableIntegerValue("g_teamAutoJoin"));
+	// Write sv_hostname (only for info)
+	MSG_WriteString(&msg, "hostname");
+	MSG_WriteString(&msg, sv_hostname->string);
+	// Write current datetime (only for info)
+	MSG_WriteString(&msg, "datetime");
+	MSG_WriteString(&msg, SV_GenerateDateTime());
+
+	// Write end of meta datas (since we will read a string each loop, we need to set a special string to specify the reader that we end the loop, we cannot use a marker because it's a byte)
+	MSG_WriteString(&msg, "endMeta");
+
+	// Write all the above into the demo file
+	SV_DemoWriteMessage(&msg);
+
+	// Write all configstrings (such as current capture score CS_SCORE1/2, etc...), including clients configstrings
+	// Note: system configstrings will be filtered and excluded (there's a check function for that), and clients configstrings  will be automatically redirected to the specialized function (see the check function)
+	for (i = 0; i < MAX_CONFIGSTRINGS; i++)
+	{
+		if ( &sv.configstrings[i] ) { // if the configstring pointer exists in memory (because we will check all the possible indexes, but we don't know if they really exist in memory and are used or not, so here we check for that)
+			SV_DemoWriteConfigString(i, sv.configstrings[i]);
+		}
+	}
+
+	// Write initial clients userinfo
+	for (i = 0; i < sv_maxclients->integer; i++)
+	{
+		client_t *client = &svs.clients[i];
+
+		if (client->state >= CS_CONNECTED) {
+
+			// store client's userinfo (should be before clients configstrings since clients configstrings are derived from userinfo)
+			if (client->userinfo) { // if player is connected and the configstring exists, we store it
+				SV_DemoWriteClientUserinfo(client, (const char *)client->userinfo);
+			}
+		}
+	}
+
+	// Write entities and players
+	Com_Memset(sv.demoEntities, 0, sizeof(sv.demoEntities));
+	Com_Memset(sv.demoPlayerStates, 0, sizeof(sv.demoPlayerStates));
+	SV_DemoWriteFrame();
+	Com_Printf("Recording demo %s.\n", sv.demoName);
+	sv.demoState = DS_RECORDING;
+	Cvar_SetValue("sv_demoState", DS_RECORDING);
+}
+
+/*
+====================
+SV_DemoStopRecord
+
+Stop the recording of a demo
+Write end of demo (demo_endDemo marker) and close the demo file
+====================
+*/
+void SV_DemoStopRecord(void)
+{
+	msg_t msg;
+
+	// End the demo
+	MSG_Init(&msg, buf, sizeof(buf));
+	MSG_WriteByte(&msg, demo_endDemo);
+	SV_DemoWriteMessage(&msg);
+
+	FS_FCloseFile(sv.demoFile);
+	sv.demoState = DS_NONE;
+	Cvar_SetValue("sv_demoState", DS_NONE);
+	Com_Printf("Stopped recording demo %s.\n", sv.demoName);
+}
+
+/*
+====================
+SV_DemoRestartPlayback
+
+Just issue again the demo_play command along with the demo filename (used when the system will automatically restart the server for special cvars values to be set up, eg: sv_maxclients, fs_game, g_gametype, etc..)
+====================
+*/
+void SV_DemoRestartPlayback(void)
+{
+	if ( strlen(savedPlaybackDemoname) ) {
+		// Set the demoState from DS_WAITINGPLAYBACK to DS_NONE (this avoids the engine to repeatedly restart the playback until it gets done, here we just launch it once) - this fix messages bug and accelerate the loading of the demo when switching mods
+		sv.demoState = DS_NONE;
+		Cvar_SetValue("sv_demoState", DS_NONE);
+		// Restart the playback (reissue the demo_play command and the demo filename)
+		Cbuf_AddText( va("%s\n", savedPlaybackDemoname ) );
+	}
+
+	return;
+}
+
+/*
+====================
+SV_DemoStartPlayback
+
+Start the playback of a demo
+sv.demo* have already been set and the demo file opened, start reading gamestate info
+This function will also check that everything is alright (such as gametype, map, sv_fps, sv_democlients, sv_maxclients, etc.), if not it will try to fix it automatically
+Note for developers: this is basically a mirror of SV_DemoStartRecord() but the other way around (there it writes, here it reads) - but only for the part about the headers, for the rest (eg: userinfo, configstrings, playerstates) it's directly managed by ReadFrame.
+====================
+*/
+void SV_DemoStartPlayback(void)
+{
+	msg_t msg;
+	int r, time, i, clients, fps, gametype, timelimit, fraglimit, capturelimit;
+
+	char *map = malloc( MAX_QPATH * sizeof *map );
+	char *fs = malloc( MAX_QPATH * sizeof *fs );
+	char *hostname = malloc( MAX_NAME_LENGTH * sizeof *hostname );
+	char *datetime = malloc( 1024 * sizeof *datetime ); // there's no limit in the whole engine specifically designed for dates and time...
+	char *metadata; // = malloc( 1024 * sizeof * metadata ); // used to store the current metadata index
+
+	// Init vars with empty values (to avoid compilation warnings)
+	r = i = clients = fps = gametype = timelimit = fraglimit = capturelimit = 0;
+	time = 400;
+
+	// Initialize the demo message buffer
+	MSG_Init(&msg, buf, sizeof(buf));
+
+	// Get the demo header
+	r = FS_Read(&msg.cursize, 4, sv.demoFile);
+	if (r != 4)
+	{
+		Com_Error(ERR_DROP, "DEMOERROR: SV_DemoReadFrame: demo is corrupted (not initialized correctly!)\n");
+		SV_DemoStopPlayback();
+		return;
+	}
+	msg.cursize = LittleLong(msg.cursize);
+	if (msg.cursize == -1)
+	{
+		Com_Error(ERR_DROP, "DEMOERROR: SV_DemoReadFrame: demo is corrupted (demo file is empty?)\n");
+		SV_DemoStopPlayback();
+		return;
+	}
+	if (msg.cursize > msg.maxsize)
+		Com_Error(ERR_DROP, "DEMOERROR: SV_DemoReadFrame: demo message too long\n");
+	r = FS_Read(msg.data, msg.cursize, sv.demoFile);
+	if (r != msg.cursize)
+	{
+		Com_Printf("DEMOERROR: Demo file was truncated.\n");
+		SV_DemoStopPlayback();
+		return;
+	}
+
+
+	// Reading meta-data (infos about the demo)
+	// Note: we read with an if statement, so that if in the future we add more meta datas, older demos which haven't these meta datas will still be replayable
+	metadata = "";
+	while( Q_stricmp(metadata, "endMeta")  )
+	{
+		metadata = MSG_ReadString( &msg ); // We read the meta data marker
+
+		if ( !Q_stricmp(metadata, "endMeta") ) { // if the string is the special endMeta string, we already break
+			break;
+
+		} else if ( !Q_stricmp(metadata, "clients") ) { // democlients
+			// Check slots, time and map
+			clients = MSG_ReadByte(&msg); // number of democlients (sv_maxclients at the time of the recording)
+			if (sv_maxclients->integer < clients || // if we have less real slots than democlients slots or
+			    savedMaxClients < 0 || // if there's no savedMaxClients (so this means we didin't change sv_maxclients yet, and we always need to do so since we need to add sv_democlients)
+			    sv_maxclients->integer <= savedMaxClients) { // or if maxclients is below or equal to the previous value of maxclients (normally it can only be equal, but if we switch the mod with game_restart, it can get the default value of 8, which can be below, so we need to check that as well)
+				Com_Printf("DEMO: Not enough demo slots, automatically increasing sv_democlients to %d and sv_maxclients to %d.\n", clients, sv_maxclients->integer + clients);
+
+				// save the old values of sv_maxclients, sv_democlients and bot_minplayers to later restore them
+				if (savedMaxClients < 0) // save only if it's the first value, the subsequent ones may be default values of the engine
+					savedMaxClients = sv_maxclients->integer;
+				if (savedBotMinPlayers < 0)
+					savedBotMinPlayers = Cvar_VariableIntegerValue("bot_minplayers");
+
+				// automatically adjusting sv_democlients, sv_maxclients and bot_minplayers
+				Cvar_SetValue("sv_democlients", clients);
+				Cvar_SetLatched("sv_maxclients", va("%i", sv_maxclients->integer + clients) );
+				/* BUGGY makes a dedicated server crash
+				Cvar_Get( "sv_maxclients", "8", 0 );
+				sv_maxclients->modified = qfalse;
+				*/
+			}
+
+		} else if ( !Q_stricmp(metadata, "time") ) { // server time
+			// reading server time (from the demo)
+			time = MSG_ReadLong(&msg);
+			if (time < 400)
+			{
+				Com_Printf("DEMO: Demo time too small: %d.\n", time);
+				SV_DemoStopPlayback();
+				return;
+			}
+		} else if ( !Q_stricmp(metadata, "sv_fps") ) {
+			// reading sv_fps (from the demo)
+			fps = MSG_ReadLong(&msg);
+			if ( sv_fps->integer != fps ) {
+				savedFPS = sv_fps->integer;
+				Cvar_SetValue("sv_fps", fps);
+			}
+		} else if ( !Q_stricmp(metadata, "g_gametype") ) {
+			// reading g_gametype (from the demo)
+			gametype = MSG_ReadLong(&msg);
+			// memorize the current gametype
+			if ( !keepSaved )
+				savedGametype = sv_gametype->integer; // save the gametype before switching
+
+		} else if ( !Q_stricmp(metadata, "fs_game") ) {
+			// reading fs_game (mod name)
+			Q_strncpyz(fs, MSG_ReadString(&msg), MAX_QPATH);
+			if (strlen(fs)){
+				Com_Printf("DEMO: Warning: this demo was recorded for the following mod: %s\n", fs);
+			}
+
+		} else if ( !Q_stricmp(metadata, "map") ) {
+			// reading map (from the demo)
+			Q_strncpyz(map, MSG_ReadString(&msg), MAX_QPATH);
+			if (!FS_FOpenFileRead(va("maps/%s.bsp", map), NULL, qfalse))
+			{
+				Com_Printf("Map does not exist: %s.\n", map);
+				SV_DemoStopPlayback();
+				return;
+			}
+
+		} else if ( !Q_stricmp(metadata, "timelimit") ) {
+			// reading initial timelimit
+			timelimit = MSG_ReadLong(&msg);
+			// memorize the current timelimit
+			if ( !keepSaved )
+				savedTimelimit = Cvar_VariableIntegerValue("timelimit");
+			// set the demo setting
+			Cvar_SetValue("timelimit", timelimit); // Note: setting the timelimit is NOT necessary for the demo to be replayed (in fact even if the timelimit is reached, the demo will still continue to feed new frames and thus force the game to continue, without any bug - also to the opposite, if the timelimit is too high, the game will be finished when the demo will replay the events, even if the timelimit is not reached but was in the demo, it will be when replaying the demo), but setting it allows for timelimit warning and suddenDeath voice announcement to happen. FIXME: if the timelimit is changed during the game, it won't be reflected in the demo (but the demo will still continue to play, or stop if the game is won).
+
+		} else if ( !Q_stricmp(metadata, "fraglimit") ) {
+			// reading initial fraglimit
+			fraglimit = MSG_ReadLong(&msg);
+			// memorize the current fraglimit
+			if ( !keepSaved )
+				savedFraglimit = Cvar_VariableIntegerValue("fraglimit");
+			// set the demo setting
+			Cvar_SetValue("fraglimit", fraglimit); // Note: unnecessary for the demo to be replayed, but allows to show the limit in the HUD. FIXME: if the limit is changed during the game, the new value won't be reflected in the demo (but the demo will continue to play to its integrality)
+
+		} else if ( !Q_stricmp(metadata, "capturelimit") ) {
+			// reading initial capturelimit
+			capturelimit = MSG_ReadLong(&msg);
+			// memorize the current capturelimit
+			if ( !keepSaved )
+				savedCapturelimit = Cvar_VariableIntegerValue("capturelimit");
+			// set the demo setting
+			Cvar_SetValue("capturelimit", capturelimit); // Note: unnecessary for the demo to be replayed, but allows to show the limit in the HUD. FIXME: if the limit is changed during the game, the new value won't be reflected in the demo (but the demo will continue to play to its integrality)
+
+		} else if ( !Q_stricmp(metadata, "g_teamAutoJoin") ) {
+			// reading g_teamAutoJoin and storing it
+			demoTeamAutoJoin = MSG_ReadLong(&msg);
+
+		// Additional infos (not necessary to replay a demo)
+		} else if ( !Q_stricmp(metadata, "hostname") ) {
+			// reading sv_hostname (additional info)
+			Q_strncpyz(hostname, MSG_ReadString(&msg), MAX_NAME_LENGTH);
+
+		} else if ( !Q_stricmp(metadata, "datetime") ) {
+			// reading datetime
+			Q_strncpyz(datetime, MSG_ReadString(&msg), 1024);
+		}
+	}
+
+	// g_doWarmup
+	if (!keepSaved) { // we memorize values only if it's the first time we launch the playback of this demo, else the values may have already been modified by the demo playback
+		// Memorize g_doWarmup
+		savedDoWarmup = Cvar_VariableIntegerValue("g_doWarmup");
+	}
+	// Remove g_doWarmup (bugfix: else it will produce a weird bug with all gametypes except CTF and Double Domination because of CheckTournament() in g_main.c which will make the demo stop after the warmup time)
+	Cvar_SetValue("g_doWarmup", 0);
+
+	// g_allowVote
+	if (!keepSaved) { // same for g_allowVote
+		// Memorize g_allowVote
+		savedAllowVote = Cvar_VariableIntegerValue("g_allowVote");
+	}
+	// Remove g_allowVote (prevent players to call a vote while a map is replaying)
+	Cvar_SetValue("g_allowVote", 0);
+
+	// g_teamAutoJoin
+	if (!keepSaved) {
+		// Memorize g_teamAutoJoin
+		savedTeamAutoJoin = Cvar_VariableIntegerValue("g_teamAutoJoin");
+	}
+	// Remove g_teamAutoJoin (prevent players to call a vote while a map is replaying)
+	Cvar_SetValue("g_teamAutoJoin", 0);
+
+
+
+	// Printing infos about the demo
+	if ( !sv_demoTolerant->integer ) // print the meta datas only if we're not in faults tolerance mode (because if there are missing meta datas, the printing will throw an exception! So we'd better avoid it)
+		Com_Printf("DEMO: Details of %s recorded %s on server \"%s\": sv_fps: %i initial_servertime: %i clients: %i fs_game: %s g_gametype: %i map: %s timelimit: %i fraglimit: %i capturelimit: %i \n", sv.demoName, datetime, hostname, fps, time, clients, fs, gametype, map, timelimit, fraglimit, capturelimit);
+
+	// Checking if all initial conditions from the demo are met (map, sv_fps, gametype, servertime, etc...)
+	// FIXME? why sv_cheats is needed? Just to be able to use cheats commands to pass through walls?
+	if ( !com_sv_running->integer || Q_stricmp(sv_mapname->string, map) ||
+	    Q_stricmp(Cvar_VariableString("fs_game"), fs) ||
+	    !Cvar_VariableIntegerValue("sv_cheats") ||
+	    (time < sv.time && !keepSaved) || // if the demo initial time is below server time AND we didn't already restart for demo playback, then we must restart to reinit the server time (because else, it might happen that the server time is still above demo time if the demo was recorded during a warmup time, in this case we won't restart the demo playback but just iterate a few demo frames in the void to catch up the server time, see below the else statement)
+	    sv_maxclients->modified ||
+	    (sv_gametype->integer != gametype && !(gametype == GT_SINGLE_PLAYER && sv_gametype->integer == GT_FFA) ) // check for gametype change (need a restart to take effect since it's a latched var) AND check that the gametype difference is not between SinglePlayer and DM/FFA, which are in fact the same gametype (and the server will automatically change SinglePlayer to FFA, so we need to detect that and ignore this automatic change)
+	   ) {
+		/// Change to the right map/maxclients/mod and restart the demo playback at the next SV_Frame() iteration
+
+		//Cvar_SetValue("sv_democlients", 0); // necessary to stop the playback, else it will produce an error since the demo has not yet started!
+		keepSaved = qtrue; // Declare that we want to keep the value saved (and we don't want to restore them now, because the demo hasn't started yet!)
+		SV_DemoStopPlayback(); // Stop the demo playback (reset back any change)
+		sv.demoState = DS_WAITINGPLAYBACK; // Set the status WAITINGPLAYBACK meaning that as soon as the server will be restarted, the next SV_Frame() iteration must reactivate the demo playback
+		Cvar_SetValue("sv_demoState", DS_WAITINGPLAYBACK); // set the cvar too because when restarting the server, all sv.* vars will be destroyed
+		Q_strncpyz(savedPlaybackDemoname, Cmd_Cmd(), MAX_QPATH); // we need to copy the value because since we may spawn a new server (if the demo is played client-side OR if we change fs_game), we will lose all sv. vars
+
+		Cvar_SetValue("sv_autoDemo", 0); // disable sv_autoDemo else it will start a recording before we can replay a demo (since we restart the map)
+
+		// **** Automatic mod (fs_game) switching management ****
+		if ( ( Q_stricmp(Cvar_VariableString("fs_game"), fs) && strlen(fs) ) ||
+		    (!strlen(fs) && Q_stricmp(Cvar_VariableString("fs_game"), fs) && Q_stricmp(fs, BASEGAME) ) ) { // change the game mod only if necessary - if it's different from the current gamemod and the new is not empty, OR the new is empty but it's not BASEGAME and it's different (we're careful because it will restart the game engine and so probably every client will get disconnected)
+
+			// Memorize the current mod (only if we are indeed switching mod, otherwise we will save basegame instead of empty strings and force a mod switching when stopping the demo when we haven't changed mod in the first place!)
+			if (strlen(Cvar_VariableString("fs_game"))) { // if fs_game is not "", we save it
+				Q_strncpyz(savedFsGame, (const char*)Cvar_VariableString("fs_game"), MAX_QPATH);
+			} else { // else, it's equal to "", and this means that we were playing in the basegame mod, but we need to have a non-empty string, else we can't use game_restart!
+				Q_strncpyz(savedFsGame, BASEGAME, MAX_QPATH);
+			}
+
+			// Switch the mod
+			Com_Printf("DEMO: Trying to switch automatically to the mod %s to replay the demo\n", strlen(fs) ? fs : BASEGAME);
+			Cvar_SetValue("sv_democlients", 0); // set sv_democlients to 0 (because game_restart will reset sv_maxclients, so we have a risk to have a greater sv_democlients than sv_maxclients, and we don't want that)
+			Cbuf_AddText(va("game_restart %s\n", fs)); // switch mod!
+		}
+
+		Cbuf_AddText(va("g_gametype %i\ndevmap %s\n", gametype, map)); // Change gametype and map (using devmap to enable cheats)
+
+		return; // Quit and wait for the next SV_Frame() iteration (when the server/map will have restarted) to retry playing the demo
+
+	} else if ( time < sv.time && keepSaved ) { // else if the demo time is still below the server time but we already restarted for the demo playback, we just iterate a few demo frames in the void to catch to until we are above the server time. Note: having a server time below the demo time is CRITICAL, else we may send to the clients a server time that is below the previous, making the time going backward, which should NEVER happen!
+		int timetoreach = sv.time;
+		sv.time = time;
+		while (sv.time < timetoreach) {
+			SV_DemoReadFrame(); // run a few frames to settle things out
+		}
+	}
+
+
+
+	// Initialize our stuff
+	Com_Memset(sv.demoEntities, 0, sizeof(sv.demoEntities));
+	Com_Memset(sv.demoPlayerStates, 0, sizeof(sv.demoPlayerStates));
+	Cvar_SetValue("sv_democlients", clients); // Note: we need SV_Startup() to NOT use SV_ChangeMaxClients for this to work without crashing when changing fs_game
+	Cvar_SetValue("bot_minplayers", 0); // if we have bots that autoconnect, this will make up for a very weird demo!
+
+	// Force all real clients already connected before the demo begins to be set to spectator team
+	for (i = sv_democlients->integer; i < sv_maxclients->integer; i++) {
+		if (svs.clients[i].state >= CS_CONNECTED) { // Only set as spectator a player that is at least connected (or primed or active)
+			SV_ExecuteClientCommand(&svs.clients[i], "team spectator", qtrue); // should be more interoperable than a forceteam
+			Cbuf_ExecuteText(EXEC_NOW, va("forceteam %i spectator", i)); // sometimes team spectator does not work when a demo is replayed client-side with some mods (eg: ExcessivePlus), in this case we also issue a forceteam (even if it's less interoperable)
+		}
+	}
+
+	// Free memory
+	free( map );
+	free( fs );
+	free( hostname );
+	free( datetime );
+	//free( metadata ); // it seems glibc already frees this pointer automatically since the malloc was removed, if we specify this line we'll get a crash
+
+	// Start reading the first frame
+	Com_Printf("Playing demo %s.\n", sv.demoName); // log that the demo is started here
+	SV_SendServerCommand( NULL, "chat \"^3Demo replay started!\"" ); // send a message to player
+	SV_SendServerCommand( NULL, "cp \"^3Demo replay started!\"" ); // send a centerprint message to player
+	sv.demoState = DS_PLAYBACK; // set state to playback
+	Cvar_SetValue("sv_demoState", DS_PLAYBACK);
+	keepSaved = qfalse; // Don't save values anymore: the next time we stop playback, we will restore previous values (because now we are really launching the playback, so anything that might happen now is either a big bug or the end of demo, in any case we want to restore the values)
+	SV_DemoReadFrame(); // reading the first frame, which should contain some initialization events (eg: initial confistrings/userinfo when demo recording started, initial entities states and placement, etc..)
+}
+
+/*
+====================
+SV_DemoStopPlayback
+
+Close the demo file and restart the map (can be used both when recording or when playing or at shutdown of the game)
+====================
+*/
+void SV_DemoStopPlayback(void)
+{
+	int olddemostate;
+	olddemostate = sv.demoState;
+
+	// Clear client configstrings
+	int i;
+	if (olddemostate == DS_PLAYBACK) { // unload democlients only if we were replaying a demo (if not it will produce an error!)
+		for (i = 0; i < sv_democlients->integer; i++)
+			SV_SetConfigstring(CS_PLAYERS + i, NULL); //qtrue
+	}
+
+	// Close demo file after playback
+	FS_FCloseFile(sv.demoFile);
+	sv.demoState = DS_NONE;
+	Cvar_SetValue("sv_demoState", DS_NONE);
+	Com_Printf("DEMO: End of demo. Stopped playing demo %s.\n", sv.demoName);
+
+	// Restore initial cvars of the server that were modified by the demo playback
+	// Note: must do it before the map_restart! so that latched values such as sv_maxclients takes effect
+	if ( !keepSaved ) {
+
+		Cvar_SetValue("sv_democlients", 0);
+
+		if (savedMaxClients >= 0) {
+			Cvar_SetLatched("sv_maxclients", va("%i", savedMaxClients) );
+			savedMaxClients = -1;
+		}
+
+		if (savedBotMinPlayers >= 0) {
+			Cvar_SetValue("bot_minplayers", savedBotMinPlayers);
+			savedBotMinPlayers = -1;
+		}
+
+		if (savedFPS > 0) {
+			Cvar_SetValue("sv_fps", savedFPS);
+			savedFPS = -1;
+		}
+
+		if (savedDoWarmup >= 0) {
+			Cvar_SetValue("g_doWarmup", savedDoWarmup);
+			savedDoWarmup = -1;
+		}
+
+		if (savedAllowVote >= 0) {
+			Cvar_SetValue("g_allowVote", savedAllowVote);
+			savedAllowVote = -1;
+		}
+
+		if (savedTeamAutoJoin >= 0) {
+			Cvar_SetValue("g_teamAutoJoin", savedTeamAutoJoin);
+			savedTeamAutoJoin = -1;
+		}
+		demoTeamAutoJoin = -1;
+
+		if (savedTimelimit >= 0) {
+			Cvar_SetValue("timelimit", savedTimelimit);
+			savedTimelimit = -1;
+		}
+
+		if (savedFraglimit >= 0) {
+			Cvar_SetValue("fraglimit", savedFraglimit);
+			savedFraglimit = -1;
+		}
+
+		if (savedCapturelimit >= 0) {
+			Cvar_SetValue("capturelimit", savedCapturelimit);
+			savedCapturelimit = -1;
+		}
+
+		if (strlen(savedFsGame)) { // After setting all the other vars, we switch back the mod if necessary (it must be done only AFTER all the other cvars are set, else cvars set after won't take effect!)
+			Cbuf_AddText(va("game_restart %s\n", savedFsGame));
+			Q_strncpyz(savedFsGame, "", MAX_QPATH);
+		}
+
+		if (savedGametype >= 0) {
+			Cvar_SetLatched("g_gametype", va("%i", savedGametype) );
+			Cbuf_AddText(va("g_gametype %i\n", savedGametype)); // force gametype switching (NOTE: must be AFTER game_restart to work!)
+			savedGametype = -1;
+		}
+	}
+
+	// LAST RELOAD (to reinit all vars)
+	// demo hasn't actually started yet
+	if (olddemostate == DS_NONE && !keepSaved ) { // If keepSaved is true, then this restart procedure is totally normal (and that's why we keep values saved), else it is not normal and probably an error happened
+#ifdef DEDICATED
+		Com_Printf("DEMOERROR: An error happened while playing/recording the demo, please check the log for more info\n"); // if server, don't crash it if an error happens, just print a message
+#else
+		Com_Error (ERR_DROP,"An error happened while replaying the demo, please check the log for more info\n");
+		Cvar_SetValue("sv_killserver", 1);
+#endif
+	} else if (olddemostate == DS_PLAYBACK) {
+		// set a special state to say that we are waiting to stop (SV_DemoChangeMaxClients() will set to DS_NONE after moving the real clients to their correct slots)
+		sv.demoState = DS_WAITINGSTOP;
+		Cvar_SetValue("sv_demoState", DS_WAITINGSTOP);
+#ifdef DEDICATED
+		Cbuf_AddText(va("map %s\n", Cvar_VariableString( "mapname" ))); // better to do a map command rather than map_restart if we do a mod switching with game_restart, map_restart will point to no map (because the config is completely unloaded)
+#else
+		// Update sv_maxclients latched value (since we will kill the server because it's not a dedicated server, we won't restart the map, so latched values won't be affected unless we force the refresh)
+		Cvar_Get( "sv_maxclients", "8", 0 ); // Get sv_maxclients value (force latched values to commit)
+		sv_maxclients->modified = qfalse; // Set modified to false
+		// Kill the local server
+		Cvar_SetValue("sv_killserver", 1); // instead of sending a Cbuf_AddText("killserver") command, we here just set a special cvar which will kill the server at the next SV_Frame() iteration (smoother than force killing)
+#endif
+	}
+
+	return;
+
+}

--- a/code/server/sv_demo_ext.c
+++ b/code/server/sv_demo_ext.c
@@ -1,0 +1,87 @@
+/*
+===========================================================================
+Copyright (C) 2012 Stephen Larroque <lrq3000@gmail.com>
+
+This file is part of OpenArena.
+
+OpenArena is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenArena is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Tremulous; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+// sv_demo_ext.c -- Server side demo recording (supplementary functions)
+
+#include "../game/g_local.h" // get both the definitions of gentity_t (to get gentity_t->health field) AND sharedEntity_t, so that we can convert a sharedEntity_t into a gentity_t (see more details in SV_GentityUpdateHealthField() notes)
+#include "../qcommon/qcommon.h" // needed so that the public declarations in server.h can access these functions (because server.h links to qcommon.h, so that it does server.h->qcommon.h->sv_demo_ext.c -- in the end, no includes redundancy conflicts and every server files can access these functions!)
+
+//#include "server.h" // DO NOT DO THAT! if you include server.h directly, you won't be able to include g_local.h, and you're stuck!
+
+/***********************************************
+ * AUXILIARY FUNCTIONS: UPDATING OF GENTITY_T->HEALTH
+ *
+ * Functions used to update some special aspects of the demo and which need to be separated from the main sv_demo.c file because of different includes that are necessary
+ ***********************************************/
+
+/*
+====================
+SV_GentityGetHealthField
+
+Get the value of the gentity_t->health field (only used for testing purposes)
+====================
+*/
+int SV_GentityGetHealthField( sharedEntity_t * gent ) {
+    gentity_t *ent;
+
+    ent = (gentity_t*)gent;
+
+    //Com_Printf("DEMODEBUG GENGETFIELD: health: %i\n", ent->health);
+    return ent->health;
+}
+
+/*
+====================
+SV_GentitySetHealthField
+
+Set the value of the gentity_t->health field (only used for testing purposes)
+====================
+*/
+void SV_GentitySetHealthField( sharedEntity_t * gent, int value ) {
+    gentity_t *ent;
+
+    ent = (gentity_t*)gent;
+
+    ent->health = value;
+}
+
+/*
+====================
+SV_GentityUpdateHealthField
+
+Update the value of the gentity_t->health field with playerState_t->stats[STAT_HEALTH] for a given player
+You need to supply the player's sharedEntity and playerState (because since we have special includes here, we don't have access to the functions that can return a player from their int id).
+The concrete effect is that when replaying a demo, the players' health will be updated on the HUD (if it weren't for this function to update the health, the health wouldn't change and stay kinda static).
+
+Note: we need to do that because the demo can only records this stats[stat_health], which is concretely the same as gentity_t->health. The latter should have been removed altogether considering the comments in g_active.c (ent->client->ps.stats[STAT_HEALTH] = ent->health;	// FIXME: get rid of ent->health...), but it seems to have survived because it allows non-player entities to have health, such as obelisks. And weirdly, gentity_t->health has ascendence over stat_health (meaning stat_health is updated following gentity_t->health, but never the other way around), when for example stat_armor has ascendence over anything else of the same kind, so here we have to update it by ourselves.
+Note2: this works pretty simply: sharedEntity_t = gentity_t but with only the first 2 fields declared (entityShared_t and entityState_t), but all the other fields are still in memory! We only need to get a valid declaration for gentity_t (which we do by doing the right includes at the top of this file, in g_local.h), and then we can convert the limited sharedEntity_t into a gentity_t with all the fields!
+====================
+*/
+void SV_GentityUpdateHealthField( sharedEntity_t * gent, playerState_t *player ) {
+    gentity_t *ent;
+
+    ent = (gentity_t*)gent; // convert the sharedEntity_t to a gentity_t by using a simple cast (now that we have included g_local.h that contains the definition of gentity_t, and at the same time we have linked to g_public.h via g_local.h with the definition of sharedEntity_t)
+
+    ent->health = player->stats[STAT_HEALTH]; // update player's health from playerState_t->stats[STAT_HEALTH] field
+
+    return;
+}

--- a/code/server/sv_demo_ext.c
+++ b/code/server/sv_demo_ext.c
@@ -1,15 +1,15 @@
 /*
 ===========================================================================
-Copyright (C) 2012 Stephen Larroque <lrq3000@gmail.com>
+Copyright (C) 2012-2017 Stephen Larroque <lrq3000@gmail.com>
 
-This file is part of OpenArena.
+This file is part of ioquake3.
 
-OpenArena is free software; you can redistribute it
+ioquake3 is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-OpenArena is distributed in the hope that it will be
+ioquake3 is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -75,6 +75,14 @@ Sends a command string to a client
 ===============
 */
 void SV_GameSendServerCommand( int clientNum, const char *text ) {
+
+	// record the game server commands in demos
+	if ( sv.demoState == DS_RECORDING ) {
+		SV_DemoWriteGameCommand( clientNum, text );
+	} else if ( sv.demoState == DS_PLAYBACK ) {
+		SV_CheckLastCmd( text, qtrue ); // store the new game command, so when replaying a demo message, we can check for duplicates: maybe this message was already submitted (because of the events simulation, an event may trigger a message), and so we want to avoid those duplicates: if an event already triggered a message, no need to issue the one stored in the demo
+	}
+
 	if ( clientNum == -1 ) {
 		SV_SendServerCommand( NULL, "%s", text );
 	} else {
@@ -376,7 +384,10 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 		return SV_inPVSIgnorePortals( VMA(1), VMA(2) );
 
 	case G_SET_CONFIGSTRING:
-		SV_SetConfigstring( args[1], VMA(2) );
+		// Don't allow the game to overwrite demo configstrings (unless it modifies the normal spectator clients configstrings, this exception allows for player connecting during a demo playback to be correctly rendered, else they will get an empty configstring so no icon, no name, nothing...)
+		if ( (sv_democlients->integer > 0 && args[1] >= CS_PLAYERS + sv_democlients->integer && args[1] < CS_PLAYERS + sv_maxclients->integer) || sv.demoState != DS_PLAYBACK ) { // ATTENTION: sv.demoState check must be placed LAST! Else, it will short-circuit and prevent normal players configstrings from being set!
+			SV_SetConfigstring( args[1], VMA(2) );
+		}
 		return 0;
 	case G_GET_CONFIGSTRING:
 		SV_GetConfigstring( args[1], VMA(2), args[3] );

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -124,6 +124,11 @@ void SV_SetConfigstring (int index, const char *val) {
 	Z_Free( sv.configstrings[index] );
 	sv.configstrings[index] = CopyString( val );
 
+	// save config strings to demo
+	if (sv.demoState == DS_RECORDING) {
+		SV_DemoWriteConfigString( index, val );
+	}
+
 	// send it to all the clients if we aren't
 	// spawning a new server
 	if ( sv.state == SS_GAME || sv.restarting ) {
@@ -180,6 +185,11 @@ void SV_SetUserinfo( int index, const char *val ) {
 
 	if ( !val ) {
 		val = "";
+	}
+
+	// Save userinfo changes to demo (also in SV_UpdateUserinfo_f() in sv_client.c)
+	if ( sv.demoState == DS_RECORDING ) {
+		SV_DemoWriteClientUserinfo( &svs.clients[index], val );
 	}
 
 	Q_strncpyz( svs.clients[index].userinfo, val, sizeof( svs.clients[ index ].userinfo ) );
@@ -356,6 +366,121 @@ void SV_ChangeMaxClients( void ) {
 	}
 }
 
+
+/*
+==================
+SV_DemoChangeMaxClients
+change sv_maxclients and move real clients slots when a demo is playing or stopped
+==================
+*/
+void SV_DemoChangeMaxClients( void ) {
+        int             oldMaxClients, oldDemoClients;
+        int             i, j, k;
+        client_t        *oldClients = NULL;
+        int             count;
+        //qboolean firstTime = svs.clients == NULL;
+
+
+	// == Checking the prerequisites
+	// Note: we check  here that we have enough slots to fit all clients, and that it doesn't overflow the MAX_CLIENTS the engine can support. Also, we save the oldMaxClients and oldDemoClients values.
+
+        // -- Get the highest client number in use
+	count = 0;
+	for ( i = 0 ; i < sv_maxclients->integer ; i++ ) {
+		if ( svs.clients[i].state >= CS_CONNECTED ) {
+			if (i > count)
+				count = i;
+		}
+	}
+	count++;
+
+	// -- Save the previous oldMaxClients and oldDemoClients values, and update
+
+	// Save the previous sv_maxclients value before updating it
+        oldMaxClients = sv_maxclients->integer;
+        // update the cvars
+        Cvar_Get( "sv_maxclients", "8", 0 );
+        Cvar_Get( "sv_democlients", "0", 0 ); // unnecessary now that sv_democlients is not latched anymore?
+	// Save the previous sv_democlients (since it's updated instantly, we cannot get it directly), we use a trick by computing the difference between the new and previous sv_maxclients (the difference should indeed be the exact value of sv_democlients)
+	oldDemoClients = (oldMaxClients - sv_maxclients->integer);
+	if (oldDemoClients < 0) // if the difference is negative, this means that before it was set to 0 (because the newer sv_maxclients is greater than the old)
+		oldDemoClients = 0;
+
+	// -- Check limits
+	// never go below the highest client number in use (make sure we have enough room for all players)
+	SV_BoundMaxClients( count );
+
+        // -- Change check: if still the same, we just quit, there's nothing to do
+        if ( sv_maxclients->integer == oldMaxClients ) {
+                return;
+        }
+
+
+	// == Memorizing clients
+	// Note: we save in a temporary variables the clients, because after we will wipe completely the svs.clients struct
+
+	// copy the clients to hunk memory
+	oldClients = Hunk_AllocateTempMemory( (sv_maxclients->integer - sv_democlients->integer) * sizeof(client_t) ); // we allocate just enough memory for the real clients (not counting in the democlients)
+	// For all previous clients slots, we copy the entire client into a temporary var
+	for ( i = 0, j = 0, k = sv_privateClients->integer ; i < oldMaxClients ; i++ ) { // for all the previously connected clients, we copy them to a temporary var
+		// If there is a real client in this slot
+		if ( svs.clients[i].state >= CS_CONNECTED ) {
+			// if the client is in a privateClient reserved slot, we move him on the reserved slots
+			if (i >= oldDemoClients && i < oldDemoClients + sv_privateClients->integer) {
+				oldClients[j++] = svs.clients[i];
+			// else the client is not a privateClient, and we move him to the first available slot after the privateClients slots
+			} else {
+				oldClients[k++] = svs.clients[i];
+			}
+		}
+	}
+
+	// Fill in the remaining clients slots with empty clients (else the engine crash when copying into memory svs.clients)
+	for (i=j; i < sv_privateClients->integer; i++) { // Fill the privateClients empty slots
+		Com_Memset(&oldClients[i], 0, sizeof(client_t));
+	}
+	for (i=k; i < (sv_maxclients->integer - sv_democlients->integer); i++) { // Fill the other normal clients slots
+		Com_Memset(&oldClients[i], 0, sizeof(client_t));
+	}
+
+	// free old clients arrays
+	Z_Free( svs.clients );
+
+
+	// == Allocating the new svs.clients and moving the saved clients over from the temporary var
+
+        // allocate new svs.clients
+        svs.clients = Z_Malloc( sv_maxclients->integer * sizeof(client_t) );
+        Com_Memset( svs.clients, 0, sv_maxclients->integer * sizeof(client_t) );
+
+	// copy the clients over (and move them depending on sv_democlients: if >0, move them upwards, if == 0, move them to their original slots)
+	Com_Memcpy( svs.clients + sv_democlients->integer, oldClients, (sv_maxclients->integer - sv_democlients->integer) * sizeof(client_t) );
+
+	// free the old clients on the hunk
+	Hunk_FreeTempMemory( oldClients );
+
+
+	// == Allocating snapshot entities
+
+        // allocate new snapshot entities
+        if ( com_dedicated->integer ) {
+                svs.numSnapshotEntities = sv_maxclients->integer * PACKET_BACKUP * 64;
+        } else {
+                // we don't need nearly as many when playing locally
+                svs.numSnapshotEntities = sv_maxclients->integer * 4 * 64;
+        }
+
+
+	// == Server-side demos management
+
+	// set demostate to none if it was just waiting to set maxclients and move real clients slots
+	if (sv.demoState == DS_WAITINGSTOP) {
+		sv.demoState = DS_NONE;
+		Cvar_SetValue("sv_demoState", DS_NONE);
+	}
+
+}
+
 /*
 ================
 SV_ClearServer
@@ -376,7 +501,7 @@ static void SV_ClearServer(void) {
 ================
 SV_TouchCGame
 
-  touch the cgame.vm so that a pure client can load it if it's in a seperate pk3
+Touch the cgame.qvm and ui.qvm so that a pure client can load it if it's in a separate pk3, and so it gets on the download list
 ================
 */
 static void SV_TouchCGame(void) {
@@ -431,7 +556,11 @@ void SV_SpawnServer( char *server, qboolean killBots ) {
 	} else {
 		// check for maxclients change
 		if ( sv_maxclients->modified ) {
-			SV_ChangeMaxClients();
+			// If we are playing/waiting to play/waiting to stop a demo, we use a specialized function that will move real clients slots (so that democlients will be put to their original slots they were affected at the time of the real game)
+			if (sv.demoState == DS_WAITINGPLAYBACK || sv.demoState == DS_PLAYBACK || sv.demoState == DS_WAITINGSTOP)
+				SV_DemoChangeMaxClients();
+			else
+				SV_ChangeMaxClients();
 		}
 	}
 
@@ -618,6 +747,11 @@ void SV_SpawnServer( char *server, qboolean killBots ) {
 #endif
 
 	Com_Printf ("-----------------------------------\n");
+
+	// start recording a demo
+    if ( sv_autoDemo->integer ) {
+        SV_DemoAutoDemoRecord();
+    }
 }
 
 /*
@@ -692,6 +826,13 @@ void SV_Init (void)
 #endif
 	sv_banFile = Cvar_Get("sv_banFile", "serverbans.dat", CVAR_ARCHIVE);
 
+	// serverside demo recording variables
+	sv_demoState = Cvar_Get ("sv_demoState", "0", CVAR_ROM );
+	sv_democlients = Cvar_Get ("sv_democlients", "0", CVAR_ROM );
+	sv_autoDemo = Cvar_Get ("sv_autoDemo", "0", CVAR_ARCHIVE );
+	cl_freezeDemo = Cvar_Get("cl_freezeDemo", "0", CVAR_TEMP); // port from client-side to freeze server-side demos
+	sv_demoTolerant = Cvar_Get ("sv_demoTolerant", "0", CVAR_ARCHIVE );
+
 	// initialize bot cvars so they are listed and can be set before loading the botlib
 	SV_BotInitCvars();
 
@@ -759,6 +900,12 @@ void SV_Shutdown( char *finalmsg ) {
 	SV_RemoveOperatorCommands();
 	SV_MasterShutdown();
 	SV_ShutdownGameProgs();
+
+	// stop any demos
+	if (sv.demoState == DS_RECORDING)
+		SV_DemoStopRecord();
+	if (sv.demoState == DS_PLAYBACK)
+		SV_DemoStopPlayback();
 
 	// free current level
 	SV_ClearServer();

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -38,6 +38,7 @@ cvar_t	*sv_rconPassword;		// password for remote server commands
 cvar_t	*sv_privatePassword;		// password for the privateClient slots
 cvar_t	*sv_allowDownload;
 cvar_t	*sv_maxclients;
+cvar_t	*sv_democlients;		// number of slots reserved for playing a demo
 
 cvar_t	*sv_privateClients;		// number of clients reserved for password
 cvar_t	*sv_hostname;
@@ -62,6 +63,11 @@ cvar_t	*sv_lanForceRate; // dedicated 1 (LAN) server forces local client rates t
 cvar_t	*sv_strictAuth;
 #endif
 cvar_t	*sv_banFile;
+
+cvar_t	*sv_demoState;
+cvar_t	*sv_autoDemo;
+cvar_t	*cl_freezeDemo; // to freeze server-side demos
+cvar_t	*sv_demoTolerant;
 
 serverBan_t serverBans[SERVER_MAXBANS];
 int serverBansCount = 0;
@@ -207,6 +213,12 @@ void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...) {
 	// hack to echo broadcast prints to console
 	if ( com_dedicated->integer && !strncmp( (char *)message, "print", 5) ) {
 		Com_Printf ("broadcast: %s\n", SV_ExpandNewlines((char *)message) );
+	}
+
+	// save broadcasts to demo
+	// note: in the case a command is only issued to a specific client, it is NOT recorded (see above when cl != NULL). If you want to record them, just place this code above, but be warned that it may be dangerous (such as "disconnect" command) because server commands will be replayed to every connected clients!
+	if ( sv.demoState == DS_RECORDING ) {
+		SV_DemoWriteServerCommand( (char *)message );
 	}
 
 	// send the data to all relevent clients
@@ -659,8 +671,8 @@ void SVC_Info( netadr_t from ) {
 	Info_SetValueForKey( infostring, "mapname", sv_mapname->string );
 	Info_SetValueForKey( infostring, "clients", va("%i", count) );
 	Info_SetValueForKey(infostring, "g_humanplayers", va("%i", humans));
-	Info_SetValueForKey( infostring, "sv_maxclients", 
-		va("%i", sv_maxclients->integer - sv_privateClients->integer ) );
+	Info_SetValueForKey( infostring, "sv_maxclients",
+		va("%i", sv_maxclients->integer - sv_privateClients->integer - sv_democlients->integer ) );
 	Info_SetValueForKey( infostring, "gametype", va("%i", sv_gametype->integer ) );
 	Info_SetValueForKey( infostring, "pure", va("%i", sv_pure->integer ) );
 	Info_SetValueForKey(infostring, "g_needpass", va("%d", Cvar_VariableIntegerValue("g_needpass")));
@@ -1145,6 +1157,14 @@ void SV_Frame( int msec ) {
 
 		// let everything in the world think and move
 		VM_Call (gvm, GAME_RUN_FRAME, sv.time);
+
+		// play/record demo frame (if enabled)
+		if (sv.demoState == DS_RECORDING) // Record the frame
+			SV_DemoWriteFrame();
+		else if (sv.demoState == DS_WAITINGPLAYBACK || Cvar_VariableIntegerValue("sv_demoState") == DS_WAITINGPLAYBACK) // Launch again the playback of the demo (because we needed a restart in order to set some cvars such as sv_maxclients or fs_game)
+			SV_DemoRestartPlayback();
+		else if (sv.demoState == DS_PLAYBACK) // Play the next demo frame
+			SV_DemoReadFrame();
 	}
 
 	if ( com_speeds->integer ) {

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -650,7 +650,7 @@ void SV_SendClientMessages(void)
 	{
 		c = &svs.clients[i];
 		
-		if(!c->state)
+		if(!c->state || c->demoClient) // do not send a packet to a democlient, this will cause the engine to crash
 			continue;		// not connected
 
 		if(*c->downloadName)

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -141,7 +141,7 @@ char *Sys_SteamPath( void )
 	DWORD pathLen = MAX_OSPATH;
 	qboolean finishPath = qfalse;
 
-#ifdef STEAMPATH_APPID
+#if defined(STEAMPATH_APPID) && defined(KEY_WOW64_32KEY)
 	// Assuming Steam is a 32-bit app
 	if (!steamPath[0] && !RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App " STEAMPATH_APPID, 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steamRegKey))
 	{


### PR DESCRIPTION
This patch implements server-side demos in a mod-agnostic way, since it only relies on server-side modification and data.

This patch works by storing all entities states info and then replaying them like "ghost" entities. Both servers and clients can replay these demos (servers are also accessible for spectators, making this patch a great replacement for GTV - it could also be extended to allow realtime rebroadcasting of games).

This patch was already tested on several competitions servers for years (eg, this [current ExcessivePlus competition](https://www.excessiveplus.net/forums/thread/hit-tournament-2017?page=6)), so it is quite stable, and memory issues have been resolved using Valgrind.

TODO:
* Add in ioq3 readme the new commands (and delete the server-side demos readme, it's provided for your info, as I don't know how to format the ioq3 readme).