### PR TITLE
Add con_autochat and con_autoclear cvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The defaults for these variables differ depending on the target platform.
                                       behaviour, 0 for standard q3
   cl_mouseAccelOffset               - Tuning the acceleration curve, see below
 
+  con_autochat                      - Set to 0 to disable sending console input
+                                      text as chat when there is not a slash
+                                      at the beginning
+  con_autoclear                     - Set to 0 to disable clearing console
+                                      input text when console is closed
+
   in_joystickUseAnalog              - Do not translate joystick axis events
                                       to keyboard commands
 

--- a/code/client/cl_console.c
+++ b/code/client/cl_console.c
@@ -56,6 +56,7 @@ typedef struct {
 console_t	con;
 
 cvar_t		*con_conspeed;
+cvar_t		*con_autoclear;
 cvar_t		*con_notifytime;
 
 #define	DEFAULT_CONSOLE_WIDTH	78
@@ -72,7 +73,10 @@ void Con_ToggleConsole_f (void) {
 		return;
 	}
 
-	Field_Clear( &g_consoleField );
+	if ( con_autoclear->integer ) {
+		Field_Clear( &g_consoleField );
+	}
+
 	g_consoleField.widthInChars = g_console_field_width;
 
 	Con_ClearNotify ();
@@ -354,6 +358,7 @@ void Con_Init (void) {
 
 	con_notifytime = Cvar_Get ("con_notifytime", "3", 0);
 	con_conspeed = Cvar_Get ("scr_conspeed", "3", 0);
+	con_autoclear = Cvar_Get("con_autoclear", "1", CVAR_ARCHIVE);
 
 	Field_Clear( &g_consoleField );
 	g_consoleField.widthInChars = g_console_field_width;

--- a/code/client/cl_keys.c
+++ b/code/client/cl_keys.c
@@ -613,7 +613,7 @@ void Console_Key (int key) {
 	// enter finishes the line
 	if ( key == K_ENTER || key == K_KP_ENTER ) {
 		// if not in the game explicitly prepend a slash if needed
-		if ( clc.state != CA_ACTIVE &&
+		if ( clc.state != CA_ACTIVE && con_autochat->integer &&
 				g_consoleField.buffer[0] &&
 				g_consoleField.buffer[0] != '\\' &&
 				g_consoleField.buffer[0] != '/' ) {
@@ -635,7 +635,10 @@ void Console_Key (int key) {
 			if ( !g_consoleField.buffer[0] ) {
 				return;	// empty lines just scroll the console without adding to history
 			} else {
-				Cbuf_AddText ("cmd say ");
+				if ( con_autochat->integer ) {
+					Cbuf_AddText ("cmd say ");
+				}
+
 				Cbuf_AddText( g_consoleField.buffer );
 				Cbuf_AddText ("\n");
 			}

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -95,6 +95,9 @@ cvar_t	*com_legacyprotocol;
 cvar_t	*com_basegame;
 cvar_t  *com_homepath;
 cvar_t	*com_busyWait;
+#ifndef DEDICATED
+cvar_t  *con_autochat;
+#endif
 
 #if idx64
 	int (*Q_VMftol)(void);
@@ -2784,6 +2787,10 @@ void Com_Init( char *commandLine ) {
 #endif
 		Cvar_Get("protocol", com_protocol->string, CVAR_ROM);
 
+#ifndef DEDICATED
+	con_autochat = Cvar_Get("con_autochat", "1", CVAR_ARCHIVE);
+#endif
+
 	Sys_Init();
 
 	Sys_InitPIDFile( FS_GetCurrentGameDir() );
@@ -3471,8 +3478,8 @@ void Field_CompleteCommand( char *cmd,
 		completionString = Cmd_Argv( completionArgument - 1 );
 
 #ifndef DEDICATED
-	// Unconditionally add a '\' to the start of the buffer
-	if( completionField->buffer[ 0 ] &&
+	// add a '\' to the start of the buffer if it might be sent as chat otherwise
+	if( con_autochat->integer && completionField->buffer[ 0 ] &&
 			completionField->buffer[ 0 ] != '\\' )
 	{
 		if( completionField->buffer[ 0 ] != '/' )

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -881,6 +881,9 @@ extern	cvar_t	*com_protocol;
 #ifdef LEGACY_PROTOCOL
 extern	cvar_t	*com_legacyprotocol;
 #endif
+#ifndef DEDICATED
+extern  cvar_t  *con_autochat;
+#endif
 
 // com_speeds times
 extern	int		time_game;

--- a/code/sys/con_tty.c
+++ b/code/sys/con_tty.c
@@ -378,7 +378,7 @@ char *CON_Input( void )
 				{
 #ifndef DEDICATED
 					// if not in the game explicitly prepend a slash if needed
-					if (clc.state != CA_ACTIVE && TTY_con.cursor &&
+					if (clc.state != CA_ACTIVE && con_autochat->integer && TTY_con.cursor &&
 						TTY_con.buffer[0] != '/' && TTY_con.buffer[0] != '\\')
 					{
 						memmove(TTY_con.buffer + 1, TTY_con.buffer, sizeof(TTY_con.buffer) - 1);
@@ -389,7 +389,11 @@ char *CON_Input( void )
 					if (TTY_con.buffer[0] == '/' || TTY_con.buffer[0] == '\\') {
 						Q_strncpyz(text, TTY_con.buffer + 1, sizeof(text));
 					} else if (TTY_con.cursor) {
-						Com_sprintf(text, sizeof(text), "cmd say %s", TTY_con.buffer);
+						if (con_autochat->integer) {
+							Com_sprintf(text, sizeof(text), "cmd say %s", TTY_con.buffer);
+						} else {
+							Q_strncpyz(text, TTY_con.buffer, sizeof(text));
+						}
 					} else {
 						text[0] = '\0';
 					}


### PR DESCRIPTION
Add `con_autoclear` cvar from ET to allow disabling clearing client console input text when console is closed.

Add `con_autochat` cvar from Spearmint to allow disabling sending console input text as chat when there isn't a leading slash. Instead it's processed as a command.

Both cvars default to 1; using the original Q3 behavior.

I believe it's ready to be merged. Do other maintainers have an opinion on adding these?