### PR TITLE
Update build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,49 +1,45 @@
-name: Build
+name: "Build"
 on: [push, pull_request]
 
 jobs:
-  linux:
-    name: Linux
-    runs-on: ubuntu-16.04
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+          - ubuntu-16.04
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - windows-2019
+          - macos-10.15
+#          - macos-11.0
+    env:
+      ARCHIVE: 1
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libsdl2-dev
-    - name: Compile
-      run: make release
-      env:
-        ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Linux
-        path: build/*.zip
-  windows:
-    name: Windows
-    runs-on: windows-2019
-    steps:
-    - uses: actions/checkout@v2
-    - name: Compile
-      run: |
-        choco install zip
-        make release
-      env:
-        ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Windows
-        path: build/*.zip
-  macos:
-    name: macOS
-    runs-on: macos-10.15
-    steps:
-    - uses: actions/checkout@v2
-    - name: Compile
-      run: make release
-      env:
-        ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
-      with:
-        name: macOS
-        path: build/*.zip
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Install Dependencies (Linux)"
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl2-dev
+
+      - name: "Install Dependencies (Windows)"
+        if: ${{ runner.os == 'Windows' }}
+        run: choco install zip
+
+#      - name: "Install Dependencies (macOS)"
+#        if: ${{ runner.os == 'macOS' }}
+#        run: 
+
+      - name: "Compile"
+        run: make release
+
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}
+          path: build/*.zip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/ioquake/ioq3/workflows/Build/badge.svg)
+[![Build](https://github.com/ioquake/ioq3/workflows/Build/badge.svg)](https://github.com/ioquake/ioq3/actions/workflows/build.yml)
 
                    ,---------------------------------------.
                    |   _                     _       ____  |


### PR DESCRIPTION
An update to the GH build script to use an OS matrix rather than copy-pasta. Also the badge icon in the readme links now to  that workflow tab.