### PR TITLE
ignore window resize event on fullscreen

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1121,6 +1121,12 @@ static void IN_ProcessEvents( void )
 							width = e.window.data1;
 							height = e.window.data2;
 
+							// ignore this event on fullscreen
+							if( cls.glconfig.isFullscreen )
+							{
+								break;
+							}
+
 							// check if size actually changed
 							if( cls.glconfig.vidWidth == width && cls.glconfig.vidHeight == height )
 							{


### PR DESCRIPTION
It is assumed that user can't resize window on fullscreen. This fixes screen looping bug