### PR TITLE
Improvements to the linux build script

### DIFF
--- a/misc/linux/server_compile.sh
+++ b/misc/linux/server_compile.sh
@@ -9,7 +9,7 @@ export USE_CODEC_OPUS="${USE_CODEC_OPUS:-1}"
 export USE_VOIP="${USE_VOIP:-1}"
 export COPYDIR="${COPYDIR:-~/ioquake3}"
 IOQ3REMOTE="${IOQ3REMOTE:-https://github.com/ioquake/ioq3.git}"
-MAKE_OPTS="${MAKE_OPTS:--j}"
+MAKE_OPTS="${MAKE_OPTS:--j2}"
 
 if ! [ -x "$(command -v git)" ] || ! [ -x "$(command -v make)" ]; then
         echo "This build script requires 'git' and 'make' to be installed." >&2

--- a/misc/linux/server_compile.sh
+++ b/misc/linux/server_compile.sh
@@ -1,30 +1,53 @@
 #!/bin/bash
-localPATH=`pwd`
-export BUILD_CLIENT="0"
-export BUILD_SERVER="1"
-export USE_CURL="1"
-export USE_CODEC_OPUS="1"
-export USE_VOIP="1"
-export COPYDIR="~/ioquake3"
-IOQ3REMOTE="https://github.com/ioquake/ioq3.git"
-IOQ3LOCAL="/tmp/ioquake3compile"
-JOPTS="-j2" 
-echo "This process requires you to have the following installed through your distribution:
- make
- git
- and all of the ioquake3 dependencies necessary for an ioquake3 server.
- If you do not have the necessary dependencies this script will bail out.
- Please post a message to http://discourse.ioquake.org/ asking for help and include whatever error messages you received during the compile phase.
- Please edit this script. Inside you will find a COPYDIR variable you can alter to change where ioquake3 will be installed to."
-while true; do
-        read -p "Are you ready to compile ioquake3 in the $IOQ3LOCAL directory, and have it installed into $COPYDIR? " yn
-case $yn in
-        [Yy]* )
-if  [ -x "$(command -v git)" ] && [ -x "$(command -v make)" ] ; then
-        git clone $IOQ3REMOTE $IOQ3LOCAL && cd $IOQ3LOCAL && make $JOPTS && make copyfiles && cd $localPATH && rm -rf $IOQ3LOCAL
+
+set -e
+
+export BUILD_CLIENT="${BUILD_CLIENT:-0}"
+export BUILD_SERVER="${BUILD_SERVER:-1}"
+export USE_CURL="${USE_CURL:-1}"
+export USE_CODEC_OPUS="${USE_CODEC_OPUS:-1}"
+export USE_VOIP="${USE_VOIP:-1}"
+export COPYDIR="${COPYDIR:-~/ioquake3}"
+IOQ3REMOTE="${IOQ3REMOTE:-https://github.com/ioquake/ioq3.git}"
+MAKE_OPTS="${MAKE_OPTS:--j}"
+
+if ! [ -x "$(command -v git)" ] || ! [ -x "$(command -v make)" ]; then
+        echo "This build script requires 'git' and 'make' to be installed." >&2
+        echo "Please install them through your normal package installation system." >&2
+        exit 1
 fi
-        exit;;
-        [Nn]* ) exit;;
-        * ) echo "Please answer yes or no.";;
-esac
+
+echo " This build process requires all of the ioquake3 dependencies necessary for an ioquake3 server.
+ If you do not have the necessary dependencies the build will fail.
+
+ Please post a message to http://discourse.ioquake.org/ asking for help and include whatever error messages you received during the compile phase.
+
+ We will be building from the git repo at ${IOQ3REMOTE}
+ The resulting binary will be installed to ${COPYDIR}
+
+ If you need to change these, please set variables as follows:
+
+ IOQ3REMOTE=https://github.com/something/something.git COPYDIR=~/somewhere $0"
+
+BUILD_DIR="$(mktemp -d)"
+trap "rm -rf $BUILD_DIR" EXIT
+
+while true; do
+        read -p "Are you ready to compile ioquake3 from ${IOQ3REMOTE}, and have it installed into $COPYDIR? " yn
+        case $yn in
+                [Yy]*)
+                        git clone $IOQ3REMOTE $BUILD_DIR/ioq3
+                        cd $BUILD_DIR/ioq3
+                        make $MAKE_OPTS
+                        make copyfiles
+                        exit
+                        ;;
+                [Nn]*)
+                        echo "aborting installation."
+                        exit
+                        ;;
+                *)
+                        echo "Please answer yes or no."
+                        ;;
+        esac
 done


### PR DESCRIPTION
(As requested by @TimeDoctor)

I tried to split things up into multiple PRs, but it really wasn't possible to get "clean" diffs that were independent of each other.  If you only want a subset of changes, let me know which ones and I can whip up a reduced changeset.

In no particular order:

* Use `set -e`, because it prevents accidents, and means we can avoid
  lengthy &&-joined command chains.
* Override defaults by setting env vars; this means people don't have to
  edit the script to change things.
* Use an unpredictable and safely-created tmpdir for building; ain't nobody
  wants to cleanup from a tmpdir race condition attack.
* Switch to passing `-j` to `make`, by default; any reasonably recent version
  of `make` will happily interpret that as "use as many cores as we have".
* Test for the presence of `git` and `make` *before* asking questions, and
  only prompt the user about them if they're missing.  No need to bother
  people with unnecessary reading.
* Automatically clean up the build directory after use.
* Tidy up some indenting that had come asunder.