### PR TITLE
Fix fraglimit causing an infinite map end loop.

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1380,6 +1380,12 @@ void CheckExitRules( void ) {
 		}
 	}
 
+	if ( g_fraglimit.integer < 0 ) {
+		trap_SendServerCommand( -1, "print \"Fraglimit is negative\n\"" );
+		trap_Cvar_Set( "fraglimit", "0" );
+		trap_Cvar_Update( &g_fraglimit );
+	}
+
 	if ( g_gametype.integer < GT_CTF && g_fraglimit.integer ) {
 		if ( level.teamScores[TEAM_RED] >= g_fraglimit.integer ) {
 			trap_SendServerCommand( -1, "print \"Red hit the fraglimit.\n\"" );


### PR DESCRIPTION
Similar to #205, but it turns out you can vote a negative fraglimit which will also cause an infinite map change/reload.

I was expecting some feedback on my previous PR and that is why I did not make this one a request.