### PR TITLE
[ai_dmq3.c] Fix bot goalfinding logic.

### DIFF
--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -5346,7 +5346,7 @@ void BotSetEntityNumForGoal(bot_goal_t *goal, char *classname) {
 		if ( !ent->inuse ) {
 			continue;
 		}
-		if ( !Q_stricmp(ent->classname, classname) ) {
+		if ( Q_stricmp(ent->classname, classname) != 0 ) {
 			continue;
 		}
 		VectorSubtract(goal->origin, ent->s.origin, dir);


### PR DESCRIPTION
The original code would *skip* any entity whose classname matches the
goal name, and fall through to finding *any* entity that's near the
goal (as long as its name *doesn't* match!).

This fix changes this behaviour to *only* consider entities whose name
matches. This new behaviour seems to be what was plauslibly intended
here in the first place, and the error may be due to a simple
misunderstanding of how strcmp works.

This is a breaking change, since any entity that was previously found
is now not found, and anything that is now found was previously never
found. However, note that the function in question is only used in
OBELISK game mode to allow bots to find an obelisk (which has hitherto
never worked correctly), and it only changes the behaviour of *bots*
in such games, arguably to make them work better. Users who were
relying on the current behaviour for workarounds may have to update
their maps to restore the desired bot behaviour.

Please review this change carefully and advise on whether the break is tolerable, or whether you would prefer a more conservative change that falls back to the original search behaviour if no entity with the given classname was found.