### PR TITLE
Add mingw32 x86_64 GH Action

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,22 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches:
+      - master
+      - test_build 
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make
+      env:
+        PLATFORM: mingw32
+        ARCH: x86_64

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - master
-      - test_build 
-  pull_request:
-    branches: [ master ]
-
+      - test_build
 jobs:
   build:
 
@@ -22,3 +19,7 @@ jobs:
       env:
         PLATFORM: mingw32
         ARCH: x86_64
+    - uses: actions/upload-artifact@v2
+      with:
+       name: release-mingw32-x86_64.zip
+       path: build/release-mingw32-x86_64.zip

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,4 +22,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
        name: release-mingw32-x86_64.zip
-       path: build/release-mingw32-x86_64.zip
+       path: /home/runner/work/ioq3/ioq3/build/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install mingw-w64
     - name: make
       run: make
       env:

--- a/.github/workflows/mingw32x86_64.yml
+++ b/.github/workflows/mingw32x86_64.yml
@@ -1,10 +1,9 @@
-name: C/C++ CI
+name: Build mingw32x86_64
 
 on:
   push:
     branches:
       - master
-      - test_build
 jobs:
   build:
 


### PR DESCRIPTION
Adds a Github Action to automatically build 64bit Windows builds on push to master.
Uses cross compiling via mingw32 on Ubuntu.
Build artifact named release-mingw32-x86_64.zip generated on completion of task.

Added the action mainly to generate new binaries while the test-builds are still unavailable. Avoids the need to set up a C development environment locally. Thought it worth pushing back upstream in case it provides a good stop-gap measure while you get the rest of the CI sorted out. 

Can confirm everything works, but I'm no expert, so its highly possible I've missed out some useful flags.
