### PR TITLE
Add stronger dll name sanity check in Sys_LoadDll

### DIFF
--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -500,8 +500,8 @@ void *Sys_LoadDll(const char *name, qboolean useSystemLib)
 {
 	void *dllhandle;
 	
-	// Don't load any DLLs that end with the pk3 extension
-	if (COM_CompareExtension(name, ".pk3"))
+	// Don't load any DLLs that try to traverse directories
+	if (strstr(name, "/") || strstr(name, "\\") || strstr(name, "..") || strstr(name, "::"))
 	{
 		Com_Printf("Rejecting DLL named \"%s\"", name);
 		return NULL;


### PR DESCRIPTION
This increases the security of Sys_LoadDll by attempting to block loading of all dll files outside the intended source directory, which is more effective than the previous pk3-specific check. Without this patch, a running VM appears able to achieve dll execution using this approach:

- Write a dll using trap_FS_FOpenFile, but using a non-dll extension like .txt to avoid the extension check
- Manipulate a cvar such as cl_renderer or cl_cURLLib to point to the written file, using .. for traversal as needed
- Craft the cvar such that the ending of the filename coincides with the limit of MAX_OSPATH used in Sys_LoadDll, so unwanted data like the real .dll extension gets truncated in Com_sprintf

Note that CVAR_PROTECTED is currently not sufficient to protect the relevant cvars because a VM can use command functions like trap_SendConsoleCommand("set ...") to avoid that restriction.