### PR TITLE
Move CON_Init ahead of Com_Init to avoid Windows dedicated server crash

### DIFF
--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -744,10 +744,9 @@ int main( int argc, char **argv )
 		Q_strcat( commandLine, sizeof( commandLine ), " " );
 	}
 
+	CON_Init( );
 	Com_Init( commandLine );
 	NET_Init( );
-
-	CON_Init( );
 
 	signal( SIGILL, Sys_SigHandler );
 	signal( SIGFPE, Sys_SigHandler );


### PR DESCRIPTION
This change prevents an intermittent crash issue I encountered (#257) with the Windows dedicated server builds, where a Com_Printf call would trigger a crash due to the console system not being initialized.

The crash traced to main->Com_Init->Com_Printf->Sys_Print->CON_Print->CON_Hide->CON_Show->WriteConsoleOutput, where WriteConsoleOutput was passed an unitialized qconsole_hout handle.

I've only very lightly tested this fix, but it should be at least safe for non-dedicated builds, since there CON_Init is only a stub so moving it doesn't make a functional difference.