### PR TITLE
Don't test fullscreen with glconfig.isFullscreen

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1125,7 +1125,7 @@ static void IN_ProcessEvents( void )
 							height = e.window.data2;
 
 							// ignore this event on fullscreen
-							if( cls.glconfig.isFullscreen )
+							if( SDL_GetWindowFlags( SDL_window ) & SDL_WINDOW_FULLSCREEN )
 							{
 								break;
 							}
@@ -1169,18 +1169,19 @@ IN_Frame
 void IN_Frame( void )
 {
 	qboolean loading;
+	qboolean isFullscreen = SDL_GetWindowFlags( SDL_window ) & SDL_WINDOW_FULLSCREEN;
 
 	IN_JoyMove( );
 
 	// If not DISCONNECTED (main menu) or ACTIVE (in game), we're loading
 	loading = ( clc.state != CA_DISCONNECTED && clc.state != CA_ACTIVE );
 
-	if( !cls.glconfig.isFullscreen && ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) )
+	if( !isFullscreen && ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) )
 	{
 		// Console is down in windowed mode
 		IN_DeactivateMouse( );
 	}
-	else if( !cls.glconfig.isFullscreen && loading )
+	else if( !isFullscreen && loading )
 	{
 		// Loading in windowed mode
 		IN_DeactivateMouse( );


### PR DESCRIPTION
After starting with fullscreen mode and switching to windowed mode, the
mouse will not be ungrabbed when it should be.

This is because `glconfig.isFullscreen` doesn't actually reflect whether
the window is fullscreen.

---

This raises the question of whether `glconfig.isFullscreen` is actually useful?