### PR TITLE
Don't interpret K_KP_DOWNARROW and K_KP_UPARROW in console.

### DIFF
--- a/code/client/cl_keys.c
+++ b/code/client/cl_keys.c
@@ -667,7 +667,7 @@ void Console_Key (int key) {
 
 	// command history (ctrl-p ctrl-n for unix style)
 
-	if ( (key == K_MWHEELUP && keys[K_SHIFT].down) || ( key == K_UPARROW ) || ( key == K_KP_UPARROW ) ||
+	if ( (key == K_MWHEELUP && keys[K_SHIFT].down) || key == K_UPARROW ||
 		 ( ( tolower(key) == 'p' ) && keys[K_CTRL].down ) ) {
 		if ( nextHistoryLine - historyLine < COMMAND_HISTORY 
 			&& historyLine > 0 ) {
@@ -677,7 +677,7 @@ void Console_Key (int key) {
 		return;
 	}
 
-	if ( (key == K_MWHEELDOWN && keys[K_SHIFT].down) || ( key == K_DOWNARROW ) || ( key == K_KP_DOWNARROW ) ||
+	if ( (key == K_MWHEELDOWN && keys[K_SHIFT].down) || key == K_DOWNARROW ||
 		 ( ( tolower(key) == 'n' ) && keys[K_CTRL].down ) ) {
 		historyLine++;
 		if (historyLine >= nextHistoryLine) {


### PR DESCRIPTION
These map to the 2 and 8 on the keypad which makes it impossible to use them on the console for entering numbers.

This is especially important for AZERTY layouts where the number keys are not directly accessible in the first row and using the keypad is more convenient.