### PR TITLE
Fixed PRINT_ERROR print level missing from CL_RefPrintf.

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3088,8 +3088,10 @@ static __attribute__ ((format (printf, 2, 3))) void QDECL CL_RefPrintf( int prin
 		Com_Printf ("%s", msg);
 	} else if ( print_level == PRINT_WARNING ) {
 		Com_Printf (S_COLOR_YELLOW "%s", msg);		// yellow
+	} else if ( print_level == PRINT_ERROR ) {
+		Com_Printf (S_COLOR_RED "%s", msg);			// red
 	} else if ( print_level == PRINT_DEVELOPER ) {
-		Com_DPrintf (S_COLOR_RED "%s", msg);		// red
+		Com_DPrintf (S_COLOR_RED "%s", msg);		// red - developer only
 	}
 }
 


### PR DESCRIPTION
A small addition to CL_RefPrintf to add support for the PRINT_ERROR print level. Currently nothing is printed to the console.