### PR TITLE
Copy server address before using it

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -1714,6 +1714,8 @@ void CL_Connect_f( void ) {
 		server = Cmd_Argv(2);
 	}
 
+	server = CopyString(server);
+
 	// save arguments for reconnect
 	Q_strncpyz( cl_reconnectArgs, Cmd_Args(), sizeof( cl_reconnectArgs ) );
 
@@ -1776,6 +1778,7 @@ void CL_Connect_f( void ) {
 
 	// server connection string
 	Cvar_Set( "cl_currentServerAddress", server );
+	Z_Free(server);
 }
 
 #define MAX_RCON_MESSAGE 1024


### PR DESCRIPTION
We can't assume that no calls to `Cmd_TokenizeString` will be made in
the middle of `CL_Connect_f` which would overwrite the command buffer
where the server address is still stored.

In fact `Cmd_TokenizeString` is actually called by
`FS_PureServerSetReferencedPaks` which is itself called from
`CL_Disconnect` but this doesn't cause any problems since the parsed
string is always empty.