### PR TITLE
Only allow safe protocols for cURL downloads.

### DIFF
--- a/code/client/cl_curl.c
+++ b/code/client/cl_curl.c
@@ -299,6 +299,8 @@ void CL_cURL_BeginDownload( const char *localName, const char *remoteURL )
 	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_FAILONERROR, 1);
 	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_FOLLOWLOCATION, 1);
 	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_MAXREDIRS, 5);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROTOCOLS,
+		CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP | CURLPROTO_FTPS);
 	clc.downloadCURLM = qcurl_multi_init();	
 	if(!clc.downloadCURLM) {
 		qcurl_easy_cleanup(clc.downloadCURL);


### PR DESCRIPTION
A malicious server could abuse dangerous protocols such as gopher:// to,
for instance, send mail via SMTP.