### PR TITLE
Freebsd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,7 +654,7 @@ else # ifdef MINGW
 ifeq ($(PLATFORM),freebsd)
 
   # flags
-  BASE_CFLAGS = $(shell env MACHINE_ARCH=$(ARCH) make -f /dev/null -VCFLAGS) \
+  BASE_CFLAGS = \
     -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
     -DUSE_ICON -DMAP_ANONYMOUS=MAP_ANON
   CLIENT_CFLAGS += $(SDL_CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -660,7 +660,7 @@ ifeq ($(PLATFORM),freebsd)
   CLIENT_CFLAGS += $(SDL_CFLAGS)
   HAVE_VM_COMPILED = true
 
-  OPTIMIZEVM = -O3
+  OPTIMIZEVM =
   OPTIMIZE = $(OPTIMIZEVM) -ffast-math
 
   SHLIBEXT=so


### PR DESCRIPTION
Make FreeBSD build work closer to how FreeBSD users expect it to work:

- Obey CFLAGS -On level
- Remove shenanigan to pull CFLAGS into BASE_CFLAGS
- Add COMPILE_ARCH conversion  i386 → x86