### PR TITLE
Add QL alias commands to ioq3

### DIFF
--- a/code/qcommon/cmd.c
+++ b/code/qcommon/cmd.c
@@ -861,6 +861,7 @@ Cmd_Init
 */
 void Cmd_Init (void) {
 	Cmd_AddCommand ("cmdlist",Cmd_List_f);
+	Cmd_AddCommand ("listcmds",Cmd_List_f);
 	Cmd_AddCommand ("exec",Cmd_Exec_f);
 	Cmd_AddCommand ("execq",Cmd_Exec_f);
 	Cmd_SetCommandCompletionFunc( "exec", Cmd_CompleteCfgName );

--- a/code/qcommon/cvar.c
+++ b/code/qcommon/cvar.c
@@ -1430,6 +1430,8 @@ void Cvar_Init (void)
 	Cmd_SetCommandCompletionFunc("unset", Cvar_CompleteCvarName);
 
 	Cmd_AddCommand ("cvarlist", Cvar_List_f);
+	Cmd_AddCommand ("listcvars", Cvar_List_f);
+	
 	Cmd_AddCommand ("cvar_modified", Cvar_ListModified_f);
 	Cmd_AddCommand ("cvar_restart", Cvar_Restart_f);
 }


### PR DESCRIPTION
Add alias commands:

listcmds -> cmdlist
listcvars -> cvarlist

Handy to have for tab completion purposes.