### PR TITLE
Add OpenGL ES 1.1 support to opengl1 renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ Makefile.local:
 The defaults for these variables differ depending on the target platform.
 
 
+# OpenGL ES support
+
+ioquake3's default renderer (cl_renderer opengl2) does not support OpenGL ES.
+
+If you build ioquake3 on a platform that uses OpenGL ES (such as Raspberry Pi),
+run the game using `./build/release-*/ioquake3.* +set cl_renderer opengl1`.
+
+The `r_useOpenGLES` cvar controls whether to use OpenGL or OpenGL ES API.
+Set to -1 for auto (default), 0 for OpenGL, and 1 for OpenGL ES. It should be
+set using command line arguments, `ioquake3 +set r_useOpenGLES 0`.
+
+ioquake3's opengl1 renderer supports OpenGL 1.1+ and OpenGL ES 1.1 with a few limitations.
+When using OpenGL ES the opengl1 renderer does not support `r_flares`[1],
+`r_measureOverdraw`[2], `r_anaglyphMode`[3], `r_stereoEnabled`[3], `r_drawBuffer GL_FRONT`[3],
+and `r_primitives 1/3`[4].
+
+* [1] Requires glReadPixels GL_DEPTH_COMPONENT
+* [2] Requires glReadPixels GL_STENCIL_INDEX
+* [3] Requires glDrawBuffer
+* [4] Requires glBegin
+
+
 # Console
 
 ## New cvars
@@ -291,6 +313,9 @@ The defaults for these variables differ depending on the target platform.
                                       cl_aviMotionJpeg is enabled
   r_mode -2                         - This new video mode automatically uses the
                                       desktop resolution.
+  r_useOpenGLES                     - Controls whether to use OpenGL API or
+                                      OpenGL ES API. Set to -1 for auto (default),
+                                      0 for OpenGL, and 1 for OpenGL ES.
 ```
 
 ## New commands

--- a/code/client/cl_avi.c
+++ b/code/client/cl_avi.c
@@ -357,11 +357,12 @@ qboolean CL_OpenAVIForWriting( const char *fileName )
   else
     afd.motionJpeg = qfalse;
 
-  // Buffers only need to store RGB pixels.
+  // Capture buffer stores RGB pixels or possibly RGBA when using OpenGL ES.
+  // Encode buffer only needs to store RGB pixels.
   // Allocate a bit more space for the capture buffer to account for possible
   // padding at the end of pixel lines, and padding for alignment
   #define MAX_PACK_LEN 16
-  afd.cBuffer = Z_Malloc((afd.width * 3 + MAX_PACK_LEN - 1) * afd.height + MAX_PACK_LEN - 1);
+  afd.cBuffer = Z_Malloc((afd.width * 4 + MAX_PACK_LEN - 1) * afd.height + MAX_PACK_LEN - 1);
   // raw avi files have pixel lines start on 4-byte boundaries
   afd.eBuffer = Z_Malloc(PAD(afd.width * 3, AVI_LINE_PADDING) * afd.height);
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -576,6 +576,11 @@ typedef struct {
 #define VectorClear(a)			((a)[0]=(a)[1]=(a)[2]=0)
 #define VectorNegate(a,b)		((b)[0]=-(a)[0],(b)[1]=-(a)[1],(b)[2]=-(a)[2])
 #define VectorSet(v, x, y, z)	((v)[0]=(x), (v)[1]=(y), (v)[2]=(z))
+
+#define Vector2Set(v, x, y)		((v)[0]=(x), (v)[1]=(y))
+#define Vector2Copy(a,b)		((b)[0]=(a)[0],(b)[1]=(a)[1])
+
+#define Vector4Set(v, x, y, z, w)	((v)[0]=(x), (v)[1]=(y), (v)[2]=(z), (v)[3]=(w))
 #define Vector4Copy(a,b)		((b)[0]=(a)[0],(b)[1]=(a)[1],(b)[2]=(a)[2],(b)[3]=(a)[3])
 
 #define Byte4Copy(a,b)			((b)[0]=(a)[0],(b)[1]=(a)[1],(b)[2]=(a)[2],(b)[3]=(a)[3])

--- a/code/renderercommon/qgl.h
+++ b/code/renderercommon/qgl.h
@@ -87,6 +87,7 @@ extern void (APIENTRYP qglUnlockArraysEXT) (void);
 #define QGL_1_1_FIXED_FUNCTION_PROCS \
 	GLE(void, AlphaFunc, GLenum func, GLclampf ref) \
 	GLE(void, Color4f, GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha) \
+	GLE(void, Color4ub, GLubyte red, GLubyte green, GLubyte blue, GLubyte alpha) \
 	GLE(void, ColorPointer, GLint size, GLenum type, GLsizei stride, const GLvoid *ptr) \
 	GLE(void, DisableClientState, GLenum cap) \
 	GLE(void, EnableClientState, GLenum cap) \

--- a/code/renderercommon/tr_common.h
+++ b/code/renderercommon/tr_common.h
@@ -81,6 +81,7 @@ extern qboolean  textureFilterAnisotropic;
 extern int       maxAnisotropy;
 extern float     displayAspect;
 extern qboolean  haveClampToEdge;
+extern qboolean  readFormatAvailable;
 
 //
 // cvars

--- a/code/renderergl1/tr_backend.c
+++ b/code/renderergl1/tr_backend.c
@@ -719,6 +719,45 @@ void	RB_SetGL2D (void) {
 	backEnd.refdef.floatTime = backEnd.refdef.time * 0.001;
 }
 
+/*
+================
+RB_InstantQuad2
+================
+*/
+void RB_InstantQuad2( vec4_t quadVerts[4], vec2_t texCoords[2] ) {
+	glIndex_t indexes[6];
+
+	qglDisableClientState( GL_COLOR_ARRAY );
+	qglEnableClientState( GL_TEXTURE_COORD_ARRAY );
+
+	qglTexCoordPointer( 2, GL_FLOAT, 0, texCoords );
+	qglVertexPointer( 3, GL_FLOAT, 16, quadVerts );
+
+	indexes[0] = 0;
+	indexes[1] = 1;
+	indexes[2] = 2;
+	indexes[3] = 0;
+	indexes[4] = 2;
+	indexes[5] = 3;
+
+	R_DrawElements( 6, indexes );
+}
+
+/*
+================
+RB_InstantQuad
+===============-
+*/
+void RB_InstantQuad( vec4_t quadVerts[4] ) {
+	vec2_t texCoords[4] = {
+		{ 0, 0 },
+		{ 1, 0 },
+		{ 1, 1 },
+		{ 0, 1 }
+	};
+
+	RB_InstantQuad2( quadVerts, texCoords );
+}
 
 /*
 =============
@@ -732,6 +771,8 @@ Used for cinematics.
 void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *data, int client, qboolean dirty) {
 	int			i, j;
 	int			start, end;
+	vec4_t		quadVerts[4];
+	vec2_t		texCoords[4];
 
 	if ( !tr.registered ) {
 		return;
@@ -771,16 +812,17 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 
 	qglColor3f( tr.identityLight, tr.identityLight, tr.identityLight );
 
-	qglBegin (GL_QUADS);
-	qglTexCoord2f ( 0.5f / cols,  0.5f / rows );
-	qglVertex2f (x, y);
-	qglTexCoord2f ( ( cols - 0.5f ) / cols ,  0.5f / rows );
-	qglVertex2f (x+w, y);
-	qglTexCoord2f ( ( cols - 0.5f ) / cols, ( rows - 0.5f ) / rows );
-	qglVertex2f (x+w, y+h);
-	qglTexCoord2f ( 0.5f / cols, ( rows - 0.5f ) / rows );
-	qglVertex2f (x, y+h);
-	qglEnd ();
+	Vector4Set( quadVerts[0], x,     y,     0.0f, 1.0f );
+	Vector4Set( quadVerts[1], x + w, y,     0.0f, 1.0f );
+	Vector4Set( quadVerts[2], x + w, y + h, 0.0f, 1.0f );
+	Vector4Set( quadVerts[3], x,     y + h, 0.0f, 1.0f );
+
+	Vector2Set( texCoords[0], 0.5f / cols,          0.5f / rows );
+	Vector2Set( texCoords[1], (cols - 0.5f) / cols, 0.5f / rows );
+	Vector2Set( texCoords[2], (cols - 0.5f) / cols, (rows - 0.5f) / rows );
+	Vector2Set( texCoords[3], 0.5f / cols,          (rows - 0.5f) / rows );
+
+	RB_InstantQuad2( quadVerts, texCoords );
 }
 
 void RE_UploadCinematic (int w, int h, int cols, int rows, const byte *data, int client, qboolean dirty) {
@@ -963,6 +1005,7 @@ void RB_ShowImages( void ) {
 	image_t	*image;
 	float	x, y, w, h;
 	int		start, end;
+	vec4_t	 quadVerts[4];
 
 	if ( !backEnd.projection2D ) {
 		RB_SetGL2D();
@@ -989,16 +1032,13 @@ void RB_ShowImages( void ) {
 		}
 
 		GL_Bind( image );
-		qglBegin (GL_QUADS);
-		qglTexCoord2f( 0, 0 );
-		qglVertex2f( x, y );
-		qglTexCoord2f( 1, 0 );
-		qglVertex2f( x + w, y );
-		qglTexCoord2f( 1, 1 );
-		qglVertex2f( x + w, y + h );
-		qglTexCoord2f( 0, 1 );
-		qglVertex2f( x, y + h );
-		qglEnd();
+
+		Vector4Set( quadVerts[0], x, y, 0, 1 );
+		Vector4Set( quadVerts[1], x + w, y, 0, 1 );
+		Vector4Set( quadVerts[2], x + w, y + h, 0, 1 );
+		Vector4Set( quadVerts[3], x, y + h, 0, 1 );
+
+		RB_InstantQuad( quadVerts );
 	}
 
 	qglFinish();

--- a/code/renderergl1/tr_cmds.c
+++ b/code/renderergl1/tr_cmds.c
@@ -302,7 +302,14 @@ void RE_BeginFrame( stereoFrame_t stereoFrame ) {
 	//
 	if ( r_measureOverdraw->integer )
 	{
-		if ( glConfig.stencilBits < 4 )
+		if ( qglesMajorVersion >= 1 )
+		{
+			ri.Printf( PRINT_WARNING, "OpenGL ES does not support reading stencil bits to measure overdraw\n" );
+			// It can be done if GL_NV_read_stencil extension exists but it's for OpenGL ES 2+ contexts.
+			ri.Cvar_Set( "r_measureOverdraw", "0" );
+			r_measureOverdraw->modified = qfalse;
+		}
+		else if ( glConfig.stencilBits < 4 )
 		{
 			ri.Printf( PRINT_ALL, "Warning: not enough stencil bits to measure overdraw: %d\n", glConfig.stencilBits );
 			ri.Cvar_Set( "r_measureOverdraw", "0" );
@@ -380,6 +387,13 @@ void RE_BeginFrame( stereoFrame_t stereoFrame ) {
 	}
 	else
 	{
+		if (qglesMajorVersion >= 1 && r_anaglyphMode->integer)
+		{
+			ri.Printf( PRINT_WARNING, "OpenGL ES does not support drawing to separate buffer for anaglyph mode\n" );
+			ri.Cvar_Set( "r_anaglyphMode", "0" );
+			r_anaglyphMode->modified = qfalse;
+		}
+
 		if(r_anaglyphMode->integer)
 		{
 			if(r_anaglyphMode->modified)

--- a/code/renderergl1/tr_flares.c
+++ b/code/renderergl1/tr_flares.c
@@ -463,6 +463,15 @@ void RB_RenderFlares (void) {
 		return;
 	}
 
+	if ( r_flares->modified ) {
+		if ( qglesMajorVersion >= 1 ) {
+			ri.Printf( PRINT_WARNING, "OpenGL ES does not support reading depth to determine if flares are visible\n" );
+			// It can be done if GL_NV_read_depth extension exists but it's for OpenGL ES 2+ contexts.
+			ri.Cvar_Set( "r_flares", "0" );
+		}
+		r_flares->modified = qfalse;
+	}
+
 	if(r_flareCoeff->modified)
 	{
 		R_SetFlareCoeff();

--- a/code/renderergl1/tr_image.c
+++ b/code/renderergl1/tr_image.c
@@ -550,60 +550,91 @@ R_ConvertTextureFormat
 Convert RGBA unsigned byte to specified format and type
 ==================
 */
+#define ROW_PADDING( width, bpp, alignment ) PAD( (width) * (bpp), (alignment) ) - (width) * (bpp)
 void R_ConvertTextureFormat( const byte *in, int width, int height, GLenum format, GLenum type, byte *out )
 {
-	int i, numPixels;
-
-	numPixels = width * height;
+	int x, y, rowPadding;
+	int unpackAlign = 4; // matches GL_UNPACK_ALIGNMENT default
 
 	if ( format == GL_RGB && type == GL_UNSIGNED_BYTE )
 	{
-		for ( i = 0; i < numPixels; i++ )
+		rowPadding = ROW_PADDING( width, 3, unpackAlign );
+
+		for ( y = 0; y < height; y++ )
 		{
-			*out++ = *in++;
-			*out++ = *in++;
-			*out++ = *in++;
-			in++;
+			for ( x = 0; x < width; x++ )
+			{
+				*out++ = *in++;
+				*out++ = *in++;
+				*out++ = *in++;
+				in++;
+			}
+
+			out += rowPadding;
 		}
 	}
 	else if ( format == GL_LUMINANCE && type == GL_UNSIGNED_BYTE )
 	{
-		for ( i = 0; i < numPixels; i++ )
+		rowPadding = ROW_PADDING( width, 1, unpackAlign );
+
+		for ( y = 0; y < height; y++ )
 		{
-			*out++ = *in++; // red
-			in += 3;
+			for ( x = 0; x < width; x++ )
+			{
+				*out++ = *in++; // red
+				in += 3;
+			}
+
+			out += rowPadding;
 		}
 	}
 	else if ( format == GL_LUMINANCE_ALPHA && type == GL_UNSIGNED_BYTE )
 	{
-		for ( i = 0; i < numPixels; i++ )
+		rowPadding = ROW_PADDING( width, 2, unpackAlign );
+
+		for ( y = 0; y < height; y++ )
 		{
-			*out++ = *in++; // red
-			in += 2;
-			*out++ = *in++; // alpha
+			for ( x = 0; x < width; x++ )
+			{
+				*out++ = *in++; // red
+				in += 2;
+				*out++ = *in++; // alpha
+			}
+
+			out += rowPadding;
 		}
 	}
 	else if ( format == GL_RGB && type == GL_UNSIGNED_SHORT_5_6_5 )
 	{
-		unsigned short *sout = (unsigned short *)out;
+		rowPadding = ROW_PADDING( width, 2, unpackAlign );
 
-		for ( i = 0; i < numPixels; i++, in += 4 )
+		for ( y = 0; y < height; y++ )
 		{
-			*sout++ = ( (unsigned short)( in[0] >> 3 ) << 11 )
-			        | ( (unsigned short)( in[1] >> 2 ) << 5 )
-			        | ( (unsigned short)( in[2] >> 3 ) << 0 );
+			for ( x = 0; x < width; x++, in += 4, out += 2 )
+			{
+				*((unsigned short*)out) = ( (unsigned short)( in[0] >> 3 ) << 11 )
+					    | ( (unsigned short)( in[1] >> 2 ) << 5 )
+					    | ( (unsigned short)( in[2] >> 3 ) << 0 );
+			}
+
+			out += rowPadding;
 		}
 	}
 	else if ( format == GL_RGBA && type == GL_UNSIGNED_SHORT_4_4_4_4 )
 	{
-		unsigned short *sout = (unsigned short *)out;
+		rowPadding = ROW_PADDING( width, 2, unpackAlign );
 
-		for ( i = 0; i < numPixels; i++, in += 4 )
+		for ( y = 0; y < height; y++ )
 		{
-			*sout++ = ( (unsigned short)( in[0] >> 4 ) << 12 )
-			        | ( (unsigned short)( in[1] >> 4 ) << 8 )
-			        | ( (unsigned short)( in[2] >> 4 ) << 4 )
-			        | ( (unsigned short)( in[3] >> 4 ) << 0 );
+			for ( x = 0; x < width; x++, in += 4, out += 2 )
+			{
+				*((unsigned short*)out) = ( (unsigned short)( in[0] >> 4 ) << 12 )
+					    | ( (unsigned short)( in[1] >> 4 ) << 8 )
+					    | ( (unsigned short)( in[2] >> 4 ) << 4 )
+					    | ( (unsigned short)( in[3] >> 4 ) << 0 );
+			}
+
+			out += rowPadding;
 		}
 	}
 	else

--- a/code/renderergl1/tr_image.c
+++ b/code/renderergl1/tr_image.c
@@ -543,6 +543,74 @@ byte	mipBlendColors[16][4] = {
 	{0,0,255,128},
 };
 
+/*
+==================
+R_ConvertTextureFormat
+
+Convert RGBA unsigned byte to specified format and type
+==================
+*/
+void R_ConvertTextureFormat( const byte *in, int width, int height, GLenum format, GLenum type, byte *out )
+{
+	int i, numPixels;
+
+	numPixels = width * height;
+
+	if ( format == GL_RGB && type == GL_UNSIGNED_BYTE )
+	{
+		for ( i = 0; i < numPixels; i++ )
+		{
+			*out++ = *in++;
+			*out++ = *in++;
+			*out++ = *in++;
+			in++;
+		}
+	}
+	else if ( format == GL_LUMINANCE && type == GL_UNSIGNED_BYTE )
+	{
+		for ( i = 0; i < numPixels; i++ )
+		{
+			*out++ = *in++; // red
+			in += 3;
+		}
+	}
+	else if ( format == GL_LUMINANCE_ALPHA && type == GL_UNSIGNED_BYTE )
+	{
+		for ( i = 0; i < numPixels; i++ )
+		{
+			*out++ = *in++; // red
+			in += 2;
+			*out++ = *in++; // alpha
+		}
+	}
+	else if ( format == GL_RGB && type == GL_UNSIGNED_SHORT_5_6_5 )
+	{
+		unsigned short *sout = (unsigned short *)out;
+
+		for ( i = 0; i < numPixels; i++, in += 4 )
+		{
+			*sout++ = ( (unsigned short)( in[0] >> 3 ) << 11 )
+			        | ( (unsigned short)( in[1] >> 2 ) << 5 )
+			        | ( (unsigned short)( in[2] >> 3 ) << 0 );
+		}
+	}
+	else if ( format == GL_RGBA && type == GL_UNSIGNED_SHORT_4_4_4_4 )
+	{
+		unsigned short *sout = (unsigned short *)out;
+
+		for ( i = 0; i < numPixels; i++, in += 4 )
+		{
+			*sout++ = ( (unsigned short)( in[0] >> 4 ) << 12 )
+			        | ( (unsigned short)( in[1] >> 4 ) << 8 )
+			        | ( (unsigned short)( in[2] >> 4 ) << 4 )
+			        | ( (unsigned short)( in[3] >> 4 ) << 0 );
+		}
+	}
+	else
+	{
+		ri.Error( ERR_DROP, "Unable to convert RGBA image to OpenGL format 0x%X and type 0x%X", format, type );
+	}
+}
 
 /*
 ===============
@@ -556,16 +624,19 @@ static void Upload32( unsigned *data,
 						  qboolean picmip, 
 							qboolean lightMap,
 						  qboolean allowCompression,
-						  int *format, 
+						  int *pInternalFormat,
 						  int *pUploadWidth, int *pUploadHeight )
 {
 	int			samples;
 	unsigned	*scaledBuffer = NULL;
 	unsigned	*resampledBuffer = NULL;
+	unsigned	*formatBuffer = NULL;
 	int			scaled_width, scaled_height;
 	int			i, c;
 	byte		*scan;
 	GLenum		internalFormat = GL_RGB;
+	GLenum		format = GL_RGBA;
+	GLenum		type = GL_UNSIGNED_BYTE;
 	float		rMax = 0, gMax = 0, bMax = 0;
 
 	//
@@ -689,11 +760,11 @@ static void Upload32( unsigned *data,
 			}
 			else
 			{
-				if ( allowCompression && glConfig.textureCompression == TC_S3TC_ARB )
+				if ( !qglesMajorVersion && allowCompression && glConfig.textureCompression == TC_S3TC_ARB )
 				{
 					internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
 				}
-				else if ( allowCompression && glConfig.textureCompression == TC_S3TC )
+				else if ( !qglesMajorVersion && allowCompression && glConfig.textureCompression == TC_S3TC )
 				{
 					internalFormat = GL_RGB4_S3TC;
 				}
@@ -738,15 +809,75 @@ static void Upload32( unsigned *data,
 		}
 	}
 
+	// Convert image data format for OpenGL ES
+	if ( qglesMajorVersion >= 1 )
+	{
+		switch ( internalFormat )
+		{
+			case GL_LUMINANCE:
+			case GL_LUMINANCE8:
+				internalFormat = GL_LUMINANCE;
+				format = GL_LUMINANCE;
+				type = GL_UNSIGNED_BYTE;
+				break;
+			case GL_LUMINANCE_ALPHA:
+			case GL_LUMINANCE8_ALPHA8:
+				internalFormat = GL_LUMINANCE_ALPHA;
+				format = GL_LUMINANCE_ALPHA;
+				type = GL_UNSIGNED_BYTE;
+				break;
+			case GL_RGB:
+			case GL_RGB8:
+				internalFormat = GL_RGB;
+				format = GL_RGB;
+				type = GL_UNSIGNED_BYTE;
+				break;
+			case GL_RGB5:
+				internalFormat = GL_RGB;
+				format = GL_RGB;
+				type = GL_UNSIGNED_SHORT_5_6_5;
+				break;
+			case GL_RGBA:
+			case GL_RGBA8:
+				internalFormat = GL_RGBA;
+				format = GL_RGBA;
+				type = GL_UNSIGNED_BYTE;
+				break;
+			case GL_RGBA4:
+				internalFormat = GL_RGBA;
+				format = GL_RGBA;
+				type = GL_UNSIGNED_SHORT_4_4_4_4;
+				break;
+			default:
+				internalFormat = GL_RGBA;
+				format = GL_RGBA;
+				type = GL_UNSIGNED_BYTE;
+				break;
+		}
+	}
+
+	if ( format != GL_RGBA || type != GL_UNSIGNED_BYTE )
+	{
+		formatBuffer = ri.Hunk_AllocateTempMemory( sizeof( unsigned ) * scaled_width * scaled_height );
+	}
+
 	// copy or resample data as appropriate for first MIP level
 	if ( ( scaled_width == width ) && 
 		( scaled_height == height ) ) {
 		if (!mipmap)
 		{
-			qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+			if ( formatBuffer )
+			{
+				R_ConvertTextureFormat( (byte *)data, scaled_width, scaled_height, format, type, (byte *)formatBuffer );
+				qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, format, type, formatBuffer);
+			}
+			else
+			{
+				qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+			}
 			*pUploadWidth = scaled_width;
 			*pUploadHeight = scaled_height;
-			*format = internalFormat;
+			*pInternalFormat = internalFormat;
 
 			goto done;
 		}
@@ -773,9 +904,17 @@ static void Upload32( unsigned *data,
 
 	*pUploadWidth = scaled_width;
 	*pUploadHeight = scaled_height;
-	*format = internalFormat;
+	*pInternalFormat = internalFormat;
 
-	qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, scaledBuffer );
+	if ( formatBuffer )
+	{
+		R_ConvertTextureFormat( (byte *)scaledBuffer, scaled_width, scaled_height, format, type, (byte *)formatBuffer );
+		qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, format, type, formatBuffer );
+	}
+	else
+	{
+		qglTexImage2D (GL_TEXTURE_2D, 0, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, scaledBuffer );
+	}
 
 	if (mipmap)
 	{
@@ -797,7 +936,15 @@ static void Upload32( unsigned *data,
 				R_BlendOverTexture( (byte *)scaledBuffer, scaled_width * scaled_height, mipBlendColors[miplevel] );
 			}
 
-			qglTexImage2D (GL_TEXTURE_2D, miplevel, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, scaledBuffer );
+			if ( formatBuffer )
+			{
+				R_ConvertTextureFormat( (byte *)scaledBuffer, scaled_width, scaled_height, format, type, (byte *)formatBuffer );
+				qglTexImage2D (GL_TEXTURE_2D, miplevel, internalFormat, scaled_width, scaled_height, 0, format, type, formatBuffer );
+			}
+			else
+			{
+				qglTexImage2D (GL_TEXTURE_2D, miplevel, internalFormat, scaled_width, scaled_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, scaledBuffer );
+			}
 		}
 	}
 done:
@@ -822,6 +969,8 @@ done:
 
 	GL_CheckErrors();
 
+	if ( formatBuffer != 0 )
+		ri.Hunk_FreeTempMemory( formatBuffer );
 	if ( scaledBuffer != 0 )
 		ri.Hunk_FreeTempMemory( scaledBuffer );
 	if ( resampledBuffer != 0 )

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -28,6 +28,7 @@ qboolean    textureFilterAnisotropic = qfalse;
 int         maxAnisotropy = 0;
 float       displayAspect = 0.0f;
 qboolean    haveClampToEdge = qfalse;
+qboolean    readFormatAvailable = qfalse;
 
 glstate_t	glState;
 
@@ -365,20 +366,55 @@ Return value must be freed with ri.Hunk_FreeTempMemory()
 byte *RB_ReadPixels(int x, int y, int width, int height, size_t *offset, int *padlen)
 {
 	byte *buffer, *bufstart;
-	int padwidth, linelen;
-	GLint packAlign;
-	
+	int padwidth, linelen, bytesPerPixel;
+	int yin, xin, xout;
+	GLint packAlign, format, type;
+
+	// OpenGL ES is only required to support reading GL_RGBA
+	if (qglesMajorVersion >= 1) {
+		if (readFormatAvailable) {
+			qglGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT_OES, &format);
+			qglGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE_OES, &type);
+		} else {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_BYTE;
+		}
+
+		if (format == GL_RGB && type == GL_UNSIGNED_BYTE) {
+			bytesPerPixel = 3;
+		} else {
+			format = GL_RGBA;
+			bytesPerPixel = 4;
+		}
+	} else {
+		format = GL_RGB;
+		bytesPerPixel = 3;
+	}
+
 	qglGetIntegerv(GL_PACK_ALIGNMENT, &packAlign);
-	
-	linelen = width * 3;
+
+	linelen = width * bytesPerPixel;
 	padwidth = PAD(linelen, packAlign);
-	
+
 	// Allocate a few more bytes so that we can choose an alignment we like
 	buffer = ri.Hunk_AllocateTempMemory(padwidth * height + *offset + packAlign - 1);
-	
+
 	bufstart = PADP((intptr_t) buffer + *offset, packAlign);
-	qglReadPixels(x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE, bufstart);
-	
+	qglReadPixels(x, y, width, height, format, GL_UNSIGNED_BYTE, bufstart);
+
+	linelen = width * 3;
+
+	// Convert RGBA to RGB, in place, line by line
+	if (format == GL_RGBA) {
+		for (yin = 0; yin < height; yin++) {
+			for (xin = 0, xout = 0; xout < linelen; xin += 4, xout += 3) {
+				bufstart[yin*padwidth + xout + 0] = bufstart[yin*padwidth + xin + 0];
+				bufstart[yin*padwidth + xout + 1] = bufstart[yin*padwidth + xin + 1];
+				bufstart[yin*padwidth + xout + 2] = bufstart[yin*padwidth + xin + 2];
+			}
+		}
+	}
+
 	*offset = bufstart - buffer;
 	*padlen = padwidth - linelen;
 	
@@ -757,26 +793,51 @@ const void *RB_TakeVideoFrameCmd( const void *data )
 {
 	const videoFrameCommand_t	*cmd;
 	byte				*cBuf;
-	size_t				memcount, linelen;
+	size_t				memcount, bytesPerPixel, linelen, avilinelen;
 	int				padwidth, avipadwidth, padlen, avipadlen;
-	GLint packAlign;
+	int				yin, xin, xout;
+	GLint packAlign, format, type;
 	
 	cmd = (const videoFrameCommand_t *)data;
 	
+	// OpenGL ES is only required to support reading GL_RGBA
+	if (qglesMajorVersion >= 1) {
+		if (readFormatAvailable) {
+			qglGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT_OES, &format);
+			qglGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE_OES, &type);
+		} else {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_BYTE;
+		}
+
+		if (format == GL_RGB && type == GL_UNSIGNED_BYTE) {
+			bytesPerPixel = 3;
+		} else {
+			format = GL_RGBA;
+			bytesPerPixel = 4;
+		}
+	} else {
+		format = GL_RGB;
+		bytesPerPixel = 3;
+	}
+
 	qglGetIntegerv(GL_PACK_ALIGNMENT, &packAlign);
 
-	linelen = cmd->width * 3;
+	linelen = cmd->width * bytesPerPixel;
 
 	// Alignment stuff for glReadPixels
 	padwidth = PAD(linelen, packAlign);
 	padlen = padwidth - linelen;
+
+	avilinelen = cmd->width * 3;
+
 	// AVI line padding
-	avipadwidth = PAD(linelen, AVI_LINE_PADDING);
-	avipadlen = avipadwidth - linelen;
+	avipadwidth = PAD(avilinelen, AVI_LINE_PADDING);
+	avipadlen = avipadwidth - avilinelen;
 
 	cBuf = PADP(cmd->captureBuffer, packAlign);
 		
-	qglReadPixels(0, 0, cmd->width, cmd->height, GL_RGB,
+	qglReadPixels(0, 0, cmd->width, cmd->height, format,
 		GL_UNSIGNED_BYTE, cBuf);
 
 	memcount = padwidth * cmd->height;
@@ -787,7 +848,21 @@ const void *RB_TakeVideoFrameCmd( const void *data )
 
 	if(cmd->motionJpeg)
 	{
-		memcount = RE_SaveJPGToBuffer(cmd->encodeBuffer, linelen * cmd->height,
+		// Convert RGBA to RGB, in place, line by line
+		if (format == GL_RGBA) {
+			linelen = cmd->width * 3;
+			padlen = padwidth - linelen;
+
+			for (yin = 0; yin < cmd->height; yin++) {
+				for (xin = 0, xout = 0; xout < linelen; xin += 4, xout += 3) {
+					cBuf[yin*padwidth + xout + 0] = cBuf[yin*padwidth + xin + 0];
+					cBuf[yin*padwidth + xout + 1] = cBuf[yin*padwidth + xin + 1];
+					cBuf[yin*padwidth + xout + 2] = cBuf[yin*padwidth + xin + 2];
+				}
+			}
+		}
+
+		memcount = RE_SaveJPGToBuffer(cmd->encodeBuffer, avilinelen * cmd->height,
 			r_aviMotionJpegQuality->integer,
 			cmd->width, cmd->height, cBuf, padlen);
 		ri.CL_WriteAVIVideoFrame(cmd->encodeBuffer, memcount);
@@ -810,7 +885,7 @@ const void *RB_TakeVideoFrameCmd( const void *data )
 				*destptr++ = srcptr[2];
 				*destptr++ = srcptr[1];
 				*destptr++ = srcptr[0];
-				srcptr += 3;
+				srcptr += bytesPerPixel;
 			}
 			
 			Com_Memset(destptr, '\0', avipadlen);
@@ -961,7 +1036,7 @@ void GfxInfo_f( void )
 		ri.Printf( PRINT_ALL, "rendering primitives: " );
 		primitives = r_primitives->integer;
 		if ( primitives == 0 ) {
-			if ( qglLockArraysEXT ) {
+			if ( qglLockArraysEXT || qglesMajorVersion >= 1 ) {
 				primitives = 2;
 			} else {
 				primitives = 1;
@@ -1296,6 +1371,7 @@ void RE_Shutdown( qboolean destroyWindow ) {
 		maxAnisotropy = 0;
 		displayAspect = 0.0f;
 		haveClampToEdge = qfalse;
+		readFormatAvailable = qfalse;
 
 		Com_Memset( &glState, 0, sizeof( glState ) );
 	}

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -1224,10 +1224,12 @@ typedef struct stageVars
 } stageVars_t;
 
 
+// xyz index SHADER_MAX_VERTEXES-1 is used to check for overflow
+// xyz index >= SHADER_MAX_VERTEXES are used for DrawNormals() and RB_ShadowTessEnd()
 typedef struct shaderCommands_s 
 {
 	glIndex_t	indexes[SHADER_MAX_INDEXES] QALIGN(16);
-	vec4_t		xyz[SHADER_MAX_VERTEXES] QALIGN(16);
+	vec4_t		xyz[SHADER_MAX_VERTEXES*2] QALIGN(16);
 	vec4_t		normal[SHADER_MAX_VERTEXES] QALIGN(16);
 	vec2_t		texCoords[SHADER_MAX_VERTEXES][2] QALIGN(16);
 	color4ub_t	vertexColors[SHADER_MAX_VERTEXES] QALIGN(16);
@@ -1266,6 +1268,8 @@ void RB_StageIteratorLightmappedMultitexture( void );
 
 void RB_AddQuadStamp( vec3_t origin, vec3_t left, vec3_t up, byte *color );
 void RB_AddQuadStampExt( vec3_t origin, vec3_t left, vec3_t up, byte *color, float s1, float t1, float s2, float t2 );
+void RB_InstantQuad( vec4_t quadVerts[4] );
+void RB_InstantQuad2( vec4_t quadVerts[4], vec2_t texCoords[4] );
 
 void RB_ShowImages( void );
 

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -40,8 +40,8 @@ QGL_DESKTOP_1_1_FIXED_FUNCTION_PROCS;
 QGL_3_0_PROCS;
 #undef GLE
 
-#define GL_INDEX_TYPE		GL_UNSIGNED_INT
-typedef unsigned int glIndex_t;
+#define GL_INDEX_TYPE		GL_UNSIGNED_SHORT
+typedef unsigned short glIndex_t;
 
 // 14 bits
 // can't be increased without changing bit packing for drawsurfs
@@ -1610,6 +1610,8 @@ void RE_TakeVideoFrame( int width, int height,
 
 void R_DrawElements( int numIndexes, const glIndex_t *indexes );
 void VectorArrayNormalize( vec4_t *normals, unsigned int count );
+
+void R_ConvertTextureFormat( const byte *in, int width, int height, GLenum format, GLenum type, byte *out );
 
 #ifdef idppc_altivec
 void LerpMeshVertexes_altivec( md3Surface_t *surf, float backlerp );

--- a/code/renderergl1/tr_main.c
+++ b/code/renderergl1/tr_main.c
@@ -1299,29 +1299,36 @@ R_DebugPolygon
 ================
 */
 void R_DebugPolygon( int color, int numPoints, float *points ) {
-	int		i;
+	if ( numPoints < 3 ) {
+		ri.Printf( PRINT_WARNING, "Debug polygon with color 0x%08X only has %d points (must have at least 3)\n", color, numPoints );
+		return;
+	}
 
 	GL_State( GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+	qglDisableClientState( GL_COLOR_ARRAY );
+	qglDisableClientState( GL_TEXTURE_COORD_ARRAY );
+
+	qglVertexPointer( 3, GL_FLOAT, 0, points );
+
+	if (qglLockArraysEXT) {
+		qglLockArraysEXT(0, numPoints);
+		GLimp_LogComment( "glLockArraysEXT\n" );
+	}
 
 	// draw solid shade
-
 	qglColor3f( color&1, (color>>1)&1, (color>>2)&1 );
-	qglBegin( GL_POLYGON );
-	for ( i = 0 ; i < numPoints ; i++ ) {
-		qglVertex3fv( points + i * 3 );
-	}
-	qglEnd();
+	qglDrawArrays( GL_TRIANGLE_FAN, 0, numPoints );
 
 	// draw wireframe outline
-	GL_State( GLS_POLYMODE_LINE | GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 	qglDepthRange( 0, 0 );
 	qglColor3f( 1, 1, 1 );
-	qglBegin( GL_POLYGON );
-	for ( i = 0 ; i < numPoints ; i++ ) {
-		qglVertex3fv( points + i * 3 );
-	}
-	qglEnd();
+	qglDrawArrays( GL_LINE_LOOP, 0, numPoints );
 	qglDepthRange( 0, 1 );
+
+	if (qglUnlockArraysEXT) {
+		qglUnlockArraysEXT();
+		GLimp_LogComment( "glUnlockArraysEXT\n" );
+	}
 }
 
 /*

--- a/code/renderergl1/tr_shade.c
+++ b/code/renderergl1/tr_shade.c
@@ -165,8 +165,19 @@ void R_DrawElements( int numIndexes, const glIndex_t *indexes ) {
 
 	primitives = r_primitives->integer;
 
+	if ( qglesMajorVersion >= 1 ) {
+		if ( primitives == 0 ) {
+			primitives = 2;
+		}
+
+		if ( primitives == 1 || primitives == 3 ) {
+			ri.Printf( PRINT_WARNING, "OpenGL ES does not support glBegin() required for r_primitives %d\n", primitives );
+			ri.Cvar_Set( "r_primitives", "0" );
+			primitives = 2;
+		}
+	}
 	// default is to use triangles if compiled vertex arrays are present
-	if ( primitives == 0 ) {
+	else if ( primitives == 0 ) {
 		if ( qglLockArraysEXT ) {
 			primitives = 2;
 		} else {

--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -671,8 +671,8 @@ Used for cinematics.
 void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *data, int client, qboolean dirty) {
 	int			i, j;
 	int			start, end;
-	vec4_t quadVerts[4];
-	vec2_t texCoords[4];
+	vec4_t		quadVerts[4];
+	vec2_t		texCoords[4];
 
 	if ( !tr.registered ) {
 		return;
@@ -716,22 +716,22 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 
 	RB_SetGL2D();
 
-	VectorSet4(quadVerts[0], x,     y,     0.0f, 1.0f);
-	VectorSet4(quadVerts[1], x + w, y,     0.0f, 1.0f);
-	VectorSet4(quadVerts[2], x + w, y + h, 0.0f, 1.0f);
-	VectorSet4(quadVerts[3], x,     y + h, 0.0f, 1.0f);
+	Vector4Set( quadVerts[0], x,     y,     0.0f, 1.0f );
+	Vector4Set( quadVerts[1], x + w, y,     0.0f, 1.0f );
+	Vector4Set( quadVerts[2], x + w, y + h, 0.0f, 1.0f );
+	Vector4Set( quadVerts[3], x,     y + h, 0.0f, 1.0f );
 
-	VectorSet2(texCoords[0], 0.5f / cols,          0.5f / rows);
-	VectorSet2(texCoords[1], (cols - 0.5f) / cols, 0.5f / rows);
-	VectorSet2(texCoords[2], (cols - 0.5f) / cols, (rows - 0.5f) / rows);
-	VectorSet2(texCoords[3], 0.5f / cols,          (rows - 0.5f) / rows);
+	Vector2Set( texCoords[0], 0.5f / cols,          0.5f / rows );
+	Vector2Set( texCoords[1], (cols - 0.5f) / cols, 0.5f / rows );
+	Vector2Set( texCoords[2], (cols - 0.5f) / cols, (rows - 0.5f) / rows );
+	Vector2Set( texCoords[3], 0.5f / cols,          (rows - 0.5f) / rows );
 
 	GLSL_BindProgram(&tr.textureColorShader);
 	
 	GLSL_SetUniformMat4(&tr.textureColorShader, UNIFORM_MODELVIEWPROJECTIONMATRIX, glState.modelviewProjection);
 	GLSL_SetUniformVec4(&tr.textureColorShader, UNIFORM_COLOR, colorWhite);
 
-	RB_InstantQuad2(quadVerts, texCoords);
+	RB_InstantQuad2( quadVerts, texCoords );
 }
 
 void RE_UploadCinematic (int w, int h, int cols, int rows, const byte *data, int client, qboolean dirty) {
@@ -1221,6 +1221,7 @@ void RB_ShowImages( void ) {
 	image_t	*image;
 	float	x, y, w, h;
 	int		start, end;
+	vec4_t	quadVerts[4];
 
 	RB_SetGL2D();
 
@@ -1244,18 +1245,14 @@ void RB_ShowImages( void ) {
 			h *= image->uploadHeight / 512.0f;
 		}
 
-		{
-			vec4_t quadVerts[4];
+		GL_BindToTMU( image, TB_COLORMAP );
 
-			GL_BindToTMU(image, TB_COLORMAP);
+		Vector4Set( quadVerts[0], x, y, 0, 1 );
+		Vector4Set( quadVerts[1], x + w, y, 0, 1 );
+		Vector4Set( quadVerts[2], x + w, y + h, 0, 1 );
+		Vector4Set( quadVerts[3], x, y + h, 0, 1 );
 
-			VectorSet4(quadVerts[0], x, y, 0, 1);
-			VectorSet4(quadVerts[1], x + w, y, 0, 1);
-			VectorSet4(quadVerts[2], x + w, y + h, 0, 1);
-			VectorSet4(quadVerts[3], x, y + h, 0, 1);
-
-			RB_InstantQuad(quadVerts);
-		}
+		RB_InstantQuad( quadVerts );
 	}
 
 	qglFinish();

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -31,6 +31,7 @@ qboolean    textureFilterAnisotropic = qfalse;
 int         maxAnisotropy = 0;
 float       displayAspect = 0.0f;
 qboolean    haveClampToEdge = qfalse;
+qboolean    readFormatAvailable = qfalse;
 
 glstate_t	glState;
 
@@ -1554,6 +1555,7 @@ void RE_Shutdown( qboolean destroyWindow ) {
 		maxAnisotropy = 0;
 		displayAspect = 0.0f;
 		haveClampToEdge = qfalse;
+		readFormatAvailable = qfalse;
 
 		Com_Memset( &glState, 0, sizeof( glState ) );
 	}

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -2020,10 +2020,12 @@ typedef struct stageVars
 	vec2_t		texcoords[NUM_TEXTURE_BUNDLES][SHADER_MAX_VERTEXES];
 } stageVars_t;
 
+// xyz index SHADER_MAX_VERTEXES-1 is used to check for overflow
+// xyz index >= SHADER_MAX_VERTEXES are used for DrawNormals() and RB_ShadowTessEnd()
 typedef struct shaderCommands_s 
 {
 	glIndex_t	indexes[SHADER_MAX_INDEXES] QALIGN(16);
-	vec4_t		xyz[SHADER_MAX_VERTEXES] QALIGN(16);
+	vec4_t		xyz[SHADER_MAX_VERTEXES*2] QALIGN(16);
 	int16_t		normal[SHADER_MAX_VERTEXES][4] QALIGN(16);
 	int16_t		tangent[SHADER_MAX_VERTEXES][4] QALIGN(16);
 	vec2_t		texCoords[SHADER_MAX_VERTEXES] QALIGN(16);

--- a/code/renderergl2/tr_main.c
+++ b/code/renderergl2/tr_main.c
@@ -1681,29 +1681,36 @@ R_DebugPolygon
 void R_DebugPolygon( int color, int numPoints, float *points ) {
 	// FIXME: implement this
 #if 0
-	int		i;
+	if ( numPoints < 3 ) {
+		ri.Printf( PRINT_WARNING, "Debug polygon with color 0x%08X only has %d points (must have at least 3)\n", color, numPoints );
+		return;
+	}
 
 	GL_State( GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
+	qglDisableClientState( GL_COLOR_ARRAY );
+	qglDisableClientState( GL_TEXTURE_COORD_ARRAY );
+
+	qglVertexPointer( 3, GL_FLOAT, 0, points );
+
+	if (qglLockArraysEXT) {
+		qglLockArraysEXT(0, numPoints);
+		GLimp_LogComment( "glLockArraysEXT\n" );
+	}
 
 	// draw solid shade
-
 	qglColor3f( color&1, (color>>1)&1, (color>>2)&1 );
-	qglBegin( GL_POLYGON );
-	for ( i = 0 ; i < numPoints ; i++ ) {
-		qglVertex3fv( points + i * 3 );
-	}
-	qglEnd();
+	qglDrawArrays( GL_TRIANGLE_FAN, 0, numPoints );
 
 	// draw wireframe outline
-	GL_State( GLS_POLYMODE_LINE | GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 	qglDepthRange( 0, 0 );
 	qglColor3f( 1, 1, 1 );
-	qglBegin( GL_POLYGON );
-	for ( i = 0 ; i < numPoints ; i++ ) {
-		qglVertex3fv( points + i * 3 );
-	}
-	qglEnd();
+	qglDrawArrays( GL_LINE_LOOP, 0, numPoints );
 	qglDepthRange( 0, 1 );
+
+	if (qglUnlockArraysEXT) {
+		qglUnlockArraysEXT();
+		GLimp_LogComment( "glUnlockArraysEXT\n" );
+	}
 #endif
 }
 

--- a/code/renderergl2/tr_shadows.c
+++ b/code/renderergl2/tr_shadows.c
@@ -44,7 +44,8 @@ typedef struct {
 static	edgeDef_t	edgeDefs[SHADER_MAX_VERTEXES][MAX_EDGE_DEFS];
 static	int			numEdgeDefs[SHADER_MAX_VERTEXES];
 //static	int			facing[SHADER_MAX_INDEXES/3];
-//static	vec3_t		shadowXyz[SHADER_MAX_VERTEXES];
+static	glIndex_t	shadowIndexes[SHADER_MAX_VERTEXES*MAX_EDGE_DEFS*6];
+static	int			numShadowIndexes;
 
 void R_AddEdgeDef( int i1, int i2, int facing ) {
 	int		c;
@@ -59,9 +60,7 @@ void R_AddEdgeDef( int i1, int i2, int facing ) {
 	numEdgeDefs[ i1 ]++;
 }
 
-void R_RenderShadowEdges( void ) {
-	// FIXME: implement this
-#if 0
+void R_CalculateShadowEdges( void ) {
 	int		i;
 
 #if 0
@@ -69,6 +68,8 @@ void R_RenderShadowEdges( void ) {
 
 	// dumb way -- render every triangle's edges
 	numTris = tess.numIndexes / 3;
+
+	numShadowIndexes = 0;
 
 	for ( i = 0 ; i < numTris ; i++ ) {
 		int		i1, i2, i3;
@@ -81,15 +82,16 @@ void R_RenderShadowEdges( void ) {
 		i2 = tess.indexes[ i*3 + 1 ];
 		i3 = tess.indexes[ i*3 + 2 ];
 
+		// FIXME: Convert to using shadowIndexes
 		qglBegin( GL_TRIANGLE_STRIP );
 		qglVertex3fv( tess.xyz[ i1 ] );
-		qglVertex3fv( shadowXyz[ i1 ] );
+		qglVertex3fv( tess.xyz[ i1 + tess.numVertexes ] );
 		qglVertex3fv( tess.xyz[ i2 ] );
-		qglVertex3fv( shadowXyz[ i2 ] );
+		qglVertex3fv( tess.xyz[ i2 + tess.numVertexes ] );
 		qglVertex3fv( tess.xyz[ i3 ] );
-		qglVertex3fv( shadowXyz[ i3 ] );
+		qglVertex3fv( tess.xyz[ i3 + tess.numVertexes ] );
 		qglVertex3fv( tess.xyz[ i1 ] );
-		qglVertex3fv( shadowXyz[ i1 ] );
+		qglVertex3fv( tess.xyz[ i1 + tess.numVertexes ] );
 		qglEnd();
 	}
 #else
@@ -98,6 +100,8 @@ void R_RenderShadowEdges( void ) {
 	int		i2;
 	int		c_edges, c_rejected;
 	int		hit[2];
+
+	numShadowIndexes = 0;
 
 	// an edge is NOT a silhouette edge if its face doesn't face the light,
 	// or if it has a reverse paired edge that also faces the light.
@@ -125,21 +129,29 @@ void R_RenderShadowEdges( void ) {
 			}
 
 			// if it doesn't share the edge with another front facing
-			// triangle, it is a sil edge
+			// triangle, it is a silhouette edge
 			if ( hit[ 1 ] == 0 ) {
+/*
 				qglBegin( GL_TRIANGLE_STRIP );
 				qglVertex3fv( tess.xyz[ i ] );
-				qglVertex3fv( shadowXyz[ i ] );
+				qglVertex3fv( tess.xyz[ i + tess.numVertexes ] );
 				qglVertex3fv( tess.xyz[ i2 ] );
-				qglVertex3fv( shadowXyz[ i2 ] );
+				qglVertex3fv( tess.xyz[ i2 + tess.numVertexes ] );
 				qglEnd();
+*/
+				shadowIndexes[numShadowIndexes++] = i;
+				shadowIndexes[numShadowIndexes++] = i + tess.numVertexes;
+				shadowIndexes[numShadowIndexes++] = i2;
+
+				shadowIndexes[numShadowIndexes++] = i2;
+				shadowIndexes[numShadowIndexes++] = i + tess.numVertexes;
+				shadowIndexes[numShadowIndexes++] = i2 + tess.numVertexes;
 				c_edges++;
 			} else {
 				c_rejected++;
 			}
 		}
 	}
-#endif
 #endif
 }
 
@@ -171,7 +183,7 @@ void RB_ShadowTessEnd( void ) {
 
 	// project vertexes away from light direction
 	for ( i = 0 ; i < tess.numVertexes ; i++ ) {
-		VectorMA( tess.xyz[i], -512, lightDir, shadowXyz[i] );
+		VectorMA( tess.xyz[i], -512, lightDir, tess.xyz[i + tess.numVertexes] );
 	}
 
 	// decide which triangles face the light
@@ -209,11 +221,23 @@ void RB_ShadowTessEnd( void ) {
 		R_AddEdgeDef( i3, i1, facing[ i ] );
 	}
 
+	R_CalculateShadowEdges();
+
 	// draw the silhouette edges
 
 	GL_BindToTMU( tr.whiteImage, TB_COLORMAP );
 	GL_State( GLS_SRCBLEND_ONE | GLS_DSTBLEND_ZERO );
 	qglColor3f( 0.2f, 0.2f, 0.2f );
+
+	qglDisableClientState( GL_TEXTURE_COORD_ARRAY );
+	qglDisableClientState( GL_COLOR_ARRAY );
+
+	qglVertexPointer( 3, GL_FLOAT, 16, tess.xyz );	// padded for SIMD
+
+	if (qglLockArraysEXT) {
+		qglLockArraysEXT(0, tess.numVertexes*2);
+		GLimp_LogComment( "glLockArraysEXT\n" );
+	}
 
 	// don't write to the color buffer
 	qglGetBooleanv(GL_COLOR_WRITEMASK, rgba);
@@ -225,16 +249,23 @@ void RB_ShadowTessEnd( void ) {
 	GL_Cull( CT_BACK_SIDED );
 	qglStencilOp( GL_KEEP, GL_KEEP, GL_INCR );
 
-	R_RenderShadowEdges();
+	R_DrawElements( numShadowIndexes, shadowIndexes );
 
 	GL_Cull( CT_FRONT_SIDED );
 	qglStencilOp( GL_KEEP, GL_KEEP, GL_DECR );
 
-	R_RenderShadowEdges();
+	R_DrawElements( numShadowIndexes, shadowIndexes );
 
+	if (qglUnlockArraysEXT) {
+		qglUnlockArraysEXT();
+		GLimp_LogComment( "glUnlockArraysEXT\n" );
+	}
 
 	// reenable writing to the color buffer
 	qglColorMask(rgba[0], rgba[1], rgba[2], rgba[3]);
+
+	// FIXME: kind of ugly to have to clear this to avoid overflow detection.
+	memset( tess.xyz[SHADER_MAX_VERTEXES-1], 0, sizeof ( tess.xyz[0] ) );
 #endif
 }
 
@@ -252,6 +283,8 @@ overlap and double darken.
 void RB_ShadowFinish( void ) {
 	// FIXME: implement this
 #if 0
+	vec4_t quadVerts[4];
+
 	if ( r_shadows->integer != 2 ) {
 		return;
 	}
@@ -273,12 +306,12 @@ void RB_ShadowFinish( void ) {
 //	qglColor3f( 1, 0, 0 );
 //	GL_State( GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ZERO );
 
-	qglBegin( GL_QUADS );
-	qglVertex3f( -100, 100, -10 );
-	qglVertex3f( 100, 100, -10 );
-	qglVertex3f( 100, -100, -10 );
-	qglVertex3f( -100, -100, -10 );
-	qglEnd ();
+	Vector4Set( quadVerts[0], -100,  100, -10, 0 );
+	Vector4Set( quadVerts[1],  100,  100, -10, 0 );
+	Vector4Set( quadVerts[2],  100, -100, -10, 0 );
+	Vector4Set( quadVerts[3], -100, -100, -10, 0 );
+
+	RB_InstantQuad( quadVerts );
 
 	qglColor4f(1,1,1,1);
 	qglDisable( GL_STENCIL_TEST );

--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -52,6 +52,7 @@ cvar_t *r_allowSoftwareGL; // Don't abort out if a hardware visual can't be obta
 cvar_t *r_allowResize; // make window resizable
 cvar_t *r_centerWindow;
 cvar_t *r_sdlDriver;
+cvar_t *r_useOpenGLES;
 
 int qglMajorVersion, qglMinorVersion;
 int qglesMajorVersion, qglesMinorVersion;
@@ -232,6 +233,52 @@ static void GLimp_DetectAvailableModes(void)
 
 /*
 ===============
+OpenGL ES compatibility
+===============
+*/
+static void APIENTRY GLimp_GLES_ClearDepth( GLclampd depth ) {
+	qglClearDepthf( depth );
+}
+
+static void APIENTRY GLimp_GLES_ClipPlane( GLenum plane, const GLdouble *equation ) {
+	GLfloat values[4];
+	values[0] = equation[0];
+	values[1] = equation[1];
+	values[2] = equation[2];
+	values[3] = equation[3];
+	qglClipPlanef( plane, values );
+}
+
+static void APIENTRY GLimp_GLES_Color3f( GLfloat red, GLfloat green, GLfloat blue ) {
+	qglColor4f( red, green, blue, 1.0f );
+}
+
+static void APIENTRY GLimp_GLES_Color4ubv( const GLubyte *v ) {
+	qglColor4ub( v[0], v[1], v[2], v[3] );
+}
+
+static void APIENTRY GLimp_GLES_DepthRange( GLclampd near_val, GLclampd far_val ) {
+	qglDepthRangef( near_val, far_val );
+}
+
+static void APIENTRY GLimp_GLES_DrawBuffer( GLenum mode ) {
+	// unsupported
+}
+
+static void APIENTRY GLimp_GLES_Frustum( GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val ) {
+	qglFrustumf( left, right, bottom, top, near_val, far_val );
+}
+
+static void APIENTRY GLimp_GLES_Ortho( GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val ) {
+	qglOrthof( left, right, bottom, top, near_val, far_val );
+}
+
+static void APIENTRY GLimp_GLES_PolygonMode( GLenum face, GLenum mode ) {
+	// unsupported
+}
+
+/*
+===============
 GLimp_GetProcAddresses
 
 Get addresses for OpenGL functions.
@@ -288,8 +335,16 @@ static qboolean GLimp_GetProcAddresses( qboolean fixedFunction ) {
 			QGL_1_1_FIXED_FUNCTION_PROCS;
 			QGL_ES_1_1_PROCS;
 			QGL_ES_1_1_FIXED_FUNCTION_PROCS;
-			// error so this doesn't segfault due to NULL desktop GL functions being used
-			Com_Error( ERR_FATAL, "Unsupported OpenGL Version: %s", version );
+
+			qglClearDepth = GLimp_GLES_ClearDepth;
+			qglClipPlane = GLimp_GLES_ClipPlane;
+			qglColor3f = GLimp_GLES_Color3f;
+			qglColor4ubv = GLimp_GLES_Color4ubv;
+			qglDepthRange = GLimp_GLES_DepthRange;
+			qglDrawBuffer = GLimp_GLES_DrawBuffer;
+			qglFrustum = GLimp_GLES_Frustum;
+			qglOrtho = GLimp_GLES_Ortho;
+			qglPolygonMode = GLimp_GLES_PolygonMode;
 		} else {
 			Com_Error( ERR_FATAL, "Unsupported OpenGL Version (%s), OpenGL 1.1 is required", version );
 		}
@@ -503,6 +558,9 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 	{
 		int testColorBits, testDepthBits, testStencilBits;
 		int realColorBits[3];
+		int profileMask;
+
+		SDL_GL_ResetAttributes();
 
 		// 0 - default
 		// 1 - minus colorBits
@@ -631,13 +689,34 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 
 		SDL_SetWindowIcon( SDL_window, icon );
 
-		if (!fixedFunction)
-		{
-			int profileMask, majorVersion, minorVersion;
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &profileMask);
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &majorVersion);
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minorVersion);
+		SDL_GL_GetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, &profileMask );
 
+#ifdef __arm__
+		// make r_useOpenGLES -1 always use OpenGL ES API on ARM
+		if( r_useOpenGLES->integer >= 1 || r_useOpenGLES->integer == -1 )
+#else
+		if( r_useOpenGLES->integer >= 1 || ( r_useOpenGLES->integer == -1 && profileMask == SDL_GL_CONTEXT_PROFILE_ES ) )
+#endif
+		{
+			if( fixedFunction )
+			{
+				// fixed function pipeline
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES );
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_MAJOR_VERSION, 1 );
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_MINOR_VERSION, 1 );
+			}
+			else
+			{
+				// shader pipeline
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES );
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_MAJOR_VERSION, 2 );
+				SDL_GL_SetAttribute( SDL_GL_CONTEXT_MINOR_VERSION, 0 );
+			}
+
+			SDL_glContext = NULL;
+		}
+		else if( !fixedFunction )
+		{
 			ri.Printf(PRINT_ALL, "Trying to get an OpenGL 3.2 core context\n");
 			SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
@@ -645,11 +724,11 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 			if ((SDL_glContext = SDL_GL_CreateContext(SDL_window)) == NULL)
 			{
 				ri.Printf(PRINT_ALL, "SDL_GL_CreateContext failed: %s\n", SDL_GetError());
-				ri.Printf(PRINT_ALL, "Reverting to default context\n");
+				ri.Printf(PRINT_ALL, "Reverting to OpenGL 2.0 context\n");
 
-				SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profileMask);
-				SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, majorVersion);
-				SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorVersion);
+				SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
+				SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+				SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 			}
 			else
 			{
@@ -676,15 +755,19 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 					SDL_GL_DeleteContext(SDL_glContext);
 					SDL_glContext = NULL;
 
-					SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profileMask);
-					SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, majorVersion);
-					SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorVersion);
+					SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
+					SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+					SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 				}
 			}
 		}
 		else
 		{
 			SDL_glContext = NULL;
+
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 		}
 
 		if ( !SDL_glContext )
@@ -815,8 +898,8 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 	glConfig.textureCompression = TC_NONE;
 
 	// GL_EXT_texture_compression_s3tc
-	if ( SDL_GL_ExtensionSupported( "GL_ARB_texture_compression" ) &&
-	     SDL_GL_ExtensionSupported( "GL_EXT_texture_compression_s3tc" ) )
+	if ( ( QGLES_VERSION_ATLEAST( 2, 0 ) || SDL_GL_ExtensionSupported( "GL_ARB_texture_compression" ) )
+	     && SDL_GL_ExtensionSupported( "GL_EXT_texture_compression_s3tc" ) )
 	{
 		if ( r_ext_compressed_textures->value )
 		{
@@ -834,6 +917,7 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 	}
 
 	// GL_S3_s3tc ... legacy extension before GL_EXT_texture_compression_s3tc.
+	// (not in OpenGL ES)
 	if (glConfig.textureCompression == TC_NONE)
 	{
 		if ( SDL_GL_ExtensionSupported( "GL_S3_s3tc" ) )
@@ -859,7 +943,7 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 	{
 		// GL_EXT_texture_env_add
 		glConfig.textureEnvAddAvailable = qfalse;
-		if ( SDL_GL_ExtensionSupported( "GL_EXT_texture_env_add" ) )
+		if ( QGLES_VERSION_ATLEAST( 1, 0 ) || SDL_GL_ExtensionSupported( "GL_EXT_texture_env_add" ) )
 		{
 			if ( r_ext_texture_env_add->integer )
 			{
@@ -881,13 +965,22 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 		qglMultiTexCoord2fARB = NULL;
 		qglActiveTextureARB = NULL;
 		qglClientActiveTextureARB = NULL;
-		if ( SDL_GL_ExtensionSupported( "GL_ARB_multitexture" ) )
+		if ( QGLES_VERSION_ATLEAST( 1, 0 ) || SDL_GL_ExtensionSupported( "GL_ARB_multitexture" ) )
 		{
 			if ( r_ext_multitexture->value )
 			{
-				qglMultiTexCoord2fARB = SDL_GL_GetProcAddress( "glMultiTexCoord2fARB" );
-				qglActiveTextureARB = SDL_GL_GetProcAddress( "glActiveTextureARB" );
-				qglClientActiveTextureARB = SDL_GL_GetProcAddress( "glClientActiveTextureARB" );
+				if ( QGLES_VERSION_ATLEAST( 1, 0 ) )
+				{
+					qglMultiTexCoord2fARB = NULL;
+					qglActiveTextureARB = SDL_GL_GetProcAddress( "glActiveTexture" );
+					qglClientActiveTextureARB = SDL_GL_GetProcAddress( "glClientActiveTexture" );
+				}
+				else
+				{
+					qglMultiTexCoord2fARB = SDL_GL_GetProcAddress( "glMultiTexCoord2fARB" );
+					qglActiveTextureARB = SDL_GL_GetProcAddress( "glActiveTextureARB" );
+					qglClientActiveTextureARB = SDL_GL_GetProcAddress( "glClientActiveTextureARB" );
+				}
 
 				if ( qglActiveTextureARB )
 				{
@@ -918,6 +1011,7 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 		}
 
 		// GL_EXT_compiled_vertex_array
+		// (not in OpenGL ES)
 		if ( SDL_GL_ExtensionSupported( "GL_EXT_compiled_vertex_array" ) )
 		{
 			if ( r_ext_compiled_vertex_array->value )
@@ -976,6 +1070,20 @@ static void GLimp_InitExtensions( qboolean fixedFunction )
 	{
 		ri.Printf( PRINT_ALL, "...GL_SGIS_texture_edge_clamp not found\n" );
 	}
+
+	if ( QGLES_VERSION_ATLEAST( 1, 0 ) )
+	{
+		readFormatAvailable = qfalse;
+		if ( QGLES_VERSION_ATLEAST( 2, 0 ) || SDL_GL_ExtensionSupported( "GL_OES_read_format" ) )
+		{
+			ri.Printf( PRINT_ALL, "...using GL_OES_read_format\n" );
+			readFormatAvailable = qtrue;
+		}
+		else
+		{
+			ri.Printf( PRINT_ALL, "...GL_OES_read_format not found\n" );
+		}
+	}
 }
 
 #define R_MODE_FALLBACK 3 // 640 * 480
@@ -996,6 +1104,7 @@ void GLimp_Init( qboolean fixedFunction )
 	r_sdlDriver = ri.Cvar_Get( "r_sdlDriver", "", CVAR_ROM );
 	r_allowResize = ri.Cvar_Get( "r_allowResize", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	r_centerWindow = ri.Cvar_Get( "r_centerWindow", "0", CVAR_ARCHIVE | CVAR_LATCH );
+	r_useOpenGLES = ri.Cvar_Get( "r_useOpenGLES", "-1", CVAR_NORESTART | CVAR_LATCH );
 
 	if( ri.Cvar_VariableIntegerValue( "com_abnormalExit" ) )
 	{


### PR DESCRIPTION
I added support for OpenGL ES 1.1 to the opengl1 renderer. This is loosely based on the OpenPandora port by ptitSeb from PR #14. Using OpenGL ES API is chosen at run-time based on SDL default GL context type or forced with r_useOpenGLES cvar. There is a single renderer_opengl1 dll.

I've made opengl1 be compatible with OpenGL ES when possible or check `if ( qglesMajorVersion >= 1 )` or use wrapper functions for incompatible OpenGL ES functions (glOrtho(double) vs glOrthof(float)). This is my preferred method and how I'd like OpenGL ES 2 added to the opengl2 renderer.

Is this an acceptable way to add support? Or is it preferable to use a separate renderer_opengles1 dll with GLES ifdefs or separate copy of code/renderergl1 altogether?

----

Tested and works on Raspberry Pi 3b running Rasbian Stretch. Build and install SDL2 from source, compile ioq3 using `make`, run using `./build/release-linux-arm/ioquake3.arm +set cl_renderer opengl1`.