### PR TITLE
Fix build when cloned as submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2657,9 +2657,9 @@ $(B)/ded/%.o: $(NDIR)/%.c
 
 # Extra dependencies to ensure the git version is incorporated
 ifeq ($(USE_GIT),1)
-  $(B)/client/cl_console.o : .git/index
-  $(B)/client/common.o : .git/index
-  $(B)/ded/common.o : .git/index
+  $(B)/client/cl_console.o : .git
+  $(B)/client/common.o : .git
+  $(B)/ded/common.o : .git
 endif
 
 


### PR DESCRIPTION
Steps to reproduce:

    git init
    git submodule add -b master git://github.com/ioquake/ioq3.git
    cd ioq3
    make USE_GIT=1

I just tried this build, and it still shows the correct git hash at the top of the console.