### PR TITLE
Update cvar.c

### DIFF
--- a/code/qcommon/cvar.c
+++ b/code/qcommon/cvar.c
@@ -569,6 +569,12 @@ cvar_t *Cvar_Set2( const char *var_name, const char *value, qboolean force ) {
 			return var;
 		}
 
+		if ((var->flags & CVAR_CHEAT) && !cvar_cheats->integer)
+		{
+			Com_Printf ("%s is cheat protected.\n", var_name);
+			return var;
+		}
+		
 		if (var->flags & CVAR_LATCH)
 		{
 			if (var->latchedString)
@@ -589,13 +595,6 @@ cvar_t *Cvar_Set2( const char *var_name, const char *value, qboolean force ) {
 			var->modificationCount++;
 			return var;
 		}
-
-		if ( (var->flags & CVAR_CHEAT) && !cvar_cheats->integer )
-		{
-			Com_Printf ("%s is cheat protected.\n", var_name);
-			return var;
-		}
-
 	}
 	else
 	{


### PR DESCRIPTION
 qcommon: Fixed the output/behaviour of CVAR_CHEAT flagged cvars in case they are also of type CVAR_LATCH (avoid the early latch case return to make it work as intended)