### PR TITLE
fixed fullscreen/windowed modes under tiling window managers

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -556,21 +556,27 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 
 		if( fullscreen )
 		{
-			SDL_DisplayMode mode;
+			SDL_DisplayMode vidMode;
 
 			switch( testColorBits )
 			{
-				case 16: mode.format = SDL_PIXELFORMAT_RGB565; break;
-				case 24: mode.format = SDL_PIXELFORMAT_RGB24;  break;
+				case 16: vidMode.format = SDL_PIXELFORMAT_RGB565; break;
+				case 24: vidMode.format = SDL_PIXELFORMAT_RGB24;  break;
 				default: ri.Printf( PRINT_DEVELOPER, "testColorBits is %d, can't fullscreen\n", testColorBits ); continue;
 			}
 
-			mode.w = glConfig.vidWidth;
-			mode.h = glConfig.vidHeight;
-			mode.refresh_rate = glConfig.displayFrequency = ri.Cvar_VariableIntegerValue( "r_displayRefresh" );
-			mode.driverdata = NULL;
+			if( mode==-1 )
+			{
+				SDL_SetWindowFullscreen(SDL_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+				SDL_GL_GetDrawableSize(SDL_window, &glConfig.vidWidth, &glConfig.vidHeight);
+			}
 
-			if( SDL_SetWindowDisplayMode( SDL_window, &mode ) < 0 )
+			vidMode.w = glConfig.vidWidth;
+			vidMode.h = glConfig.vidHeight;
+			vidMode.refresh_rate = glConfig.displayFrequency = ri.Cvar_VariableIntegerValue( "r_displayRefresh" );
+			vidMode.driverdata = NULL;
+
+			if( SDL_SetWindowDisplayMode( SDL_window, &vidMode ) < 0 )
 			{
 				ri.Printf( PRINT_DEVELOPER, "SDL_SetWindowDisplayMode failed: %s\n", SDL_GetError( ) );
 				continue;


### PR DESCRIPTION
Hi,
I'm using i3 and the mode option at -1, and always had a lot of issues with quake3 on tiling window managers:
- The window floats over the first half of my taskbar  when I escape the fullscreen mode without the resize option enabled. This is really annoying for people at the edge of OCD.
- If I use the resize option it works better, but the mouse can't move through the entire window and the game gets completely crazy once I try to go back to the fullscreen mode (notably, the wrong resolution is used).

I wrote theses changes after reading some resources on the SDL wiki, and it fixes all those issues as long as we use the in-game option to enable/disable fullscreen. In windowed mode, it also helps me getting the real window size without exiting the tiling mode. I tested it on a floating window manager as well, and it doesn't seem to break anything, so I hope it's useful :)