### PR TITLE
vm_x86.c: Add `defined(_M_IX86) || defined(_M_X64)` (fix for VS2019)

### DIFF
--- a/code/qcommon/vm_x86.c
+++ b/code/qcommon/vm_x86.c
@@ -42,7 +42,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #endif
 #endif
 
-#if defined (__i386__) || defined(__x86_64__)
+#if defined (__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 static void VM_Destroy_Compiled(vm_t* self);
 
 /*


### PR DESCRIPTION
Fixes https://github.com/ioquake/ioq3/issues/538 based on @zturtleman's example code (which just worked perfectly as it was), thank you a lot (and the other contributers @tomkidd and @DanielGibson for elaborating and discussing the issue)!

Tested in VS2019 only, but I don't see how this could conflict with anything else, as these predefinitions are made for this.

From https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160:

`_M_IX86`: Defined as the integer literal value 600 for compilations that target x86 processors. This macro isn't defined for x64 or ARM compilation targets.

`_M_X64`: Defined as the integer literal value 100 for compilations that target x64 processors. Otherwise, undefined.

![image](https://user-images.githubusercontent.com/5236548/148038302-716a7fd5-9f34-47fa-ab1b-1f0f1e4f8500.png)
