### PR TITLE
q3rcc: Allow to override build date

### DIFF
--- a/code/tools/lcc/cpp/cpp.c
+++ b/code/tools/lcc/cpp/cpp.c
@@ -19,6 +19,15 @@ int	ifdepth;
 int	ifsatisfied[NIF];
 int	skipping;
 
+time_t reproducible_time()
+{
+	char *source_date_epoch;
+	time_t t;
+	if ((source_date_epoch = getenv("SOURCE_DATE_EPOCH")) == NULL ||
+		(t = (time_t)strtol(source_date_epoch, NULL, 10)) <= 0)
+		return time(NULL);
+	return t;
+}
 
 int
 main(int argc, char **argv)
@@ -28,7 +37,7 @@ main(int argc, char **argv)
 	char ebuf[BUFSIZ];
 
 	setbuf(stderr, ebuf);
-	t = time(NULL);
+	t = reproducible_time();
 	curtime = ctime(&t);
 	maketokenrow(3, &tr);
 	expandlex();


### PR DESCRIPTION
Allow to override `__DATE__` and `__TIME__` with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This behavior is what gcc already does.

Without this patch, `qagame.qvm` would differ between builds.

This PR was done while working on reproducible builds for openSUSE.