### PR TITLE
Maximize cURL buffer size

### DIFF
--- a/code/client/cl_curl.c
+++ b/code/client/cl_curl.c
@@ -301,6 +301,7 @@ void CL_cURL_BeginDownload( const char *localName, const char *remoteURL )
 	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_MAXREDIRS, 5);
 	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_PROTOCOLS,
 		CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP | CURLPROTO_FTPS);
+	qcurl_easy_setopt_warn(clc.downloadCURL, CURLOPT_BUFFERSIZE, CURL_MAX_READ_SIZE);
 	clc.downloadCURLM = qcurl_multi_init();	
 	if(!clc.downloadCURLM) {
 		qcurl_easy_cleanup(clc.downloadCURL);


### PR DESCRIPTION
Allows higher download throughput (from ~2 MB/s to ~60 MB/s at 120FPS)

This has no effect for curl versions older than 7.53.0 (for which the
buffer can only be shrunk below 16k)