### PR TITLE
Map ascii extended characters to K_WORLD_0..95

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -197,6 +197,10 @@ static keyNum_t IN_TranslateSDLToQ3Key( SDL_Keysym *keysym, qboolean down )
 		// These happen to match the ASCII chars
 		key = (int)keysym->sym;
 	}
+	else if (keysym->sym >= 0xA0 && keysym->sym <= 0xFF) {
+		// These are extended ASCII chars, map them to K_WORLD_0..95
+		key = K_WORLD_0 + (keysym->sym - 0xA0);
+	}
 	else
 	{
 		switch( keysym->sym )


### PR DESCRIPTION
This matches the original SDL1 behavior and allows keys such as "²", "é", "ç" and "à" on AZERTY keyboard that are located on the first row (where numbers keys would be on QWERTY).