### PR TITLE
QVM memory access sanitization

### DIFF
--- a/code/botlib/be_aas_bsp.h
+++ b/code/botlib/be_aas_bsp.h
@@ -79,11 +79,11 @@ void AAS_BSPModelMinsMaxsOrigin(int modelnum, vec3_t angles, vec3_t mins, vec3_t
 //handle to the next bsp entity
 int AAS_NextBSPEntity(int ent);
 //return the value of the BSP epair key
-int AAS_ValueForBSPEpairKey(int ent, char *key, char *value, int size);
+int AAS_ValueForBSPEpairKey(int ent, const char *key, char *value, int size);
 //get a vector for the BSP epair key
-int AAS_VectorForBSPEpairKey(int ent, char *key, vec3_t v);
+int AAS_VectorForBSPEpairKey(int ent, const char *key, vec3_t v);
 //get a float for the BSP epair key
-int AAS_FloatForBSPEpairKey(int ent, char *key, float *value);
+int AAS_FloatForBSPEpairKey(int ent, const char *key, float *value);
 //get an integer for the BSP epair key
-int AAS_IntForBSPEpairKey(int ent, char *key, int *value);
+int AAS_IntForBSPEpairKey(int ent, const char *key, int *value);
 

--- a/code/botlib/be_aas_bspq3.c
+++ b/code/botlib/be_aas_bspq3.c
@@ -276,7 +276,7 @@ int AAS_BSPEntityInRange(int ent)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int AAS_ValueForBSPEpairKey(int ent, char *key, char *value, int size)
+int AAS_ValueForBSPEpairKey(int ent, const char *key, char *value, int size)
 {
 	bsp_epair_t *epair;
 
@@ -299,7 +299,7 @@ int AAS_ValueForBSPEpairKey(int ent, char *key, char *value, int size)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_VectorForBSPEpairKey(int ent, char *key, vec3_t v)
+int AAS_VectorForBSPEpairKey(int ent, const char *key, vec3_t v)
 {
 	char buf[MAX_EPAIRKEY];
 	double v1, v2, v3;
@@ -320,7 +320,7 @@ int AAS_VectorForBSPEpairKey(int ent, char *key, vec3_t v)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_FloatForBSPEpairKey(int ent, char *key, float *value)
+int AAS_FloatForBSPEpairKey(int ent, const char *key, float *value)
 {
 	char buf[MAX_EPAIRKEY];
 	
@@ -335,7 +335,7 @@ int AAS_FloatForBSPEpairKey(int ent, char *key, float *value)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int AAS_IntForBSPEpairKey(int ent, char *key, int *value)
+int AAS_IntForBSPEpairKey(int ent, const char *key, int *value)
 {
 	char buf[MAX_EPAIRKEY];
 	

--- a/code/botlib/be_ai_char.c
+++ b/code/botlib/be_ai_char.c
@@ -209,7 +209,7 @@ void BotDefaultCharacteristics(bot_character_t *ch, bot_character_t *defaultch)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-bot_character_t *BotLoadCharacterFromFile(char *charfile, int skill)
+bot_character_t *BotLoadCharacterFromFile(const char *charfile, int skill)
 {
 	int indent, index, foundcharacter;
 	bot_character_t *ch;
@@ -359,7 +359,7 @@ bot_character_t *BotLoadCharacterFromFile(char *charfile, int skill)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotFindCachedCharacter(char *charfile, float skill)
+int BotFindCachedCharacter(const char *charfile, float skill)
 {
 	int handle;
 
@@ -380,7 +380,7 @@ int BotFindCachedCharacter(char *charfile, float skill)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadCachedCharacter(char *charfile, float skill, int reload)
+int BotLoadCachedCharacter(const char *charfile, float skill, int reload)
 {
 	int handle, cachedhandle, intskill;
 	bot_character_t *ch = NULL;
@@ -493,7 +493,7 @@ int BotLoadCachedCharacter(char *charfile, float skill, int reload)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadCharacterSkill(char *charfile, float skill)
+int BotLoadCharacterSkill(const char *charfile, float skill)
 {
 	int ch, defaultch;
 
@@ -565,7 +565,7 @@ int BotInterpolateCharacters(int handle1, int handle2, float desiredskill)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadCharacter(char *charfile, float skill)
+int BotLoadCharacter(const char *charfile, float skill)
 {
 	int firstskill, secondskill, handle;
 

--- a/code/botlib/be_ai_char.h
+++ b/code/botlib/be_ai_char.h
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *****************************************************************************/
 
 //loads a bot character from a file
-int BotLoadCharacter(char *charfile, float skill);
+int BotLoadCharacter(const char *charfile, float skill);
 //frees a bot character
 void BotFreeCharacter(int character);
 //returns a float characteristic

--- a/code/botlib/be_ai_chat.h
+++ b/code/botlib/be_ai_chat.h
@@ -75,7 +75,7 @@ int BotAllocChatState(void);
 //frees the chatstate
 void BotFreeChatState(int handle);
 //adds a console message to the chat state
-void BotQueueConsoleMessage(int chatstate, int type, char *message);
+void BotQueueConsoleMessage(int chatstate, int type, const char *message);
 //removes the console message from the chat state
 void BotRemoveConsoleMessage(int chatstate, int handle);
 //returns the next console message from the state
@@ -83,11 +83,11 @@ int BotNextConsoleMessage(int chatstate, bot_consolemessage_t *cm);
 //returns the number of console messages currently stored in the state
 int BotNumConsoleMessages(int chatstate);
 //selects a chat message of the given type
-void BotInitialChat(int chatstate, char *type, int mcontext, char *var0, char *var1, char *var2, char *var3, char *var4, char *var5, char *var6, char *var7);
+void BotInitialChat(int chatstate, const char *type, int mcontext, const char *var0, const char *var1, const char *var2, const char *var3, const char *var4, const char *var5, const char *var6, const char *var7);
 //returns the number of initial chat messages of the given type
-int BotNumInitialChats(int chatstate, char *type);
+int BotNumInitialChats(int chatstate, const char *type);
 //find and select a reply for the given message
-int BotReplyChat(int chatstate, char *message, int mcontext, int vcontext, char *var0, char *var1, char *var2, char *var3, char *var4, char *var5, char *var6, char *var7);
+int BotReplyChat(int chatstate, const char *message, int mcontext, int vcontext, const char *var0, const char *var1, const char *var2, const char *var3, const char *var4, const char *var5, const char *var6, const char *var7);
 //returns the length of the currently selected chat message
 int BotChatLength(int chatstate);
 //enters the selected chat message
@@ -95,19 +95,19 @@ void BotEnterChat(int chatstate, int clientto, int sendto);
 //get the chat message ready to be output
 void BotGetChatMessage(int chatstate, char *buf, int size);
 //checks if the first string contains the second one, returns index into first string or -1 if not found
-int StringContains(char *str1, char *str2, int casesensitive);
+int StringContains(const char *str1, const char *str2, int casesensitive);
 //finds a match for the given string using the match templates
-int BotFindMatch(char *str, bot_match_t *match, unsigned long int context);
+int BotFindMatch(const char *str, bot_match_t *match, unsigned long int context);
 //returns a variable from a match
 void BotMatchVariable(bot_match_t *match, int variable, char *buf, int size);
 //unify all the white spaces in the string
 void UnifyWhiteSpaces(char *string);
 //replace all the context related synonyms in the string
-void BotReplaceSynonyms(char *string, unsigned long int context);
+void BotReplaceSynonyms(char *string, int stringSize, unsigned long int context);
 //loads a chat file for the chat state
-int BotLoadChatFile(int chatstate, char *chatfile, char *chatname);
+int BotLoadChatFile(int chatstate, const char *chatfile, const char *chatname);
 //store the gender of the bot in the chat state
 void BotSetChatGender(int chatstate, int gender);
 //store the bot name in the chat state
-void BotSetChatName(int chatstate, char *name, int client);
+void BotSetChatName(int chatstate, const char *name, int client);
 

--- a/code/botlib/be_ai_goal.c
+++ b/code/botlib/be_ai_goal.c
@@ -239,7 +239,7 @@ void BotInterbreedGoalFuzzyLogic(int parent1, int parent2, int child)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void BotSaveGoalFuzzyLogic(int goalstate, char *filename)
+void BotSaveGoalFuzzyLogic(int goalstate, const char *filename)
 {
 	//bot_goalstate_t *gs;
 
@@ -856,7 +856,7 @@ void BotSetAvoidGoalTime(int goalstate, int number, float avoidtime)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotGetLevelItemGoal(int index, char *name, bot_goal_t *goal)
+int BotGetLevelItemGoal(int index, const char *name, bot_goal_t *goal)
 {
 	levelitem_t *li;
 
@@ -910,7 +910,7 @@ int BotGetLevelItemGoal(int index, char *name, bot_goal_t *goal)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-int BotGetMapLocationGoal(char *name, bot_goal_t *goal)
+int BotGetMapLocationGoal(const char *name, bot_goal_t *goal)
 {
 	maplocation_t *ml;
 	vec3_t mins = {-8, -8, -8}, maxs = {8, 8, 8};
@@ -1694,7 +1694,7 @@ void BotResetGoalState(int goalstate)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadItemWeights(int goalstate, char *filename)
+int BotLoadItemWeights(int goalstate, const char *filename)
 {
 	bot_goalstate_t *gs;
 

--- a/code/botlib/be_ai_goal.h
+++ b/code/botlib/be_ai_goal.h
@@ -85,11 +85,11 @@ int BotTouchingGoal(vec3_t origin, bot_goal_t *goal);
 int BotItemGoalInVisButNotVisible(int viewer, vec3_t eye, vec3_t viewangles, bot_goal_t *goal);
 //search for a goal for the given classname, the index can be used
 //as a start point for the search when multiple goals are available with that same classname
-int BotGetLevelItemGoal(int index, char *classname, bot_goal_t *goal);
+int BotGetLevelItemGoal(int index, const char *classname, bot_goal_t *goal);
 //get the next camp spot in the map
 int BotGetNextCampSpotGoal(int num, bot_goal_t *goal);
 //get the map location with the given name
-int BotGetMapLocationGoal(char *name, bot_goal_t *goal);
+int BotGetMapLocationGoal(const char *name, bot_goal_t *goal);
 //returns the avoid goal time
 float BotAvoidGoalTime(int goalstate, int number);
 //set the avoid goal time
@@ -101,11 +101,11 @@ void BotUpdateEntityItems(void);
 //interbreed the goal fuzzy logic
 void BotInterbreedGoalFuzzyLogic(int parent1, int parent2, int child);
 //save the goal fuzzy logic to disk
-void BotSaveGoalFuzzyLogic(int goalstate, char *filename);
+void BotSaveGoalFuzzyLogic(int goalstate, const char *filename);
 //mutate the goal fuzzy logic
 void BotMutateGoalFuzzyLogic(int goalstate, float range);
 //loads item weights for the bot
-int BotLoadItemWeights(int goalstate, char *filename);
+int BotLoadItemWeights(int goalstate, const char *filename);
 //frees the item weights of the bot
 void BotFreeItemWeights(int goalstate);
 //returns the handle of a newly allocated goal state

--- a/code/botlib/be_ai_weap.c
+++ b/code/botlib/be_ai_weap.c
@@ -361,7 +361,7 @@ void BotFreeWeaponWeights(int weaponstate)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-int BotLoadWeaponWeights(int weaponstate, char *filename)
+int BotLoadWeaponWeights(int weaponstate, const char *filename)
 {
 	bot_weaponstate_t *ws;
 

--- a/code/botlib/be_ai_weap.h
+++ b/code/botlib/be_ai_weap.h
@@ -95,7 +95,7 @@ int BotChooseBestFightWeapon(int weaponstate, int *inventory);
 //returns the information of the current weapon
 void BotGetWeaponInfo(int weaponstate, int weapon, weaponinfo_t *weaponinfo);
 //loads the weapon weights
-int BotLoadWeaponWeights(int weaponstate, char *filename);
+int BotLoadWeaponWeights(int weaponstate, const char *filename);
 //returns a handle to a newly allocated weapon state
 int BotAllocWeaponState(void);
 //frees the weapon state

--- a/code/botlib/be_ai_weight.c
+++ b/code/botlib/be_ai_weight.c
@@ -282,7 +282,7 @@ fuzzyseperator_t *ReadFuzzySeperators_r(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-weightconfig_t *ReadWeightConfig(char *filename)
+weightconfig_t *ReadWeightConfig(const char *filename)
 {
 	int newindent, avail = 0, n;
 	token_t token;

--- a/code/botlib/be_ai_weight.h
+++ b/code/botlib/be_ai_weight.h
@@ -61,7 +61,7 @@ typedef struct weightconfig_s
 } weightconfig_t;
 
 //reads a weight configuration
-weightconfig_t *ReadWeightConfig(char *filename);
+weightconfig_t *ReadWeightConfig(const char *filename);
 //free a weight configuration
 void FreeWeightConfig(weightconfig_t *config);
 //writes a weight configuration, returns true if successful

--- a/code/botlib/be_ea.c
+++ b/code/botlib/be_ea.c
@@ -48,7 +48,7 @@ bot_input_t *botinputs;
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_Say(int client, char *str)
+void EA_Say(int client, const char *str)
 {
 	botimport.BotClientCommand(client, va("say %s", str) );
 } //end of the function EA_Say
@@ -58,7 +58,7 @@ void EA_Say(int client, char *str)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_SayTeam(int client, char *str)
+void EA_SayTeam(int client, const char *str)
 {
 	botimport.BotClientCommand(client, va("say_team %s", str));
 } //end of the function EA_SayTeam
@@ -68,7 +68,7 @@ void EA_SayTeam(int client, char *str)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_Tell(int client, int clientto, char *str)
+void EA_Tell(int client, int clientto, const char *str)
 {
 	botimport.BotClientCommand(client, va("tell %d, %s", clientto, str));
 } //end of the function EA_SayTeam
@@ -78,7 +78,7 @@ void EA_Tell(int client, int clientto, char *str)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_UseItem(int client, char *it)
+void EA_UseItem(int client, const char *it)
 {
 	botimport.BotClientCommand(client, va("use %s", it));
 } //end of the function EA_UseItem
@@ -88,7 +88,7 @@ void EA_UseItem(int client, char *it)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_DropItem(int client, char *it)
+void EA_DropItem(int client, const char *it)
 {
 	botimport.BotClientCommand(client, va("drop %s", it));
 } //end of the function EA_DropItem
@@ -98,7 +98,7 @@ void EA_DropItem(int client, char *it)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_UseInv(int client, char *inv)
+void EA_UseInv(int client, const char *inv)
 {
 	botimport.BotClientCommand(client, va("invuse %s", inv));
 } //end of the function EA_UseInv
@@ -108,7 +108,7 @@ void EA_UseInv(int client, char *inv)
 // Returns:				-
 // Changes Globals:		-
 //===========================================================================
-void EA_DropInv(int client, char *inv)
+void EA_DropInv(int client, const char *inv)
 {
 	botimport.BotClientCommand(client, va("invdrop %s", inv));
 } //end of the function EA_DropInv
@@ -132,7 +132,7 @@ void EA_Gesture(int client)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
-void EA_Command(int client, char *command)
+void EA_Command(int client, const char *command)
 {
 	botimport.BotClientCommand(client, command);
 } //end of the function EA_Command

--- a/code/botlib/be_ea.h
+++ b/code/botlib/be_ea.h
@@ -31,9 +31,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *****************************************************************************/
 
 //ClientCommand elementary actions
-void EA_Say(int client, char *str);
-void EA_SayTeam(int client, char *str);
-void EA_Command(int client, char *command );
+void EA_Say(int client, const char *str);
+void EA_SayTeam(int client, const char *str);
+void EA_Command(int client, const char *command );
 
 void EA_Action(int client, int action);
 void EA_Crouch(int client);

--- a/code/botlib/botlib.h
+++ b/code/botlib/botlib.h
@@ -184,7 +184,7 @@ typedef struct botlib_import_s
 	//
 	void		(*BSPModelMinsMaxsOrigin)(int modelnum, vec3_t angles, vec3_t mins, vec3_t maxs, vec3_t origin);
 	//send a bot client command
-	void		(*BotClientCommand)(int client, char *command);
+	void		(*BotClientCommand)(int client, const char *command);
 	//memory allocation
 	void		*(*GetMemory)(int size);		// allocate from Zone
 	void		(*FreeMemory)(void *ptr);		// free memory from Zone
@@ -230,10 +230,10 @@ typedef struct aas_export_s
 	//--------------------------------------------
 	int			(*AAS_PointContents)(vec3_t point);
 	int			(*AAS_NextBSPEntity)(int ent);
-	int			(*AAS_ValueForBSPEpairKey)(int ent, char *key, char *value, int size);
-	int			(*AAS_VectorForBSPEpairKey)(int ent, char *key, vec3_t v);
-	int			(*AAS_FloatForBSPEpairKey)(int ent, char *key, float *value);
-	int			(*AAS_IntForBSPEpairKey)(int ent, char *key, int *value);
+	int			(*AAS_ValueForBSPEpairKey)(int ent, const char *key, char *value, int size);
+	int			(*AAS_VectorForBSPEpairKey)(int ent, const char *key, vec3_t v);
+	int			(*AAS_FloatForBSPEpairKey)(int ent, const char *key, float *value);
+	int			(*AAS_IntForBSPEpairKey)(int ent, const char *key, int *value);
 	//--------------------------------------------
 	// be_aas_reach.c
 	//--------------------------------------------
@@ -268,9 +268,9 @@ typedef struct aas_export_s
 typedef struct ea_export_s
 {
 	//ClientCommand elementary actions
-	void	(*EA_Command)(int client, char *command );
-	void	(*EA_Say)(int client, char *str);
-	void	(*EA_SayTeam)(int client, char *str);
+	void	(*EA_Command)(int client, const char *command );
+	void	(*EA_Say)(int client, const char *str);
+	void	(*EA_SayTeam)(int client, const char *str);
 	//
 	void	(*EA_Action)(int client, int action);
 	void	(*EA_Gesture)(int client);
@@ -302,7 +302,7 @@ typedef struct ai_export_s
 	//-----------------------------------
 	// be_ai_char.h
 	//-----------------------------------
-	int		(*BotLoadCharacter)(char *charfile, float skill);
+	int		(*BotLoadCharacter)(const char *charfile, float skill);
 	void	(*BotFreeCharacter)(int character);
 	float	(*Characteristic_Float)(int character, int index);
 	float	(*Characteristic_BFloat)(int character, int index, float min, float max);
@@ -314,24 +314,24 @@ typedef struct ai_export_s
 	//-----------------------------------
 	int		(*BotAllocChatState)(void);
 	void	(*BotFreeChatState)(int handle);
-	void	(*BotQueueConsoleMessage)(int chatstate, int type, char *message);
+	void	(*BotQueueConsoleMessage)(int chatstate, int type, const char *message);
 	void	(*BotRemoveConsoleMessage)(int chatstate, int handle);
 	int		(*BotNextConsoleMessage)(int chatstate, struct bot_consolemessage_s *cm);
 	int		(*BotNumConsoleMessages)(int chatstate);
-	void	(*BotInitialChat)(int chatstate, char *type, int mcontext, char *var0, char *var1, char *var2, char *var3, char *var4, char *var5, char *var6, char *var7);
-	int		(*BotNumInitialChats)(int chatstate, char *type);
-	int		(*BotReplyChat)(int chatstate, char *message, int mcontext, int vcontext, char *var0, char *var1, char *var2, char *var3, char *var4, char *var5, char *var6, char *var7);
+	void	(*BotInitialChat)(int chatstate, const char *type, int mcontext, const char *var0, const char *var1, const char *var2, const char *var3, const char *var4, const char *var5, const char *var6, const char *var7);
+	int		(*BotNumInitialChats)(int chatstate, const char *type);
+	int		(*BotReplyChat)(int chatstate, const char *message, int mcontext, int vcontext, const char *var0, const char *var1, const char *var2, const char *var3, const char *var4, const char *var5, const char *var6, const char *var7);
 	int		(*BotChatLength)(int chatstate);
 	void	(*BotEnterChat)(int chatstate, int client, int sendto);
 	void	(*BotGetChatMessage)(int chatstate, char *buf, int size);
-	int		(*StringContains)(char *str1, char *str2, int casesensitive);
-	int		(*BotFindMatch)(char *str, struct bot_match_s *match, unsigned long int context);
+	int		(*StringContains)(const char *str1, const char *str2, int casesensitive);
+	int		(*BotFindMatch)(const char *str, struct bot_match_s *match, unsigned long int context);
 	void	(*BotMatchVariable)(struct bot_match_s *match, int variable, char *buf, int size);
 	void	(*UnifyWhiteSpaces)(char *string);
-	void	(*BotReplaceSynonyms)(char *string, unsigned long int context);
-	int		(*BotLoadChatFile)(int chatstate, char *chatfile, char *chatname);
+	void	(*BotReplaceSynonyms)(char *string, int stringSize, unsigned long int context);
+	int		(*BotLoadChatFile)(int chatstate, const char *chatfile, const char *chatname);
 	void	(*BotSetChatGender)(int chatstate, int gender);
-	void	(*BotSetChatName)(int chatstate, char *name, int client);
+	void	(*BotSetChatName)(int chatstate, const char *name, int client);
 	//-----------------------------------
 	// be_ai_goal.h
 	//-----------------------------------
@@ -351,17 +351,17 @@ typedef struct ai_export_s
 								struct bot_goal_s *ltg, float maxtime);
 	int		(*BotTouchingGoal)(vec3_t origin, struct bot_goal_s *goal);
 	int		(*BotItemGoalInVisButNotVisible)(int viewer, vec3_t eye, vec3_t viewangles, struct bot_goal_s *goal);
-	int		(*BotGetLevelItemGoal)(int index, char *classname, struct bot_goal_s *goal);
+	int		(*BotGetLevelItemGoal)(int index, const char *classname, struct bot_goal_s *goal);
 	int		(*BotGetNextCampSpotGoal)(int num, struct bot_goal_s *goal);
-	int		(*BotGetMapLocationGoal)(char *name, struct bot_goal_s *goal);
+	int		(*BotGetMapLocationGoal)(const char *name, struct bot_goal_s *goal);
 	float	(*BotAvoidGoalTime)(int goalstate, int number);
 	void	(*BotSetAvoidGoalTime)(int goalstate, int number, float avoidtime);
 	void	(*BotInitLevelItems)(void);
 	void	(*BotUpdateEntityItems)(void);
-	int		(*BotLoadItemWeights)(int goalstate, char *filename);
+	int		(*BotLoadItemWeights)(int goalstate, const char *filename);
 	void	(*BotFreeItemWeights)(int goalstate);
 	void	(*BotInterbreedGoalFuzzyLogic)(int parent1, int parent2, int child);
-	void	(*BotSaveGoalFuzzyLogic)(int goalstate, char *filename);
+	void	(*BotSaveGoalFuzzyLogic)(int goalstate, const char *filename);
 	void	(*BotMutateGoalFuzzyLogic)(int goalstate, float range);
 	int		(*BotAllocGoalState)(int client);
 	void	(*BotFreeGoalState)(int handle);
@@ -385,7 +385,7 @@ typedef struct ai_export_s
 	//-----------------------------------
 	int		(*BotChooseBestFightWeapon)(int weaponstate, int *inventory);
 	void	(*BotGetWeaponInfo)(int weaponstate, int weapon, struct weaponinfo_s *weaponinfo);
-	int		(*BotLoadWeaponWeights)(int weaponstate, char *filename);
+	int		(*BotLoadWeaponWeights)(int weaponstate, const char *filename);
 	int		(*BotAllocWeaponState)(void);
 	void	(*BotFreeWeaponState)(int weaponstate);
 	void	(*BotResetWeaponState)(int weaponstate);
@@ -414,11 +414,11 @@ typedef struct botlib_export_s
 	int (*BotLibVarGet)(const char *var_name, char *value, int size);
 
 	//sets a C-like define returns BLERR_
-	int (*PC_AddGlobalDefine)(char *string);
+	int (*PC_AddGlobalDefine)(const char *string);
 	int (*PC_LoadSourceHandle)(const char *filename);
 	int (*PC_FreeSourceHandle)(int handle);
 	int (*PC_ReadTokenHandle)(int handle, pc_token_t *pc_token);
-	int (*PC_SourceFileAndLine)(int handle, char *filename, int *line);
+	int (*PC_SourceFileAndLine)(int handle, char *filename, size_t filenameCapacity, int *line);
 
 	//start a frame in the bot library
 	int (*BotLibStartFrame)(float time);

--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -1310,7 +1310,7 @@ int PC_Directive_define(source_t *source)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-define_t *PC_DefineFromString(char *string)
+define_t *PC_DefineFromString(const char *string)
 {
 	script_t *script;
 	source_t src;
@@ -1389,7 +1389,7 @@ int PC_AddDefine(source_t *source, char *string)
 // Returns:					-
 // Changes Globals:		-
 //============================================================================
-int PC_AddGlobalDefine(char *string)
+int PC_AddGlobalDefine(const char *string)
 {
 	define_t *define;
 
@@ -3188,14 +3188,14 @@ int PC_ReadTokenHandle(int handle, pc_token_t *pc_token)
 // Returns:				-
 // Changes Globals:		-
 //============================================================================
-int PC_SourceFileAndLine(int handle, char *filename, int *line)
+int PC_SourceFileAndLine(int handle, char *filename, size_t filenameCapacity, int *line)
 {
 	if (handle < 1 || handle >= MAX_SOURCEFILES)
 		return qfalse;
 	if (!sourceFiles[handle])
 		return qfalse;
 
-	strcpy(filename, sourceFiles[handle]->filename);
+	strncpy(filename, sourceFiles[handle]->filename, filenameCapacity);
 	if (sourceFiles[handle]->scriptstack)
 		*line = sourceFiles[handle]->scriptstack->line;
 	else

--- a/code/botlib/l_precomp.h
+++ b/code/botlib/l_precomp.h
@@ -128,7 +128,7 @@ int PC_WhiteSpaceBeforeToken(token_t *token);
 //add a define to the source
 int PC_AddDefine(source_t *source, char *string);
 //add a globals define that will be added to all opened sources
-int PC_AddGlobalDefine(char *string);
+int PC_AddGlobalDefine(const char *string);
 //remove the given global define
 int PC_RemoveGlobalDefine(char *name);
 //remove all globals defines
@@ -172,5 +172,5 @@ typedef struct pc_token_s
 int PC_LoadSourceHandle(const char *filename);
 int PC_FreeSourceHandle(int handle);
 int PC_ReadTokenHandle(int handle, pc_token_t *pc_token);
-int PC_SourceFileAndLine(int handle, char *filename, int *line);
+int PC_SourceFileAndLine(int handle, char *filename, size_t filenameCapacity, int *line);
 void PC_CheckOpenSourceHandles(void);

--- a/code/botlib/l_script.c
+++ b/code/botlib/l_script.c
@@ -1388,7 +1388,7 @@ script_t *LoadScriptFile(const char *filename)
 // Returns:				-
 // Changes Globals:		-
 //============================================================================
-script_t *LoadScriptMemory(char *ptr, int length, char *name)
+script_t *LoadScriptMemory(const char *ptr, int length, char *name)
 {
 	void *buffer;
 	script_t *script;

--- a/code/botlib/l_script.h
+++ b/code/botlib/l_script.h
@@ -234,7 +234,7 @@ char *PunctuationFromNum(script_t *script, int num);
 //load a script from the given file at the given offset with the given length
 script_t *LoadScriptFile(const char *filename);
 //load a script from the given memory with the given length
-script_t *LoadScriptMemory(char *ptr, int length, char *name);
+script_t *LoadScriptMemory(const char *ptr, int length, char *name);
 //free a script
 void FreeScript(script_t *script);
 //set the base folder to load files from

--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -410,40 +410,40 @@ The cgame module is making a system call
 intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 	switch( args[0] ) {
 	case CG_PRINT:
-		Com_Printf( "%s", (const char*)VMA(1) );
+		Com_Printf( "%s", VMA_STR(1) );
 		return 0;
 	case CG_ERROR:
-		Com_Error( ERR_DROP, "%s", (const char*)VMA(1) );
+		Com_Error( ERR_DROP, "%s", VMA_STR(1) );
 		return 0;
 	case CG_MILLISECONDS:
 		return Sys_Milliseconds();
 	case CG_CVAR_REGISTER:
-		Cvar_Register( VMA(1), VMA(2), VMA(3), args[4] ); 
+		Cvar_Register( VMA_1(1, vmCvar_t), VMA_STR(2), VMA_STR(3), args[4] );
 		return 0;
 	case CG_CVAR_UPDATE:
-		Cvar_Update( VMA(1) );
+		Cvar_Update( VMA_1(1, vmCvar_t) );
 		return 0;
 	case CG_CVAR_SET:
-		Cvar_SetSafe( VMA(1), VMA(2) );
+		Cvar_SetSafe( VMA_STR(1), VMA_STR(2) );
 		return 0;
 	case CG_CVAR_VARIABLESTRINGBUFFER:
-		Cvar_VariableStringBuffer( VMA(1), VMA(2), args[3] );
+		Cvar_VariableStringBuffer( VMA_STR(1), VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 	case CG_ARGC:
 		return Cmd_Argc();
 	case CG_ARGV:
-		Cmd_ArgvBuffer( args[1], VMA(2), args[3] );
+		Cmd_ArgvBuffer( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 	case CG_ARGS:
-		Cmd_ArgsBuffer( VMA(1), args[2] );
+		Cmd_ArgsBuffer( VMA_DYN(1, char, args[2]), args[2] );
 		return 0;
 	case CG_FS_FOPENFILE:
-		return FS_FOpenFileByMode( VMA(1), VMA(2), args[3] );
+		return FS_FOpenFileByMode( VMA_STR(1), VMA_1(2, fileHandle_t), args[3] );
 	case CG_FS_READ:
-		FS_Read( VMA(1), args[2], args[3] );
+		FS_Read( VMA_DYN(1, char, args[2]), args[2], args[3] );
 		return 0;
 	case CG_FS_WRITE:
-		FS_Write( VMA(1), args[2], args[3] );
+		FS_Write( VMA_DYN(1, char, args[2]), args[2], args[3] );
 		return 0;
 	case CG_FS_FCLOSEFILE:
 		FS_FCloseFile( args[1] );
@@ -451,16 +451,16 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 	case CG_FS_SEEK:
 		return FS_Seek( args[1], args[2], args[3] );
 	case CG_SENDCONSOLECOMMAND:
-		Cbuf_AddText( VMA(1) );
+		Cbuf_AddText( VMA_STR(1) );
 		return 0;
 	case CG_ADDCOMMAND:
-		CL_AddCgameCommand( VMA(1) );
+		CL_AddCgameCommand( VMA_STR(1) );
 		return 0;
 	case CG_REMOVECOMMAND:
-		Cmd_RemoveCommandSafe( VMA(1) );
+		Cmd_RemoveCommandSafe( VMA_STR(1) );
 		return 0;
 	case CG_SENDCLIENTCOMMAND:
-		CL_AddReliableCommand(VMA(1), qfalse);
+		CL_AddReliableCommand( VMA_STR(1), qfalse);
 		return 0;
 	case CG_UPDATESCREEN:
 		// this is used during lengthy level loading, so pump message loop
@@ -471,36 +471,36 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		SCR_UpdateScreen();
 		return 0;
 	case CG_CM_LOADMAP:
-		CL_CM_LoadMap( VMA(1) );
+		CL_CM_LoadMap( VMA_STR(1) );
 		return 0;
 	case CG_CM_NUMINLINEMODELS:
 		return CM_NumInlineModels();
 	case CG_CM_INLINEMODEL:
 		return CM_InlineModel( args[1] );
 	case CG_CM_TEMPBOXMODEL:
-		return CM_TempBoxModel( VMA(1), VMA(2), /*int capsule*/ qfalse );
+		return CM_TempBoxModel( VMA_VEC3(1), VMA_VEC3(2), /*int capsule*/ qfalse );
 	case CG_CM_TEMPCAPSULEMODEL:
-		return CM_TempBoxModel( VMA(1), VMA(2), /*int capsule*/ qtrue );
+		return CM_TempBoxModel( VMA_VEC3(1), VMA_VEC3(2), /*int capsule*/ qtrue );
 	case CG_CM_POINTCONTENTS:
-		return CM_PointContents( VMA(1), args[2] );
+		return CM_PointContents( VMA_VEC3(1), args[2] );
 	case CG_CM_TRANSFORMEDPOINTCONTENTS:
-		return CM_TransformedPointContents( VMA(1), args[2], VMA(3), VMA(4) );
+		return CM_TransformedPointContents( VMA_VEC3(1), args[2], VMA_VEC3(3), VMA_VEC3(4) );
 	case CG_CM_BOXTRACE:
-		CM_BoxTrace( VMA(1), VMA(2), VMA(3), VMA(4), VMA(5), args[6], args[7], /*int capsule*/ qfalse );
+		CM_BoxTrace( VMA_1(1, trace_t), VMA_VEC3(2), VMA_VEC3(3), VMA_VEC3(4), VMA_VEC3(5), args[6], args[7], /*int capsule*/ qfalse );
 		return 0;
 	case CG_CM_CAPSULETRACE:
-		CM_BoxTrace( VMA(1), VMA(2), VMA(3), VMA(4), VMA(5), args[6], args[7], /*int capsule*/ qtrue );
+		CM_BoxTrace( VMA_1(1, trace_t), VMA_VEC3(2), VMA_VEC3(3), VMA_VEC3(4), VMA_VEC3(5), args[6], args[7], /*int capsule*/ qtrue );
 		return 0;
 	case CG_CM_TRANSFORMEDBOXTRACE:
-		CM_TransformedBoxTrace( VMA(1), VMA(2), VMA(3), VMA(4), VMA(5), args[6], args[7], VMA(8), VMA(9), /*int capsule*/ qfalse );
+		CM_TransformedBoxTrace( VMA_1(1, trace_t), VMA_VEC3(2), VMA_VEC3(3), VMA_VEC3(4), VMA_VEC3(5), args[6], args[7], VMA_VEC3(8), VMA_VEC3(9), /*int capsule*/ qfalse );
 		return 0;
 	case CG_CM_TRANSFORMEDCAPSULETRACE:
-		CM_TransformedBoxTrace( VMA(1), VMA(2), VMA(3), VMA(4), VMA(5), args[6], args[7], VMA(8), VMA(9), /*int capsule*/ qtrue );
+		CM_TransformedBoxTrace( VMA_1(1, trace_t), VMA_VEC3(2), VMA_VEC3(3), VMA_VEC3(4), VMA_VEC3(5), args[6], args[7], VMA_VEC3(8), VMA_VEC3(9), /*int capsule*/ qtrue );
 		return 0;
 	case CG_CM_MARKFRAGMENTS:
-		return re.MarkFragments( args[1], VMA(2), VMA(3), args[4], VMA(5), args[6], VMA(7) );
+		return re.MarkFragments( args[1], VMA_DYN(2, vec3_t, args[1]), VMA_VEC3(3), args[4], (vec_t *)VMA_DYN(5, vec3_t, args[4]), args[6], VMA_DYN(7, markFragment_t, args[6]) );
 	case CG_S_STARTSOUND:
-		S_StartSound( VMA(1), args[2], args[3], args[4] );
+		S_StartSound( VMA_VEC3(1), args[2], args[3], args[4] );
 		return 0;
 	case CG_S_STARTLOCALSOUND:
 		S_StartLocalSound( args[1], args[2] );
@@ -509,90 +509,90 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		S_ClearLoopingSounds(args[1]);
 		return 0;
 	case CG_S_ADDLOOPINGSOUND:
-		S_AddLoopingSound( args[1], VMA(2), VMA(3), args[4] );
+		S_AddLoopingSound( args[1], VMA_VEC3(2), VMA_VEC3(3), args[4] );
 		return 0;
 	case CG_S_ADDREALLOOPINGSOUND:
-		S_AddRealLoopingSound( args[1], VMA(2), VMA(3), args[4] );
+		S_AddRealLoopingSound( args[1], VMA_VEC3(2), VMA_VEC3(3), args[4] );
 		return 0;
 	case CG_S_STOPLOOPINGSOUND:
 		S_StopLoopingSound( args[1] );
 		return 0;
 	case CG_S_UPDATEENTITYPOSITION:
-		S_UpdateEntityPosition( args[1], VMA(2) );
+		S_UpdateEntityPosition( args[1], VMA_VEC3(2) );
 		return 0;
 	case CG_S_RESPATIALIZE:
-		S_Respatialize( args[1], VMA(2), VMA(3), args[4] );
+		S_Respatialize( args[1], VMA_VEC3(2), VMA_N(3, vec3_t, 3), args[4] );
 		return 0;
 	case CG_S_REGISTERSOUND:
-		return S_RegisterSound( VMA(1), args[2] );
+		return S_RegisterSound( VMA_STR(1), args[2] );
 	case CG_S_STARTBACKGROUNDTRACK:
-		S_StartBackgroundTrack( VMA(1), VMA(2) );
+		S_StartBackgroundTrack( VMA_STR(1), VMA_STR(2) );
 		return 0;
 	case CG_R_LOADWORLDMAP:
-		re.LoadWorld( VMA(1) );
+		re.LoadWorld( VMA_STR(1) );
 		return 0; 
 	case CG_R_REGISTERMODEL:
-		return re.RegisterModel( VMA(1) );
+		return re.RegisterModel( VMA_STR(1) );
 	case CG_R_REGISTERSKIN:
-		return re.RegisterSkin( VMA(1) );
+		return re.RegisterSkin( VMA_STR(1) );
 	case CG_R_REGISTERSHADER:
-		return re.RegisterShader( VMA(1) );
+		return re.RegisterShader( VMA_STR(1) );
 	case CG_R_REGISTERSHADERNOMIP:
-		return re.RegisterShaderNoMip( VMA(1) );
+		return re.RegisterShaderNoMip( VMA_STR(1) );
 	case CG_R_REGISTERFONT:
-		re.RegisterFont( VMA(1), args[2], VMA(3));
+		re.RegisterFont( VMA_STR(1), args[2], VMA_1(3, fontInfo_t));
 		return 0;
 	case CG_R_CLEARSCENE:
 		re.ClearScene();
 		return 0;
 	case CG_R_ADDREFENTITYTOSCENE:
-		re.AddRefEntityToScene( VMA(1) );
+		re.AddRefEntityToScene( VMA_1(1, refEntity_t) );
 		return 0;
 	case CG_R_ADDPOLYTOSCENE:
-		re.AddPolyToScene( args[1], args[2], VMA(3), 1 );
+		re.AddPolyToScene( args[1], args[2], VMA_DYN(3, polyVert_t, args[2]), 1 );
 		return 0;
 	case CG_R_ADDPOLYSTOSCENE:
-		re.AddPolyToScene( args[1], args[2], VMA(3), args[4] );
+		re.AddPolyToScene( args[1], args[2], VMA_DYN(3, polyVert_t, args[2]), args[4] );
 		return 0;
 	case CG_R_LIGHTFORPOINT:
-		return re.LightForPoint( VMA(1), VMA(2), VMA(3), VMA(4) );
+		return re.LightForPoint( VMA_VEC3(1), VMA_VEC3(2), VMA_VEC3(3), VMA_VEC3(4) );
 	case CG_R_ADDLIGHTTOSCENE:
-		re.AddLightToScene( VMA(1), VMF(2), VMF(3), VMF(4), VMF(5) );
+		re.AddLightToScene( VMA_VEC3(1), VMF(2), VMF(3), VMF(4), VMF(5) );
 		return 0;
 	case CG_R_ADDADDITIVELIGHTTOSCENE:
-		re.AddAdditiveLightToScene( VMA(1), VMF(2), VMF(3), VMF(4), VMF(5) );
+		re.AddAdditiveLightToScene( VMA_VEC3(1), VMF(2), VMF(3), VMF(4), VMF(5) );
 		return 0;
 	case CG_R_RENDERSCENE:
-		re.RenderScene( VMA(1) );
+		re.RenderScene( VMA_1(1, refdef_t) );
 		return 0;
 	case CG_R_SETCOLOR:
-		re.SetColor( VMA(1) );
+		re.SetColor( VMA_N(1, float, 4) );
 		return 0;
 	case CG_R_DRAWSTRETCHPIC:
 		re.DrawStretchPic( VMF(1), VMF(2), VMF(3), VMF(4), VMF(5), VMF(6), VMF(7), VMF(8), args[9] );
 		return 0;
 	case CG_R_MODELBOUNDS:
-		re.ModelBounds( args[1], VMA(2), VMA(3) );
+		re.ModelBounds( args[1], VMA_VEC3(2), VMA_VEC3(3) );
 		return 0;
 	case CG_R_LERPTAG:
-		return re.LerpTag( VMA(1), args[2], args[3], args[4], VMF(5), VMA(6) );
+		return re.LerpTag( VMA_1(1, orientation_t), args[2], args[3], args[4], VMF(5), VMA_STR(6) );
 	case CG_GETGLCONFIG:
-		CL_GetGlconfig( VMA(1) );
+		CL_GetGlconfig( VMA_1(1, glconfig_t) );
 		return 0;
 	case CG_GETGAMESTATE:
-		CL_GetGameState( VMA(1) );
+		CL_GetGameState( VMA_1(1, gameState_t) );
 		return 0;
 	case CG_GETCURRENTSNAPSHOTNUMBER:
-		CL_GetCurrentSnapshotNumber( VMA(1), VMA(2) );
+		CL_GetCurrentSnapshotNumber( VMA_1(1, int), VMA_1(2, int) );
 		return 0;
 	case CG_GETSNAPSHOT:
-		return CL_GetSnapshot( args[1], VMA(2) );
+		return CL_GetSnapshot( args[1], VMA_1(2, snapshot_t) );
 	case CG_GETSERVERCOMMAND:
 		return CL_GetServerCommand( args[1] );
 	case CG_GETCURRENTCMDNUMBER:
 		return CL_GetCurrentCmdNumber();
 	case CG_GETUSERCMD:
-		return CL_GetUserCmd( args[1], VMA(2) );
+		return CL_GetUserCmd( args[1], VMA_1(2, usercmd_t) );
 	case CG_SETUSERCMDVALUE:
 		CL_SetUserCmdValue( args[1], VMF(2) );
 		return 0;
@@ -607,18 +607,18 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Key_SetCatcher( args[1] | ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) );
     return 0;
   case CG_KEY_GETKEY:
-		return Key_GetKey( VMA(1) );
+		return Key_GetKey( VMA_STR(1) );
 
 
 
 	case CG_MEMSET:
-		Com_Memset( VMA(1), args[2], args[3] );
+		Com_Memset( VMA_DYN(1, char, args[3]), args[2], args[3] );
 		return 0;
 	case CG_MEMCPY:
-		Com_Memcpy( VMA(1), VMA(2), args[3] );
+		Com_Memcpy( VMA_DYN(1, char, args[3]), VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		strncpy( VMA_DYN(1, char, args[3]), VMA_STR(2), args[3] );
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );
@@ -636,28 +636,28 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		return FloatAsInt( Q_acos( VMF(1) ) );
 
 	case CG_PC_ADD_GLOBAL_DEFINE:
-		return botlib_export->PC_AddGlobalDefine( VMA(1) );
+		return botlib_export->PC_AddGlobalDefine( VMA_STR(1) );
 	case CG_PC_LOAD_SOURCE:
-		return botlib_export->PC_LoadSourceHandle( VMA(1) );
+		return botlib_export->PC_LoadSourceHandle( VMA_STR(1) );
 	case CG_PC_FREE_SOURCE:
 		return botlib_export->PC_FreeSourceHandle( args[1] );
 	case CG_PC_READ_TOKEN:
-		return botlib_export->PC_ReadTokenHandle( args[1], VMA(2) );
+		return botlib_export->PC_ReadTokenHandle( args[1], VMA_1(2, pc_token_t) );
 	case CG_PC_SOURCE_FILE_AND_LINE:
-		return botlib_export->PC_SourceFileAndLine( args[1], VMA(2), VMA(3) );
+		return botlib_export->PC_SourceFileAndLine( args[1], VMA_DYN(2, char, VMA_HACK_AVAILABLE(2, 128)), VMA_HACK_AVAILABLE(2, 128), VMA_1(3, int) );
 
 	case CG_S_STOPBACKGROUNDTRACK:
 		S_StopBackgroundTrack();
 		return 0;
 
 	case CG_REAL_TIME:
-		return Com_RealTime( VMA(1) );
+		return Com_RealTime( VMA_1(1, qtime_t) );
 	case CG_SNAPVECTOR:
-		Q_SnapVector(VMA(1));
+		Q_SnapVector( VMA_VEC3(1) );
 		return 0;
 
 	case CG_CIN_PLAYCINEMATIC:
-	  return CIN_PlayCinematic(VMA(1), args[2], args[3], args[4], args[5], args[6]);
+	  return CIN_PlayCinematic( VMA_STR(1), args[2], args[3], args[4], args[5], args[6]);
 
 	case CG_CIN_STOPCINEMATIC:
 	  return CIN_StopCinematic(args[1]);
@@ -674,7 +674,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 	  return 0;
 
 	case CG_R_REMAP_SHADER:
-		re.RemapShader( VMA(1), VMA(2), VMA(3) );
+		re.RemapShader( VMA_STR(1), VMA_STR(2), VMA_STR(3) );
 		return 0;
 
 /*
@@ -689,9 +689,9 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		return getCameraInfo(args[1], VMA(2), VMA(3));
 */
 	case CG_GET_ENTITY_TOKEN:
-		return re.GetEntityToken( VMA(1), args[2] );
+		return re.GetEntityToken( VMA_DYN(1, char, args[2]), args[2] );
 	case CG_R_INPVS:
-		return re.inPVS( VMA(1), VMA(2) );
+		return re.inPVS( VMA_VEC3(1), VMA_VEC3(2) );
 
 	default:
 	        assert(0);

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3969,7 +3969,7 @@ serverStatus_t *CL_GetServerStatus( netadr_t from ) {
 CL_ServerStatus
 ===================
 */
-int CL_ServerStatus( char *serverAddress, char *serverStatusString, int maxLen ) {
+int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int maxLen ) {
 	int i;
 	netadr_t	to;
 	serverStatus_t *serverStatus;

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -573,7 +573,7 @@ qboolean LAN_UpdateVisiblePings(int source ) {
 LAN_GetServerStatus
 ====================
 */
-int LAN_GetServerStatus( char *serverAddress, char *serverStatus, int maxLen ) {
+int LAN_GetServerStatus( const char *serverAddress, char *serverStatus, int maxLen ) {
 	return CL_ServerStatus( serverAddress, serverStatus, maxLen );
 }
 
@@ -660,7 +660,7 @@ CLUI_SetCDKey
 ====================
 */
 #ifndef STANDALONE
-static void CLUI_SetCDKey( char *buf ) {
+static void CLUI_SetCDKey( const char *buf ) {
 	const char *gamedir;
 	gamedir = Cvar_VariableString( "fs_game" );
 	if (UI_usesUniqueCDKey() && gamedir[0] != 0) {
@@ -722,79 +722,79 @@ The ui module is making a system call
 intptr_t CL_UISystemCalls( intptr_t *args ) {
 	switch( args[0] ) {
 	case UI_ERROR:
-		Com_Error( ERR_DROP, "%s", (const char*)VMA(1) );
+		Com_Error( ERR_DROP, "%s", VMA_STR(1) );
 		return 0;
 
 	case UI_PRINT:
-		Com_Printf( "%s", (const char*)VMA(1) );
+		Com_Printf( "%s", VMA_STR(1) );
 		return 0;
 
 	case UI_MILLISECONDS:
 		return Sys_Milliseconds();
 
 	case UI_CVAR_REGISTER:
-		Cvar_Register( VMA(1), VMA(2), VMA(3), args[4] ); 
+		Cvar_Register( VMA_1(1, vmCvar_t), VMA_STR(2), VMA_STR(3), args[4] );
 		return 0;
 
 	case UI_CVAR_UPDATE:
-		Cvar_Update( VMA(1) );
+		Cvar_Update( VMA_1(1, vmCvar_t) );
 		return 0;
 
 	case UI_CVAR_SET:
-		Cvar_SetSafe( VMA(1), VMA(2) );
+		Cvar_SetSafe( VMA_STR(1), VMA_STR(2) );
 		return 0;
 
 	case UI_CVAR_VARIABLEVALUE:
-		return FloatAsInt( Cvar_VariableValue( VMA(1) ) );
+		return FloatAsInt( Cvar_VariableValue( VMA_STR(1) ) );
 
 	case UI_CVAR_VARIABLESTRINGBUFFER:
-		Cvar_VariableStringBuffer( VMA(1), VMA(2), args[3] );
+		Cvar_VariableStringBuffer( VMA_STR(1), VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_CVAR_SETVALUE:
-		Cvar_SetValueSafe( VMA(1), VMF(2) );
+		Cvar_SetValueSafe( VMA_STR(1), VMF(2) );
 		return 0;
 
 	case UI_CVAR_RESET:
-		Cvar_Reset( VMA(1) );
+		Cvar_Reset( VMA_STR(1) );
 		return 0;
 
 	case UI_CVAR_CREATE:
-		Cvar_Register( NULL, VMA(1), VMA(2), args[3] );
+		Cvar_Register( NULL, VMA_STR(1), VMA_STR(2), args[3] );
 		return 0;
 
 	case UI_CVAR_INFOSTRINGBUFFER:
-		Cvar_InfoStringBuffer( args[1], VMA(2), args[3] );
+		Cvar_InfoStringBuffer( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_ARGC:
 		return Cmd_Argc();
 
 	case UI_ARGV:
-		Cmd_ArgvBuffer( args[1], VMA(2), args[3] );
+		Cmd_ArgvBuffer( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_CMD_EXECUTETEXT:
 		if(args[1] == EXEC_NOW
-		&& (!strncmp(VMA(2), "snd_restart", 11)
-		|| !strncmp(VMA(2), "vid_restart", 11)
-		|| !strncmp(VMA(2), "quit", 5)))
+		&& (!strncmp(VMA_STR(2), "snd_restart", 11)
+		|| !strncmp(VMA_STR(2), "vid_restart", 11)
+		|| !strncmp(VMA_STR(2), "quit", 5)))
 		{
-			Com_Printf (S_COLOR_YELLOW "turning EXEC_NOW '%.11s' into EXEC_INSERT\n", (const char*)VMA(2));
+			Com_Printf (S_COLOR_YELLOW "turning EXEC_NOW '%.11s' into EXEC_INSERT\n", VMA_STR(2));
 			args[1] = EXEC_INSERT;
 		}
-		Cbuf_ExecuteText( args[1], VMA(2) );
+		Cbuf_ExecuteText( args[1], VMA_STR(2) );
 		return 0;
 
 	case UI_FS_FOPENFILE:
-		return FS_FOpenFileByMode( VMA(1), VMA(2), args[3] );
+		return FS_FOpenFileByMode( VMA_STR(1), VMA_1(2, fileHandle_t), args[3] );
 
 	case UI_FS_READ:
-		FS_Read( VMA(1), args[2], args[3] );
+		FS_Read( VMA_DYN(1, char, args[2]), args[2], args[3] );
 		return 0;
 
 	case UI_FS_WRITE:
-		FS_Write( VMA(1), args[2], args[3] );
+		FS_Write( VMA_DYN(1, char, args[2]), args[2], args[3] );
 		return 0;
 
 	case UI_FS_FCLOSEFILE:
@@ -802,42 +802,42 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_FS_GETFILELIST:
-		return FS_GetFileList( VMA(1), VMA(2), VMA(3), args[4] );
+		return FS_GetFileList( VMA_STR(1), VMA_STR(2), VMA_DYN(3, char, args[4]), args[4] );
 
 	case UI_FS_SEEK:
 		return FS_Seek( args[1], args[2], args[3] );
 	
 	case UI_R_REGISTERMODEL:
-		return re.RegisterModel( VMA(1) );
+		return re.RegisterModel( VMA_STR(1) );
 
 	case UI_R_REGISTERSKIN:
-		return re.RegisterSkin( VMA(1) );
+		return re.RegisterSkin( VMA_STR(1) );
 
 	case UI_R_REGISTERSHADERNOMIP:
-		return re.RegisterShaderNoMip( VMA(1) );
+		return re.RegisterShaderNoMip( VMA_STR(1) );
 
 	case UI_R_CLEARSCENE:
 		re.ClearScene();
 		return 0;
 
 	case UI_R_ADDREFENTITYTOSCENE:
-		re.AddRefEntityToScene( VMA(1) );
+		re.AddRefEntityToScene( VMA_1(1, refEntity_t) );
 		return 0;
 
 	case UI_R_ADDPOLYTOSCENE:
-		re.AddPolyToScene( args[1], args[2], VMA(3), 1 );
+		re.AddPolyToScene( args[1], args[2], VMA_1(3, polyVert_t), 1 );
 		return 0;
 
 	case UI_R_ADDLIGHTTOSCENE:
-		re.AddLightToScene( VMA(1), VMF(2), VMF(3), VMF(4), VMF(5) );
+		re.AddLightToScene( VMA_VEC3(1), VMF(2), VMF(3), VMF(4), VMF(5) );
 		return 0;
 
 	case UI_R_RENDERSCENE:
-		re.RenderScene( VMA(1) );
+		re.RenderScene( VMA_1(1, refdef_t) );
 		return 0;
 
 	case UI_R_SETCOLOR:
-		re.SetColor( VMA(1) );
+		re.SetColor( VMA_N(1, float, 4) );
 		return 0;
 
 	case UI_R_DRAWSTRETCHPIC:
@@ -845,7 +845,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
   case UI_R_MODELBOUNDS:
-		re.ModelBounds( args[1], VMA(2), VMA(3) );
+		re.ModelBounds( args[1], VMA_VEC3(2), VMA_VEC3(3) );
 		return 0;
 
 	case UI_UPDATESCREEN:
@@ -853,26 +853,26 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_CM_LERPTAG:
-		re.LerpTag( VMA(1), args[2], args[3], args[4], VMF(5), VMA(6) );
+		re.LerpTag( VMA_1(1, orientation_t), args[2], args[3], args[4], VMF(5), VMA_STR(6) );
 		return 0;
 
 	case UI_S_REGISTERSOUND:
-		return S_RegisterSound( VMA(1), args[2] );
+		return S_RegisterSound( VMA_STR(1), args[2] );
 
 	case UI_S_STARTLOCALSOUND:
 		S_StartLocalSound( args[1], args[2] );
 		return 0;
 
 	case UI_KEY_KEYNUMTOSTRINGBUF:
-		Key_KeynumToStringBuf( args[1], VMA(2), args[3] );
+		Key_KeynumToStringBuf( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_KEY_GETBINDINGBUF:
-		Key_GetBindingBuf( args[1], VMA(2), args[3] );
+		Key_GetBindingBuf( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_KEY_SETBINDING:
-		Key_SetBinding( args[1], VMA(2) );
+		Key_SetBinding( args[1], VMA_STR(2) );
 		return 0;
 
 	case UI_KEY_ISDOWN:
@@ -898,19 +898,19 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_GETCLIPBOARDDATA:
-		CL_GetClipboardData( VMA(1), args[2] );
+		CL_GetClipboardData( VMA_DYN(1, char, args[2]), args[2] );
 		return 0;
 
 	case UI_GETCLIENTSTATE:
-		GetClientState( VMA(1) );
+		GetClientState( VMA_1(1, uiClientState_t) );
 		return 0;		
 
 	case UI_GETGLCONFIG:
-		CL_GetGlconfig( VMA(1) );
+		CL_GetGlconfig( VMA_1(1, glconfig_t) );
 		return 0;
 
 	case UI_GETCONFIGSTRING:
-		return GetConfigString( args[1], VMA(2), args[3] );
+		return GetConfigString( args[1], VMA_DYN(2, char, args[3]), args[3] );
 
 	case UI_LAN_LOADCACHEDSERVERS:
 		LAN_LoadCachedServers();
@@ -921,10 +921,10 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_LAN_ADDSERVER:
-		return LAN_AddServer(args[1], VMA(2), VMA(3));
+		return LAN_AddServer(args[1], VMA_STR(2), VMA_STR(3));
 
 	case UI_LAN_REMOVESERVER:
-		LAN_RemoveServer(args[1], VMA(2));
+		LAN_RemoveServer(args[1], VMA_STR(2));
 		return 0;
 
 	case UI_LAN_GETPINGQUEUECOUNT:
@@ -935,22 +935,22 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_LAN_GETPING:
-		LAN_GetPing( args[1], VMA(2), args[3], VMA(4) );
+		LAN_GetPing( args[1], VMA_DYN(2, char, args[3]), args[3], VMA_1(4, int) );
 		return 0;
 
 	case UI_LAN_GETPINGINFO:
-		LAN_GetPingInfo( args[1], VMA(2), args[3] );
+		LAN_GetPingInfo( args[1], VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_LAN_GETSERVERCOUNT:
 		return LAN_GetServerCount(args[1]);
 
 	case UI_LAN_GETSERVERADDRESSSTRING:
-		LAN_GetServerAddressString( args[1], args[2], VMA(3), args[4] );
+		LAN_GetServerAddressString( args[1], args[2], VMA_DYN(3, char, args[4]), args[4] );
 		return 0;
 
 	case UI_LAN_GETSERVERINFO:
-		LAN_GetServerInfo( args[1], args[2], VMA(3), args[4] );
+		LAN_GetServerInfo( args[1], args[2], VMA_DYN(3, char, args[4]), args[4] );
 		return 0;
 
 	case UI_LAN_GETSERVERPING:
@@ -971,7 +971,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_LAN_SERVERSTATUS:
-		return LAN_GetServerStatus( VMA(1), VMA(2), args[3] );
+		return LAN_GetServerStatus( VMA_STR(1), VMA_DYN(2, char, args[3]), args[3] );
 
 	case UI_LAN_COMPARESERVERS:
 		return LAN_CompareServers( args[1], args[2], args[3], args[4], args[5] );
@@ -980,12 +980,12 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return Hunk_MemoryRemaining();
 
 	case UI_GET_CDKEY:
-		CLUI_GetCDKey( VMA(1), args[2] );
+		CLUI_GetCDKey( VMA_DYN(1, char, args[2]), args[2] );
 		return 0;
 
 	case UI_SET_CDKEY:
 #ifndef STANDALONE
-		CLUI_SetCDKey( VMA(1) );
+		CLUI_SetCDKey( VMA_STR(1) );
 #endif
 		return 0;
 	
@@ -993,19 +993,19 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;	
 
 	case UI_R_REGISTERFONT:
-		re.RegisterFont( VMA(1), args[2], VMA(3));
+		re.RegisterFont( VMA_STR(1), args[2], VMA_1(3, fontInfo_t));
 		return 0;
 
 	case UI_MEMSET:
-		Com_Memset( VMA(1), args[2], args[3] );
+		Com_Memset( VMA_DYN(1, char, args[3]), args[2], args[3] );
 		return 0;
 
 	case UI_MEMCPY:
-		Com_Memcpy( VMA(1), VMA(2), args[3] );
+		Com_Memcpy( VMA_DYN(1, char, args[3]), VMA_DYN(2, char, args[3]), args[3] );
 		return 0;
 
 	case UI_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		strncpy( VMA_DYN(1, char, args[3]), VMA_STR(2), args[3] );
 		return args[1];
 
 	case UI_SIN:
@@ -1027,29 +1027,29 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return FloatAsInt( ceil( VMF(1) ) );
 
 	case UI_PC_ADD_GLOBAL_DEFINE:
-		return botlib_export->PC_AddGlobalDefine( VMA(1) );
+		return botlib_export->PC_AddGlobalDefine( VMA_STR(1) );
 	case UI_PC_LOAD_SOURCE:
-		return botlib_export->PC_LoadSourceHandle( VMA(1) );
+		return botlib_export->PC_LoadSourceHandle( VMA_STR(1) );
 	case UI_PC_FREE_SOURCE:
 		return botlib_export->PC_FreeSourceHandle( args[1] );
 	case UI_PC_READ_TOKEN:
-		return botlib_export->PC_ReadTokenHandle( args[1], VMA(2) );
+		return botlib_export->PC_ReadTokenHandle( args[1], VMA_1(2, pc_token_t) );
 	case UI_PC_SOURCE_FILE_AND_LINE:
-		return botlib_export->PC_SourceFileAndLine( args[1], VMA(2), VMA(3) );
+		return botlib_export->PC_SourceFileAndLine( args[1], VMA_DYN(2, char, VMA_HACK_AVAILABLE(2, 128)), VMA_HACK_AVAILABLE(2, 128), VMA_1(3, int) );
 
 	case UI_S_STOPBACKGROUNDTRACK:
 		S_StopBackgroundTrack();
 		return 0;
 	case UI_S_STARTBACKGROUNDTRACK:
-		S_StartBackgroundTrack( VMA(1), VMA(2));
+		S_StartBackgroundTrack( VMA_STR(1), VMA_STR(2));
 		return 0;
 
 	case UI_REAL_TIME:
-		return Com_RealTime( VMA(1) );
+		return Com_RealTime( VMA_1(1, qtime_t) );
 
 	case UI_CIN_PLAYCINEMATIC:
 	  Com_DPrintf("UI_CIN_PlayCinematic\n");
-	  return CIN_PlayCinematic(VMA(1), args[2], args[3], args[4], args[5], args[6]);
+	  return CIN_PlayCinematic(VMA_STR(1), args[2], args[3], args[4], args[5], args[6]);
 
 	case UI_CIN_STOPCINEMATIC:
 	  return CIN_StopCinematic(args[1]);
@@ -1066,11 +1066,11 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 	  return 0;
 
 	case UI_R_REMAP_SHADER:
-		re.RemapShader( VMA(1), VMA(2), VMA(3) );
+		re.RemapShader( VMA_STR(1), VMA_STR(2), VMA_STR(3) );
 		return 0;
 
 	case UI_VERIFY_CDKEY:
-		return CL_CDKeyValidate(VMA(1), VMA(2));
+		return CL_CDKeyValidate(VMA_STR(1), VMA_STR(2));
 		
 	default:
 		Com_Error( ERR_DROP, "Bad UI system trap: %ld", (long int) args[0] );

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -483,7 +483,7 @@ int CL_GetPingQueueCount( void );
 void CL_ShutdownRef( void );
 void CL_InitRef( void );
 qboolean CL_CDKeyValidate( const char *key, const char *checksum );
-int CL_ServerStatus( char *serverAddress, char *serverStatusString, int maxLen );
+int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int maxLen );
 
 qboolean CL_CheckPaused(void);
 

--- a/code/server/sv_bot.c
+++ b/code/server/sv_bot.c
@@ -422,7 +422,7 @@ static void BotImport_DebugLineShow(int line, vec3_t start, vec3_t end, int colo
 SV_BotClientCommand
 ==================
 */
-static void BotClientCommand( int client, char *command ) {
+static void BotClientCommand( int client, const char *command ) {
 	SV_ExecuteClientCommand( &svs.clients[client], command, qtrue );
 }
 


### PR DESCRIPTION
Fix #358 

Bit of a different approach from https://github.com/ioquake/ioq3/pull/441 that should be more maintainable.

Removes VMA macro.  Replacements:
VMA_N: Address must have enough space for multiple of a specified non-array type.
VMA_1: Address must have enough space for 1 of a specified non-array type.
VMA_VEC3: Address must have enough space for a vec3_t.
VMA_STR: Argument is an input string.  (Not valid for output strings - use VMA_DYN)
VMA_DYN: Argument is an array with a specified maximum output quantity, and the quantity must not be negative.  Also checks for arithmetic overflow.
VMA_HACK_AVAILABLE: Compatibility hack for syscalls that output to unbounded char pointer (only PC_SourceFileAndLine). In this case, the available address range is used for QVM, and a fallback number is used for DLLs.
VMA_DYN_SIZED: Argument is an array of type with specified size that includes extra space (used for SV_LocateGameData).  Specified size must be at least the size of the element type.
VMA_UNBOUNDED: Unchecked pointer, only used for UnifyWhiteSpaces, which should not be able to expand the string size.

Updated StringReplaceWords, BotReplaceSynonyms, BotReplaceReplySynonyms.  Synonym replacement now stops if the destination string would be expanded by the synonym replacement beyond its expected size.

There are a ton of other string handling safety issues in botlib though so it's really not a great situation.

Tested offline and everything seems OK?

After this I will try to get another change to harden the memory access a bit further by forcing there to be a decommitted guard page 2 pages after the VM memory, which will mean that any attempt to access memory >1 page beyond the VM memory space will just page fault and crash the game immediately instead of doing bad things to valid memory.