### PR TITLE
Fix duplicate call to BroadcastTeamChange when a bot join a team

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -637,7 +637,9 @@ void SetTeam( gentity_t *ent, const char *s ) {
 		CheckTeamLeader( oldTeam );
 	}
 
-	BroadcastTeamChange( client, oldTeam );
+	if ( !(ent->r.svFlags & SVF_BOT) ) {
+		BroadcastTeamChange( client, oldTeam );
+	}
 
 	// get and distribute relevant parameters
 	ClientUserinfoChanged( clientNum );


### PR DESCRIPTION
After this commit: https://github.com/ioquake/ioq3/commit/f7c3276fe803388bd613ab6bf6ad8e0a6647b740, BroadcastTeamChange is called twice when a bot join a team.
This can be annoying when many bots join teams at the same time, as this can lead to a Server command overflow.