### PR TITLE
[qcommon] Use unsigned types where wrapping arithmetic is intended

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -1376,7 +1376,7 @@ Touch all known used data to make sure it is paged in
 void Com_TouchMemory( void ) {
 	int		start, end;
 	int		i, j;
-	int		sum;
+	unsigned	sum;
 	memblock_t	*block;
 
 	Z_CheckHeap();

--- a/code/qcommon/q_math.c
+++ b/code/qcommon/q_math.c
@@ -148,7 +148,7 @@ vec3_t	bytedirs[NUMVERTEXNORMALS] =
 //==============================================================
 
 int		Q_rand( int *seed ) {
-	*seed = (69069 * *seed + 1);
+	*seed = (69069U * *seed + 1U);
 	return *seed;
 }
 


### PR DESCRIPTION
The use of signed types in these expressions lead to overflow, hence undefined behaviour. The "sum" aggregator in Com_TouchMemory isn't even used (and presumbably just exists to inhibit optimizations from removing the memory access).