### PR TITLE
Fix shader corruption on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1183,7 +1183,7 @@ define DO_REF_STR
 $(echo_cmd) "REF_STR $<"
 $(Q)rm -f $@
 $(Q)echo "const char *fallbackShader_$(notdir $(basename $<)) =" >> $@
-$(Q)cat $< | sed -e 's/^/\"/;s/$$/\\n\"/' -e 's/\r//g' >> $@
+$(Q)cat $< | sed -e 's/^/\"/;s/$$/\\n\"/' | tr -d '\r' >> $@
 $(Q)echo ";" >> $@
 endef
 


### PR DESCRIPTION
OpenBSD's sed (and possibly other platforms') interprets `\r` as a
literal `r` rather than a carriage return, which leads to all `r`
letters being stripped from the shaders' source.

This fixes the issue by using the POSIX-compliant `tr -d '\r'` to remove
carriage returns.

Thanks to @ryan-sg for reporting the issue