### PR TITLE
Fix memory corruption in S_TransferPaintBuffer

### DIFF
--- a/code/client/snd_mix.c
+++ b/code/client/snd_mix.c
@@ -175,7 +175,7 @@ void S_TransferPaintBuffer(int endtime)
 	{	// general case
 		p = (int *) paintbuffer;
 		count = (endtime - s_paintedtime) * dma.channels;
-		out_idx = (s_paintedtime * dma.channels) % dma.samples;
+		out_idx = ((unsigned int)s_paintedtime * dma.channels) % dma.samples;
 		step = 3 - MIN(dma.channels, 2);
 
 		if ((dma.isfloat) && (dma.samplebits == 32))


### PR DESCRIPTION
When using a non-default sound configuration (such as 6 channels), after
a long time (about 4.5hours for 6 channels at 22050 Hz) an overflow will
occur in `S_TransferPaintBuffer`, causing an out of bounds write into
the dma buffer.

The problematic line is:
```
out_idx = (s_paintedtime * dma.channels) % dma.samples;
```

With `s_paintedtime` large enough, the result of the multiplication will
overflow to a negative number (since `s_paintedtime` is signed), and the
index into the output buffer will be negative.