### PR TITLE
Makefile: using generic windres if specific one is not present in mingw platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,9 +530,11 @@ ifdef MINGW
       CC=gcc
     endif
 
-    ifndef WINDRES
-      WINDRES=windres
-    endif
+  endif
+
+  # using generic windres if specific one is not present
+  ifndef WINDRES
+    WINDRES=windres
   endif
 
   ifeq ($(CC),)


### PR DESCRIPTION
If [platform specific](https://cygwin.com/cgi-bin2/package-cat.cgi?file=x86_64%2Fmingw64-x86_64-binutils%2Fmingw64-x86_64-binutils-2.25.0.1.23f238d-1&grep=windres) binutils is not installed, but [generic binutils](https://cygwin.com/cgi-bin2/package-cat.cgi?file=x86_64%2Fbinutils%2Fbinutils-2.25-4&grep=windres) is installed, WINDRES equals to empty string. In this situation when make tries to call 

> $(WINDRES) bebebe

it will fail with "bebebe command not found". This commit sets default value for WINDRES for mingw platform