### PR TITLE
Error correction for network packets (proof of concept)

### DIFF
--- a/code/rscode/LICENSE
+++ b/code/rscode/LICENSE
@@ -1,0 +1,10 @@
+ * (C) Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE. [See file gpl.txt]
+ * 
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Latest source code and other info at http://rscode.sourceforge.net
+

--- a/code/rscode/Makefile
+++ b/code/rscode/Makefile
@@ -1,0 +1,50 @@
+# Makefile for Cross Interleaved Reed Solomon encoder/decoder
+#
+# (c) Henry Minsky, Universal Access 1991-1996
+#
+
+RANLIB = ranlib
+AR = ar
+
+
+VERSION = 1.0
+DIRNAME= rscode-$(VERSION)
+
+
+CC = gcc
+# OPTIMIZE_FLAGS = -O69
+DEBUG_FLAGS = -g
+CFLAGS = -Wall -Wstrict-prototypes  $(OPTIMIZE_FLAGS) $(DEBUG_FLAGS) -I..
+LDFLAGS = $(OPTIMIZE_FLAGS) $(DEBUG_FLAGS)
+
+LIB_CSRC = rs.c galois.c berlekamp.c crcgen.c 
+LIB_HSRC = ecc.h
+LIB_OBJS = rs.o galois.o berlekamp.o crcgen.o 
+
+TARGET_LIB = libecc.a
+TEST_PROGS = example
+
+TARGETS = $(TARGET_LIB) $(TEST_PROGS)
+
+all: $(TARGETS)
+
+$(TARGET_LIB): $(LIB_OBJS)
+	$(RM) $@
+	$(AR) cq $@ $(LIB_OBJS)
+	if [ "$(RANLIB)" ]; then $(RANLIB) $@; fi
+
+example: example.o galois.o berlekamp.o crcgen.o rs.o
+	gcc -o example example.o -L. -lecc
+
+clean:
+	rm -f *.o example libecc.a
+	rm -f *~
+
+dist:
+	(cd ..; tar -cvf rscode-$(VERSION).tar $(DIRNAME))
+
+depend:
+	makedepend $(SRCS)
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+

--- a/code/rscode/README
+++ b/code/rscode/README
@@ -1,0 +1,27 @@
+RSCODE version 1.3
+
+See the files
+
+config.doc 	documentation of some compile time parameters
+rs.doc 		overview of the Reed-Solomon coding program
+rs.man		a man page, slightly outdated at this point
+example.c	a simple example of encoding,decoding, and error correction
+
+Makefile	should work on a Sun system, may require GNU make.
+
+
+Henry Minsky
+hqm@alum.mit.edu
+
+
+ * (c) Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE. (See gpl.txt)
+ * 
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+
+

--- a/code/rscode/berlekamp.c
+++ b/code/rscode/berlekamp.c
@@ -1,0 +1,324 @@
+/***********************************************************************
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ * 
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+ * Berlekamp-Peterson and Berlekamp-Massey Algorithms for error-location
+ *
+ * From Cain, Clark, "Error-Correction Coding For Digital Communications", pp. 205.
+ *
+ * This finds the coefficients of the error locator polynomial.
+ *
+ * The roots are then found by looking for the values of a^n
+ * where evaluating the polynomial yields zero.
+ *
+ * Error correction is done using the error-evaluator equation  on pp 207.
+ *
+ */
+
+#include <stdio.h>
+#include "ecc.h"
+
+/* The Error Locator Polynomial, also known as Lambda or Sigma. Lambda[0] == 1 */
+static int Lambda[MAXDEG];
+
+/* The Error Evaluator Polynomial */
+static int Omega[MAXDEG];
+
+/* local ANSI declarations */
+static int compute_discrepancy(int lambda[], int S[], int L, int n);
+static void init_gamma(int gamma[]);
+static void compute_modified_omega (void);
+static void mul_z_poly (int src[]);
+
+/* error locations found using Chien's search*/
+static int ErrorLocs[256];
+static int NErrors;
+
+/* erasure flags */
+static int ErasureLocs[256];
+static int NErasures;
+
+/* From  Cain, Clark, "Error-Correction Coding For Digital Communications", pp. 216. */
+void
+Modified_Berlekamp_Massey (void)
+{	
+  int n, L, L2, k, d, i;
+  int psi[MAXDEG], psi2[MAXDEG], D[MAXDEG];
+  int gamma[MAXDEG];
+	
+  /* initialize Gamma, the erasure locator polynomial */
+  init_gamma(gamma);
+
+  /* initialize to z */
+  copy_poly(D, gamma);
+  mul_z_poly(D);
+	
+  copy_poly(psi, gamma);	
+  k = -1; L = NErasures;
+	
+  for (n = NErasures; n < NPAR; n++) {
+	
+    d = compute_discrepancy(psi, synBytes, L, n);
+		
+    if (d != 0) {
+		
+      /* psi2 = psi - d*D */
+      for (i = 0; i < MAXDEG; i++) psi2[i] = psi[i] ^ gmult(d, D[i]);
+		
+		
+      if (L < (n-k)) {
+	L2 = n-k;
+	k = n-L;
+	/* D = scale_poly(ginv(d), psi); */
+	for (i = 0; i < MAXDEG; i++) D[i] = gmult(psi[i], ginv(d));
+	L = L2;
+      }
+			
+      /* psi = psi2 */
+      for (i = 0; i < MAXDEG; i++) psi[i] = psi2[i];
+    }
+		
+    mul_z_poly(D);
+  }
+	
+  for(i = 0; i < MAXDEG; i++) Lambda[i] = psi[i];
+  compute_modified_omega();
+
+	
+}
+
+/* given Psi (called Lambda in Modified_Berlekamp_Massey) and synBytes,
+   compute the combined erasure/error evaluator polynomial as 
+   Psi*S mod z^4
+  */
+void
+compute_modified_omega ()
+{
+  int i;
+  int product[MAXDEG*2];
+	
+  mult_polys(product, Lambda, synBytes);	
+  zero_poly(Omega);
+  for(i = 0; i < NPAR; i++) Omega[i] = product[i];
+
+}
+
+/* polynomial multiplication */
+void
+mult_polys (int dst[], int p1[], int p2[])
+{
+  int i, j;
+  int tmp1[MAXDEG*2];
+	
+  for (i=0; i < (MAXDEG*2); i++) dst[i] = 0;
+	
+  for (i = 0; i < MAXDEG; i++) {
+    for(j=MAXDEG; j<(MAXDEG*2); j++) tmp1[j]=0;
+		
+    /* scale tmp1 by p1[i] */
+    for(j=0; j<MAXDEG; j++) tmp1[j]=gmult(p2[j], p1[i]);
+    /* and mult (shift) tmp1 right by i */
+    for (j = (MAXDEG*2)-1; j >= i; j--) tmp1[j] = tmp1[j-i];
+    for (j = 0; j < i; j++) tmp1[j] = 0;
+		
+    /* add into partial product */
+    for(j=0; j < (MAXDEG*2); j++) dst[j] ^= tmp1[j];
+  }
+}
+
+
+	
+/* gamma = product (1-z*a^Ij) for erasure locs Ij */
+void
+init_gamma (int gamma[])
+{
+  int e, tmp[MAXDEG];
+	
+  zero_poly(gamma);
+  zero_poly(tmp);
+  gamma[0] = 1;
+	
+  for (e = 0; e < NErasures; e++) {
+    copy_poly(tmp, gamma);
+    scale_poly(gexp[ErasureLocs[e]], tmp);
+    mul_z_poly(tmp);
+    add_polys(gamma, tmp);
+  }
+}
+	
+	
+	
+void 
+compute_next_omega (int d, int A[], int dst[], int src[])
+{
+  int i;
+  for ( i = 0; i < MAXDEG;  i++) {
+    dst[i] = src[i] ^ gmult(d, A[i]);
+  }
+}
+	
+
+
+int
+compute_discrepancy (int lambda[], int S[], int L, int n)
+{
+  int i, sum=0;
+	
+  for (i = 0; i <= L; i++) 
+    sum ^= gmult(lambda[i], S[n-i]);
+  return (sum);
+}
+
+/********** polynomial arithmetic *******************/
+
+void add_polys (int dst[], int src[]) 
+{
+  int i;
+  for (i = 0; i < MAXDEG; i++) dst[i] ^= src[i];
+}
+
+void copy_poly (int dst[], int src[]) 
+{
+  int i;
+  for (i = 0; i < MAXDEG; i++) dst[i] = src[i];
+}
+
+void scale_poly (int k, int poly[]) 
+{	
+  int i;
+  for (i = 0; i < MAXDEG; i++) poly[i] = gmult(k, poly[i]);
+}
+
+
+void zero_poly (int poly[]) 
+{
+  int i;
+  for (i = 0; i < MAXDEG; i++) poly[i] = 0;
+}
+
+
+/* multiply by z, i.e., shift right by 1 */
+static void mul_z_poly (int src[])
+{
+  int i;
+  for (i = MAXDEG-1; i > 0; i--) src[i] = src[i-1];
+  src[0] = 0;
+}
+
+
+/* Finds all the roots of an error-locator polynomial with coefficients
+ * Lambda[j] by evaluating Lambda at successive values of alpha. 
+ * 
+ * This can be tested with the decoder's equations case.
+ */
+
+
+void 
+Find_Roots (void)
+{
+  int sum, r, k;	
+  NErrors = 0;
+  
+  for (r = 1; r < 256; r++) {
+    sum = 0;
+    /* evaluate lambda at r */
+    for (k = 0; k < NPAR+1; k++) {
+      sum ^= gmult(gexp[(k*r)%255], Lambda[k]);
+    }
+    if (sum == 0) 
+      { 
+	ErrorLocs[NErrors] = (255-r); NErrors++; 
+	if (DEBUG) fprintf(stderr, "Root found at r = %d, (255-r) = %d\n", r, (255-r));
+      }
+  }
+}
+
+/* Combined Erasure And Error Magnitude Computation 
+ * 
+ * Pass in the codeword, its size in bytes, as well as
+ * an array of any known erasure locations, along the number
+ * of these erasures.
+ * 
+ * Evaluate Omega(actually Psi)/Lambda' at the roots
+ * alpha^(-i) for error locs i. 
+ *
+ * Returns 1 if everything ok, or 0 if an out-of-bounds error is found
+ *
+ */
+
+int
+correct_errors_erasures (unsigned char codeword[], 
+			 int csize,
+			 int nerasures,
+			 int erasures[])
+{
+  int r, i, j, err;
+
+  /* If you want to take advantage of erasure correction, be sure to
+     set NErasures and ErasureLocs[] with the locations of erasures. 
+     */
+  NErasures = nerasures;
+  for (i = 0; i < NErasures; i++) ErasureLocs[i] = erasures[i];
+
+  Modified_Berlekamp_Massey();
+  Find_Roots();
+  
+
+  if ((NErrors <= NPAR) && NErrors > 0) { 
+
+    /* first check for illegal error locs */
+    for (r = 0; r < NErrors; r++) {
+      if (ErrorLocs[r] >= csize) {
+	if (DEBUG) fprintf(stderr, "Error loc i=%d outside of codeword length %d\n", i, csize);
+	return(0);
+      }
+    }
+
+    for (r = 0; r < NErrors; r++) {
+      int num, denom;
+      i = ErrorLocs[r];
+      /* evaluate Omega at alpha^(-i) */
+
+      num = 0;
+      for (j = 0; j < MAXDEG; j++) 
+	num ^= gmult(Omega[j], gexp[((255-i)*j)%255]);
+      
+      /* evaluate Lambda' (derivative) at alpha^(-i) ; all odd powers disappear */
+      denom = 0;
+      for (j = 1; j < MAXDEG; j += 2) {
+	denom ^= gmult(Lambda[j], gexp[((255-i)*(j-1)) % 255]);
+      }
+      
+      err = gmult(num, ginv(denom));
+      if (DEBUG) fprintf(stderr, "Error magnitude %#x at loc %d\n", err, csize-i);
+      
+      codeword[csize-i-1] ^= err;
+    }
+    return(1);
+  }
+  else {
+    if (DEBUG && NErrors) fprintf(stderr, "Uncorrectable codeword\n");
+    return(0);
+  }
+}
+

--- a/code/rscode/config.doc
+++ b/code/rscode/config.doc
@@ -1,0 +1,18 @@
+The basic coding parameters are defined using
+macros, and an executable can be made by compiling using macro
+definitions defining the values of the following names in the file
+"ecc.h":
+
+The important compile time parameter is the number of parity bytes,
+specified by the #define NPAR.
+
+The library is shipped with 
+
+#define NPAR 4
+
+The error-correction routines are polynomial in the number of
+parity bytes, so try to keep NPAR small for high performance.
+
+Remember, the sum of the message length (in bytes) plus parity bytes
+must be less than or equal to 255. 
+

--- a/code/rscode/crcgen.c
+++ b/code/rscode/crcgen.c
@@ -1,0 +1,66 @@
+/*****************************
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+ *
+ * CRC-CCITT generator simulator for byte wide data.
+ *
+ *
+ * CRC-CCITT = x^16 + x^12 + x^5 + 1
+ *
+ *
+ ******************************/
+ 
+ 
+#include "ecc.h"
+
+BIT16 crchware(BIT16 data, BIT16 genpoly, BIT16 accum);
+
+/* Computes the CRC-CCITT checksum on array of byte data, length len
+*/
+BIT16 crc_ccitt(unsigned char *msg, int len)
+{
+	int i;
+	BIT16 acc = 0;
+
+	for (i = 0; i < len; i++) {
+		acc = crchware((BIT16) msg[i], (BIT16) 0x1021, acc);
+	}
+	
+	return(acc);
+}
+	
+/* models crc hardware (minor variation on polynomial division algorithm) */
+BIT16 crchware(BIT16 data, BIT16 genpoly, BIT16 accum)
+{
+	static BIT16 i;
+	data <<= 8;
+	for (i = 8; i > 0; i--) {
+		if ((data ^ accum) & 0x8000)
+			accum = ((accum << 1) ^ genpoly) & 0xFFFF;
+		else
+			accum = (accum<<1) & 0xFFFF;
+		data = (data<<1) & 0xFFFF;
+	}
+	return (accum);
+}
+		

--- a/code/rscode/ecc.h
+++ b/code/rscode/ecc.h
@@ -1,0 +1,100 @@
+/* Reed Solomon Coding for glyphs
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+ *
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ */
+
+/****************************************************************
+  
+  Below is NPAR, the only compile-time parameter you should have to
+  modify.
+  
+  It is the number of parity bytes which will be appended to
+  your data to create a codeword.
+
+  Note that the maximum codeword size is 255, so the
+  sum of your message length plus parity should be less than
+  or equal to this maximum limit.
+
+  In practice, you will get slooow error correction and decoding
+  if you use more than a reasonably small number of parity bytes.
+  (say, 10 or 20)
+
+  ****************************************************************/
+
+#define NPAR 4
+
+/****************************************************************/
+
+
+
+
+#define TRUE 1
+#define FALSE 0
+
+typedef unsigned long BIT32;
+typedef unsigned short BIT16;
+
+/* **************************************************************** */
+
+/* Maximum degree of various polynomials. */
+#define MAXDEG (NPAR*2)
+
+/*************************************/
+/* Encoder parity bytes */
+extern int pBytes[MAXDEG];
+
+/* Decoder syndrome bytes */
+extern int synBytes[MAXDEG];
+
+/* print debugging info */
+extern int DEBUG;
+
+/* Reed Solomon encode/decode routines */
+void initialize_ecc (void);
+int check_syndrome (void);
+void decode_data (unsigned char data[], int nbytes);
+void encode_data (unsigned char msg[], int nbytes, unsigned char dst[]);
+
+/* CRC-CCITT checksum generator */
+BIT16 crc_ccitt(unsigned char *msg, int len);
+
+/* galois arithmetic tables */
+extern int gexp[];
+extern int glog[];
+
+void init_galois_tables (void);
+int ginv(int elt); 
+int gmult(int a, int b);
+
+
+/* Error location routines */
+int correct_errors_erasures (unsigned char codeword[], int csize,int nerasures, int erasures[]);
+
+/* polynomial arithmetic */
+void add_polys(int dst[], int src[]) ;
+void scale_poly(int k, int poly[]);
+void mult_polys(int dst[], int p1[], int p2[]);
+
+void copy_poly(int dst[], int src[]);
+void zero_poly(int poly[]);

--- a/code/rscode/example.c
+++ b/code/rscode/example.c
@@ -1,0 +1,128 @@
+/* Example use of Reed-Solomon library 
+ *
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * This same code demonstrates the use of the encodier and 
+ * decoder/error-correction routines. 
+ *
+ * We are assuming we have at least four bytes of parity (NPAR >= 4).
+ * 
+ * This gives us the ability to correct up to two errors, or 
+ * four erasures. 
+ *
+ * In general, with E errors, and K erasures, you will need
+ * 2E + K bytes of parity to be able to correct the codeword
+ * back to recover the original message data.
+ *
+ * You could say that each error 'consumes' two bytes of the parity,
+ * whereas each erasure 'consumes' one byte.
+ *
+ * Thus, as demonstrated below, we can inject one error (location unknown)
+ * and two erasures (with their locations specified) and the 
+ * error-correction routine will be able to correct the codeword
+ * back to the original message.
+ * */
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include "ecc.h"
+ 
+unsigned char msg[] = "Nervously I loaded the twin ducks aboard the revolving pl\
+atform.";
+unsigned char codeword[256];
+ 
+/* Some debugging routines to introduce errors or erasures
+   into a codeword. 
+   */
+
+/* Introduce a byte error at LOC */
+void
+byte_err (int err, int loc, unsigned char *dst)
+{
+  printf("Adding Error at loc %d, data %#x\n", loc, dst[loc-1]);
+  dst[loc-1] ^= err;
+}
+
+/* Pass in location of error (first byte position is
+   labeled starting at 1, not 0), and the codeword.
+*/
+void
+byte_erasure (int loc, unsigned char dst[], int cwsize, int erasures[]) 
+{
+  printf("Erasure at loc %d, data %#x\n", loc, dst[loc-1]);
+  dst[loc-1] = 0;
+}
+
+
+int
+main (int argc, char *argv[])
+{
+ 
+  int erasures[16];
+  int nerasures = 0;
+
+  /* Initialization the ECC library */
+ 
+  initialize_ecc ();
+ 
+  /* ************** */
+ 
+  /* Encode data into codeword, adding NPAR parity bytes */
+  encode_data(msg, sizeof(msg), codeword);
+ 
+  printf("Encoded data is: \"%s\"\n", codeword);
+ 
+#define ML (sizeof (msg) + NPAR)
+
+
+  /* Add one error and two erasures */
+  byte_err(0x35, 3, codeword);
+
+  byte_err(0x23, 17, codeword);
+  byte_err(0x34, 19, codeword);
+
+
+  printf("with some errors: \"%s\"\n", codeword);
+
+  /* We need to indicate the position of the erasures.  Eraseure
+     positions are indexed (1 based) from the end of the message... */
+
+  erasures[nerasures++] = ML-17;
+  erasures[nerasures++] = ML-19;
+
+ 
+  /* Now decode -- encoded codeword size must be passed */
+  decode_data(codeword, ML);
+
+  /* check if syndrome is all zeros */
+  if (check_syndrome () != 0) {
+    correct_errors_erasures (codeword, 
+			     ML,
+			     nerasures, 
+			     erasures);
+ 
+    printf("Corrected codeword: \"%s\"\n", codeword);
+  }
+ 
+  exit(0);
+}
+

--- a/code/rscode/galois.c
+++ b/code/rscode/galois.c
@@ -1,0 +1,112 @@
+/*****************************
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+ * 
+ *
+ * Multiplication and Arithmetic on Galois Field GF(256)
+ *
+ * From Mee, Daniel, "Magnetic Recording, Volume III", Ch. 5 by Patel.
+ * 
+ *
+ ******************************/
+ 
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include "ecc.h"
+
+/* This is one of 14 irreducible polynomials
+ * of degree 8 and cycle length 255. (Ch 5, pp. 275, Magnetic Recording)
+ * The high order 1 bit is implicit */
+/* x^8 + x^4 + x^3 + x^2 + 1 */
+#define PPOLY 0x1D 
+
+
+int gexp[512];
+int glog[256];
+
+
+static void init_exp_table (void);
+
+
+void
+init_galois_tables (void)
+{	
+  /* initialize the table of powers of alpha */
+  init_exp_table();
+}
+
+
+static void
+init_exp_table (void)
+{
+  int i, z;
+  int pinit,p1,p2,p3,p4,p5,p6,p7,p8;
+
+  pinit = p2 = p3 = p4 = p5 = p6 = p7 = p8 = 0;
+  p1 = 1;
+	
+  gexp[0] = 1;
+  gexp[255] = gexp[0];
+  glog[0] = 0;			/* shouldn't log[0] be an error? */
+	
+  for (i = 1; i < 256; i++) {
+    pinit = p8;
+    p8 = p7;
+    p7 = p6;
+    p6 = p5;
+    p5 = p4 ^ pinit;
+    p4 = p3 ^ pinit;
+    p3 = p2 ^ pinit;
+    p2 = p1;
+    p1 = pinit;
+    gexp[i] = p1 + p2*2 + p3*4 + p4*8 + p5*16 + p6*32 + p7*64 + p8*128;
+    gexp[i+255] = gexp[i];
+  }
+	
+  for (i = 1; i < 256; i++) {
+    for (z = 0; z < 256; z++) {
+      if (gexp[z] == i) {
+	glog[i] = z;
+	break;
+      }
+    }
+  }
+}
+
+/* multiplication using logarithms */
+int gmult(int a, int b)
+{
+  int i,j;
+  if (a==0 || b == 0) return (0);
+  i = glog[a];
+  j = glog[b];
+  return (gexp[i+j]);
+}
+		
+
+int ginv (int elt) 
+{ 
+  return (gexp[255-glog[elt]]);
+}
+

--- a/code/rscode/gpl.txt
+++ b/code/rscode/gpl.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/code/rscode/rs.c
+++ b/code/rscode/rs.c
@@ -1,0 +1,201 @@
+/* 
+ * Reed Solomon Encoder/Decoder 
+ *
+ * Copyright Henry Minsky (hqm@alum.mit.edu) 1991-2009
+ *
+ * This software library is licensed under terms of the GNU GENERAL
+ * PUBLIC LICENSE
+ *
+ * RSCODE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * RSCODE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rscode.  If not, see <http://www.gnu.org/licenses/>.
+
+ * Commercial licensing is available under a separate license, please
+ * contact author for details.
+ *
+ * Source code is available at http://rscode.sourceforge.net
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+#include "ecc.h"
+
+/* Encoder parity bytes */
+int pBytes[MAXDEG];
+
+/* Decoder syndrome bytes */
+int synBytes[MAXDEG];
+
+/* generator polynomial */
+int genPoly[MAXDEG*2];
+
+int DEBUG = FALSE;
+
+static void
+compute_genpoly (int nbytes, int genpoly[]);
+
+/* Initialize lookup tables, polynomials, etc. */
+void
+initialize_ecc ()
+{
+  /* Initialize the galois field arithmetic tables */
+    init_galois_tables();
+
+    /* Compute the encoder generator polynomial */
+    compute_genpoly(NPAR, genPoly);
+}
+
+void
+zero_fill_from (unsigned char buf[], int from, int to)
+{
+  int i;
+  for (i = from; i < to; i++) buf[i] = 0;
+}
+
+/* debugging routines */
+void
+print_parity (void)
+{ 
+  int i;
+  printf("Parity Bytes: ");
+  for (i = 0; i < NPAR; i++) 
+    printf("[%d]:%x, ",i,pBytes[i]);
+  printf("\n");
+}
+
+
+void
+print_syndrome (void)
+{ 
+  int i;
+  printf("Syndrome Bytes: ");
+  for (i = 0; i < NPAR; i++) 
+    printf("[%d]:%x, ",i,synBytes[i]);
+  printf("\n");
+}
+
+/* Append the parity bytes onto the end of the message */
+void
+build_codeword (unsigned char msg[], int nbytes, unsigned char dst[])
+{
+  int i;
+	
+  for (i = 0; i < nbytes; i++) dst[i] = msg[i];
+	
+  for (i = 0; i < NPAR; i++) {
+    dst[i+nbytes] = pBytes[NPAR-1-i];
+  }
+}
+	
+/**********************************************************
+ * Reed Solomon Decoder 
+ *
+ * Computes the syndrome of a codeword. Puts the results
+ * into the synBytes[] array.
+ */
+ 
+void
+decode_data(unsigned char data[], int nbytes)
+{
+  int i, j, sum;
+  for (j = 0; j < NPAR;  j++) {
+    sum	= 0;
+    for (i = 0; i < nbytes; i++) {
+      sum = data[i] ^ gmult(gexp[j+1], sum);
+    }
+    synBytes[j]  = sum;
+  }
+}
+
+
+/* Check if the syndrome is zero */
+int
+check_syndrome (void)
+{
+ int i, nz = 0;
+ for (i =0 ; i < NPAR; i++) {
+  if (synBytes[i] != 0) {
+      nz = 1;
+      break;
+  }
+ }
+ return nz;
+}
+
+
+void
+debug_check_syndrome (void)
+{	
+  int i;
+	
+  for (i = 0; i < 3; i++) {
+    printf(" inv log S[%d]/S[%d] = %d\n", i, i+1, 
+	   glog[gmult(synBytes[i], ginv(synBytes[i+1]))]);
+  }
+}
+
+
+/* Create a generator polynomial for an n byte RS code. 
+ * The coefficients are returned in the genPoly arg.
+ * Make sure that the genPoly array which is passed in is 
+ * at least n+1 bytes long.
+ */
+
+static void
+compute_genpoly (int nbytes, int genpoly[])
+{
+  int i, tp[256], tp1[256];
+	
+  /* multiply (x + a^n) for n = 1 to nbytes */
+
+  zero_poly(tp1);
+  tp1[0] = 1;
+
+  for (i = 1; i <= nbytes; i++) {
+    zero_poly(tp);
+    tp[0] = gexp[i];		/* set up x+a^n */
+    tp[1] = 1;
+	  
+    mult_polys(genpoly, tp, tp1);
+    copy_poly(tp1, genpoly);
+  }
+}
+
+/* Simulate a LFSR with generator polynomial for n byte RS code. 
+ * Pass in a pointer to the data array, and amount of data. 
+ *
+ * The parity bytes are deposited into pBytes[], and the whole message
+ * and parity are copied to dest to make a codeword.
+ * 
+ */
+
+void
+encode_data (unsigned char msg[], int nbytes, unsigned char dst[])
+{
+  int i, LFSR[NPAR+1],dbyte, j;
+	
+  for(i=0; i < NPAR+1; i++) LFSR[i]=0;
+
+  for (i = 0; i < nbytes; i++) {
+    dbyte = msg[i] ^ LFSR[NPAR-1];
+    for (j = NPAR-1; j > 0; j--) {
+      LFSR[j] = LFSR[j-1] ^ gmult(genPoly[j], dbyte);
+    }
+    LFSR[0] = gmult(genPoly[0], dbyte);
+  }
+
+  for (i = 0; i < NPAR; i++) 
+    pBytes[i] = LFSR[i];
+	
+  build_codeword(msg, nbytes, dst);
+}
+

--- a/code/rscode/rs.doc
+++ b/code/rscode/rs.doc
@@ -1,0 +1,86 @@
+
+
+Introduction to Reed Solomon Codes: 
+
+Henry Minsky, Universal Access Inc.
+hqm@alum.mit.edu
+
+[For details see Cain, Clark, "Error-Correction Coding For Digital
+Communications", pp. 205.] The Reed-Solomon Code is an algebraic code
+belonging to the class of BCH (Bose-Chaudry-Hocquehen) multiple burst
+correcting cyclic codes. The Reed Solomon code operates on bytes of
+fixed length.
+
+Given m parity bytes, a Reed-Solomon code can correct up to m byte
+errors in known positions (erasures), or detect and correct up to m/2
+byte errors in unknown positions.
+
+This is an implementation of a Reed-Solomon code with 8 bit bytes, and
+a configurable number of parity bytes.  The maximum sequence length
+(codeword) that can be generated is 255 bytes, including parity bytes.
+In practice, shorter sequences are used. 
+
+ENCODING: The basic principle of encoding is to find the remainder of
+the message divided by a generator polynomial G(x). The encoder works
+by simulating a Linear Feedback Shift Register with degree equal to
+G(x), and feedback taps with the coefficents of the generating
+polynomial of the code.
+
+The rs.c file contains an algorithm to generate the encoder polynomial
+for any number of bytes of parity, configurable as the NPAR constant
+in the file ecc.h.
+
+For this RS code, G(x) = (x-a^1)(x-a^2)(x-a^3)(x-a^4)...(x-a^NPAR)
+where 'a' is a primitive element of the Galois Field GF(256) (== 2).
+
+DECODING
+
+The decoder generates four syndrome bytes, which will be all zero if
+the message has no errors. If there are errors, the location and value
+of the errors can be determined in a number of ways.
+
+Computing the syndromes is easily done as a sum of products, see pp.
+179 [Rhee 89].
+
+Fundamentally, the syndome bytes form four simultaneous equations
+which can be solved to find the error locations. Once error locations
+are known, the syndrome bytes can be used to find the value of the
+errors, and they can thus be corrected.
+
+A simplified solution for locating and correcting single errors is
+given in Cain and Clark, Ch. 5.
+
+The more general error-location algorithm is the Berlekamp-Massey
+algorithm, which will locate up to four errors, by iteratively solving
+for the error-locator polynomial. The Modified Berlekamp Massey
+algorithm takes as initial conditions any known suspicious bytes
+(erasure flags) which you may have (such as might be flagged by
+a laser demodulator, or deduced from a failure in a cross-interleaved
+block code row or column).
+
+Once the location of errors is known, error correction is done using
+the error-evaluator polynomial.
+
+APPLICATION IDEAS
+
+As an example application, this library could be used to implement the
+Compact Disc standard of 24 data bytes and 4 parity bytes. A RS code
+with 24 data bytes and 4 parity bytes is referred to as a (28,24) RS
+code.  A (n, k) RS code is said to have efficiency k/n. This first
+(28,24) coding is called the C2 or level 2 encoding, because in a
+doubly encoded scheme, the codewords are decoded at the second
+decoding step.
+
+In following the approach used by Compact Disc digital audio, the 28
+byte C2 codewords are four way interleaved and then the interleaved
+data is encoded again with a (32,28) RS code. The is the C1 encoding
+stage. This produces what is known as a "product code", and has
+excellent error correction capability due to the imposition of
+two-dimensional structure on the parity checks. The interleave helps
+to insure against the case that a multibyte burst error wipes out more
+than two bytes in each codeword. The cross-correction capability of
+the product code can provide backup if in fact there are more than 2
+uncorrectable errors in a block.
+
+
+

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -141,7 +141,7 @@ char *Sys_SteamPath( void )
 	DWORD pathLen = MAX_OSPATH;
 	qboolean finishPath = qfalse;
 
-#ifdef STEAMPATH_APPID
+#if defined(STEAMPATH_APPID) && defined(KEY_WOW64_32KEY)
 	// Assuming Steam is a 32-bit app
 	if (!steamPath[0] && !RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App " STEAMPATH_APPID, 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steamRegKey))
 	{


### PR DESCRIPTION
This implements a proof of concept for #124.

The goal is to protect UDP network packets with error correction code (Reed-Solomon), in order to reduce the number of dropped/incorrect packets. This should significantly enhance long-distance reliability (eg, servers in different countries from clients).

This is not made as a replacement to packets duplication, but rather an additional protection mechanism.

This code is currently untested. Help is welcome, particularly in network packets and messages management (I can fix all issues about Reed-Solomon, but I am inexperienced in ioq3 networking).

TODO:
* Make the PR work (of course).
* Implement for fragmented packets.
* Add a cvar to enable/disable.
* Bonus: allow tweaking of number of ecc symbols with a simple sv* cvar. This cvar would be sent by server in the configstring, so that clients would know what number of ecc symbols to use. Would also need to make rscode lib use a runtime variable instead of a constant (see ecc.h `#define NPAR 4`, this is the number of ecc symbols).