### PR TITLE
Protocol handler

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -24,6 +24,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "client.h"
 #include <limits.h>
 
+#ifdef WIN32
+#include <winreg.h>
+#endif
+
 #include "../sys/sys_local.h"
 #include "../sys/sys_loadlib.h"
 
@@ -162,6 +166,7 @@ void CL_CheckForResend( void );
 void CL_ShowIP_f(void);
 void CL_ServerStatus_f(void);
 void CL_ServerStatusResponse( netadr_t from, msg_t *msg );
+void CL_RegisterProtocolHandler_f( void );
 
 /*
 ===============
@@ -3694,6 +3699,7 @@ void CL_Init( void ) {
 		Cmd_AddCommand ("sayto", CL_Sayto_f );
 		Cmd_SetCommandCompletionFunc( "sayto", CL_CompletePlayerName );
 	}
+	Cmd_AddCommand ("registerprotocolhandler", CL_RegisterProtocolHandler_f );
 	CL_InitRef();
 
 	SCR_Init ();
@@ -4707,4 +4713,92 @@ qboolean CL_CDKeyValidate( const char *key, const char *checksum ) {
 
 	return qfalse;
 #endif
+}
+
+/*
+==================
+CL_RegisterProtocolHandler_f
+==================
+*/
+void CL_RegisterProtocolHandler_f( void )
+{
+	#ifndef PROTOCOL_HANDLER
+	Com_Printf( "Not built with protocol handler support.\n" );
+	#elif _WIN32
+
+	HKEY key;
+	int error;
+	char *path;
+	char value[MAX_PATH];
+
+	error = RegCreateKeyEx( HKEY_CURRENT_USER, "Software\\Classes\\" PROTOCOL_HANDLER, 0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error opening registry key.\n" );
+		return;
+	}
+
+	path = Sys_ExecutablePath( );
+	error = RegSetValueEx( key, "CustomUrlApplication", 0, REG_SZ, (LPBYTE) path, strlen( path ) + 1 );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error writing to registry.\n" );
+		return;
+	}
+
+	// value = "\"%1\"";
+	strcpy( value, "\"%1\"" );
+	error = RegSetValueEx( key, "CustomUrlArguments", 0, REG_SZ, (LPBYTE) value, strlen( value ) + 1 );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error writing to registry key.\n" );
+		return;
+	}
+
+	strcpy( value, "" );
+	error = RegSetValueEx( key, "URL Protocol", 0, REG_SZ, (LPBYTE) value, strlen( value ) + 1 );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error writing to registry.\n" );
+		return;
+	}
+	RegCloseKey( key );
+
+	error = RegCreateKeyEx( HKEY_CURRENT_USER, "Software\\Classes\\" PROTOCOL_HANDLER "\\DefaultIcon", 0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error opening registry key.\n" );
+		return;
+	}
+
+	snprintf( value, sizeof(value), "%s,0", path );
+	error = RegSetValueEx( key, "", 0, REG_SZ, (LPBYTE) value, strlen( value ) + 1 );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error writing to registry.\n" );
+		return;
+	}
+	RegCloseKey( key );
+
+	error = RegCreateKeyEx( HKEY_CURRENT_USER, "Software\\Classes\\" PROTOCOL_HANDLER "\\shell\\open\\command", 0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error opening registry key.\n" );
+		return;
+	}
+
+	snprintf( value, sizeof(value), "\"%s\" --uri \"%%1\"", path );
+	error = RegSetValueEx( key, "", 0, REG_SZ, (LPBYTE) value, strlen( value ) + 1 );
+	if ( error != ERROR_SUCCESS )
+	{
+		Com_Printf( "Error writing to registry.\n" );
+		return;
+	}
+	RegCloseKey( key );
+
+	Com_Printf( "Registered protocol " PROTOCOL_HANDLER ":// at HKEY_CURRENT_USER\\Software\\Classes\\" PROTOCOL_HANDLER "\\\n" );
+
+	#else
+	Com_Printf( "Only implemented for Windows.\n" );
+	#endif
 }

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -4722,9 +4722,9 @@ CL_RegisterProtocolHandler_f
 */
 void CL_RegisterProtocolHandler_f( void )
 {
-	#ifndef PROTOCOL_HANDLER
+#ifndef PROTOCOL_HANDLER
 	Com_Printf( "Not built with protocol handler support.\n" );
-	#elif _WIN32
+#elif _WIN32
 
 	HKEY key;
 	int error;
@@ -4746,7 +4746,6 @@ void CL_RegisterProtocolHandler_f( void )
 		return;
 	}
 
-	// value = "\"%1\"";
 	strcpy( value, "\"%1\"" );
 	error = RegSetValueEx( key, "CustomUrlArguments", 0, REG_SZ, (LPBYTE) value, strlen( value ) + 1 );
 	if ( error != ERROR_SUCCESS )
@@ -4798,7 +4797,7 @@ void CL_RegisterProtocolHandler_f( void )
 
 	Com_Printf( "Registered protocol " PROTOCOL_HANDLER ":// at HKEY_CURRENT_USER\\Software\\Classes\\" PROTOCOL_HANDLER "\\\n" );
 
-	#else
+#else
 	Com_Printf( "Only implemented for Windows.\n" );
-	#endif
+#endif
 }

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -40,6 +40,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #define CINEMATICS_LOGO		"foologo.roq"
   #define CINEMATICS_INTRO		"intro.roq"
 //  #define LEGACY_PROTOCOL	// You probably don't need this for your standalone game
+//  #define PROTOCOL_HANDLER		"foobar"
 #else
   #define PRODUCT_NAME				"ioq3"
   #define BASEGAME					"baseq3"
@@ -56,6 +57,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #define CINEMATICS_LOGO		"idlogo.RoQ"
   #define CINEMATICS_INTRO		"intro.RoQ"
   #define LEGACY_PROTOCOL
+  #define PROTOCOL_HANDLER		"quake3"
 #endif
 
 // Heartbeat for dpmaster protocol. You shouldn't change this unless you know what you're doing

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 #endif
 
-char *Sys_ExecutablePath(void);
+char *Sys_ExecutablePath( void );
 
 // Console
 void CON_Shutdown( void );
@@ -68,6 +68,6 @@ int Sys_PID( void );
 qboolean Sys_PIDIsRunning( int pid );
 
 #ifdef PROTOCOL_HANDLER
-void Sys_InitProtocolHandler( void );
+char *Sys_InitProtocolHandler( void );
 char *Sys_ParseProtocolUri( const char *uri );
 #endif

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -40,6 +40,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 #endif
 
+char *Sys_ExecutablePath(void);
+
 // Console
 void CON_Shutdown( void );
 void CON_Init( void );

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -66,5 +66,6 @@ int Sys_PID( void );
 qboolean Sys_PIDIsRunning( int pid );
 
 #ifdef PROTOCOL_HANDLER
+void Sys_InitProtocolHandler( );
 char *Sys_ParseProtocolUri( char *uri );
 #endif

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -67,5 +67,5 @@ qboolean Sys_PIDIsRunning( int pid );
 
 #ifdef PROTOCOL_HANDLER
 void Sys_InitProtocolHandler( void );
-char *Sys_ParseProtocolUri( char *uri );
+char *Sys_ParseProtocolUri( const char *uri );
 #endif

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -66,6 +66,6 @@ int Sys_PID( void );
 qboolean Sys_PIDIsRunning( int pid );
 
 #ifdef PROTOCOL_HANDLER
-void Sys_InitProtocolHandler( );
+void Sys_InitProtocolHandler( void );
 char *Sys_ParseProtocolUri( char *uri );
 #endif

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -64,3 +64,7 @@ void Sys_AnsiColorPrint( const char *msg );
 
 int Sys_PID( void );
 qboolean Sys_PIDIsRunning( int pid );
+
+#ifdef PROTOCOL_HANDLER
+char *Sys_ParseProtocolUri( char *uri );
+#endif

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -40,8 +40,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 #endif
 
-char *Sys_ExecutablePath( void );
-
 // Console
 void CON_Shutdown( void );
 void CON_Init( void );

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -48,6 +48,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../qcommon/qcommon.h"
 
 static char binaryPath[ MAX_OSPATH ] = { 0 };
+static char executablePath[ MAX_OSPATH ] = { 0 };
 static char installPath[ MAX_OSPATH ] = { 0 };
 
 /*
@@ -68,6 +69,26 @@ Sys_BinaryPath
 char *Sys_BinaryPath(void)
 {
 	return binaryPath;
+}
+
+/*
+=================
+Sys_SetExecutablePath
+=================
+*/
+void Sys_SetExecutablePath(const char *path)
+{
+	Q_strncpyz(executablePath, path, sizeof(executablePath));
+}
+
+/*
+=================
+Sys_ExecutablePath
+=================
+*/
+char *Sys_ExecutablePath(void)
+{
+	return executablePath;
 }
 
 /*
@@ -821,6 +842,7 @@ int main( int argc, char **argv )
 #endif
 
 	Sys_ParseArgs( argc, argv );
+	Sys_SetExecutablePath( argv[ 0 ] );
 	Sys_SetBinaryPath( Sys_Dirname( argv[ 0 ] ) );
 	Sys_SetDefaultInstallPath( DEFAULT_BASEDIR );
 

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -682,10 +682,6 @@ char *Sys_ParseProtocolUri( char *uri )
 	{
 		command += strlen( "//" );
 	}
-	if ( command[0] == '\0' )
-	{
-		return NULL;
-	}
 	Com_Printf( "Sys_ParseProtocolUri: %s\n", command );
 
 	// At the moment, only "connect/hostname:port" is supported

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -686,7 +686,7 @@ char *Sys_ParseProtocolUri( char *uri )
 
 	// At the moment, only "connect/hostname:port" is supported
 	// For safety reasons, the "hostname:port" part can only
-	// contain characters from [a-zA-Z0-9.:-]
+	// contain characters from: a-zA-Z0-9.:-[]
 	if ( Q_strncmp( command, "connect/", strlen( "connect/" ) ) )
 	{
 		Com_Printf( "Sys_ParseProtocolUri: unsupported command.\n" );
@@ -713,7 +713,8 @@ char *Sys_ParseProtocolUri( char *uri )
 		}
 
 		if ( isalpha( arg[i] ) == 0 && isdigit( arg[i] ) == 0
-		 && arg[i] != '.' && arg[i] != ':' && arg[i] != '-' )
+		 && arg[i] != '.' && arg[i] != ':' && arg[i] != '-'
+		 && arg[i] != '[' && arg[i] != ']' )
 		{
 			Com_Printf( "Sys_ParseProtocolUri: hostname contains unsupported characters.\n" );
 			return NULL;

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -861,7 +861,7 @@ int main( int argc, char **argv )
 
 		// For security reasons we always detect --uri, even when PROTOCOL_HANDLER is undefined
 		// Any arguments after "--uri quake3://..." is ignored
-		if (!strcmp( argv[i], "--uri" ))
+		if ( !strcmp( argv[i], "--uri" ) )
 		{
 #ifdef PROTOCOL_HANDLER
 			if ( argc > i+1 )

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -714,10 +714,7 @@ char *Sys_ParseProtocolUri( char *uri )
 		}
 	}
 
-	int bufsize = strlen( command ) + 1;
-	char *data = Z_Malloc( bufsize );
-	Q_strncpyz( data, command, bufsize );
-	return data;
+	return CopyString(command);
 }
 #endif
 

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -48,7 +48,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../qcommon/qcommon.h"
 
 static char binaryPath[ MAX_OSPATH ] = { 0 };
-static char executablePath[ MAX_OSPATH ] = { 0 };
 static char installPath[ MAX_OSPATH ] = { 0 };
 
 /*
@@ -69,26 +68,6 @@ Sys_BinaryPath
 char *Sys_BinaryPath(void)
 {
 	return binaryPath;
-}
-
-/*
-=================
-Sys_SetExecutablePath
-=================
-*/
-void Sys_SetExecutablePath(const char *path)
-{
-	Q_strncpyz(executablePath, path, sizeof(executablePath));
-}
-
-/*
-=================
-Sys_ExecutablePath
-=================
-*/
-char *Sys_ExecutablePath(void)
-{
-	return executablePath;
 }
 
 /*
@@ -850,7 +829,6 @@ int main( int argc, char **argv )
 #endif
 
 	Sys_ParseArgs( argc, argv );
-	Sys_SetExecutablePath( argv[ 0 ] );
 	Sys_SetBinaryPath( Sys_Dirname( argv[ 0 ] ) );
 	Sys_SetDefaultInstallPath( DEFAULT_BASEDIR );
 

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -855,7 +855,7 @@ int main( int argc, char **argv )
 		// Any arguments after "--uri quake3://..." is ignored
 		if (!strcmp( argv[i], "--uri" ))
 		{
-			#if defined(PROTOCOL_HANDLER) && !defined(__APPLE__)
+			#ifdef PROTOCOL_HANDLER
 			if ( argc > i+1 )
 			{
 				char *command = Sys_ParseProtocolUri( argv[i+1] );

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -672,18 +672,15 @@ char *Sys_ParseProtocolUri( char *uri )
 	int i;
 
 	// Both "quake3://" and "quake3:" can be used
-	if ( !Q_strncmp( uri, PROTOCOL_HANDLER "://", strlen( PROTOCOL_HANDLER "://" ) ) )
-	{
-		command = uri + strlen( PROTOCOL_HANDLER "://" );
-	}
-	else if ( !Q_strncmp(uri, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
-	{
-		command = uri + strlen( PROTOCOL_HANDLER ":" );
-	}
-	else
+	if ( Q_strncmp(uri, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
 	{
 		Com_Printf( "Sys_ParseProtocolUri: unsupported protocol.\n" );
 		return NULL;
+	}
+	command = uri + strlen( PROTOCOL_HANDLER ":" );
+	if ( !Q_strncmp(command, "//", strlen( "//" ) ) )
+	{
+		command += strlen( "//" );
 	}
 	if ( command[0] == '\0' )
 	{

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -690,13 +690,13 @@ At the moment only the "connect" command is supported.
 char *Sys_ParseProtocolUri( const char *uri )
 {
 	// Both "quake3://" and "quake3:" can be used
-	if ( Q_strncmp(uri, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
+	if ( Q_strncmp( uri, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
 	{
 		Com_Printf( "Sys_ParseProtocolUri: unsupported protocol.\n" );
 		return NULL;
 	}
 	uri += strlen( PROTOCOL_HANDLER ":" );
-	if ( !Q_strncmp(uri, "//", strlen( "//" ) ) )
+	if ( !Q_strncmp( uri, "//", strlen( "//" ) ) )
 	{
 		uri += strlen( "//" );
 	}

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -47,10 +47,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../qcommon/q_shared.h"
 #include "../qcommon/qcommon.h"
 
-#if defined(PROTOCOL_HANDLER) && defined(__APPLE__)
-void Sys_InitProtocolHandler();
-#endif
-
 static char binaryPath[ MAX_OSPATH ] = { 0 };
 static char installPath[ MAX_OSPATH ] = { 0 };
 
@@ -646,6 +642,20 @@ void Sys_ParseArgs( int argc, char **argv )
 	}
 }
 
+#ifdef PROTOCOL_HANDLER
+/*
+=================
+Sys_InitProtocolHandler
+
+See sys_osx.m for macOS implementation.
+=================
+*/
+#ifndef __APPLE__
+void Sys_InitProtocolHandler( )
+{
+}
+#endif
+
 /*
 =================
 Sys_ParseProtocolUri
@@ -656,65 +666,66 @@ operation is invalid or unsupported.
 At the moment only the "connect" command is supported.
 =================
 */
-#ifdef PROTOCOL_HANDLER
 char *Sys_ParseProtocolUri( char *uri )
 {
 	// Both "quake3://" and "quake3:" can be used
 	char *command;
-	if (strstr(uri, PROTOCOL_HANDLER "://") == uri)
+	if ( strstr( uri, PROTOCOL_HANDLER "://" ) == uri )
 	{
-		command = uri + strlen(PROTOCOL_HANDLER "://");
+		command = uri + strlen( PROTOCOL_HANDLER "://" );
 	}
-	else if (strstr(uri, PROTOCOL_HANDLER ":") == uri)
+	else if ( strstr(uri, PROTOCOL_HANDLER ":" ) == uri )
 	{
-		command = uri + strlen(PROTOCOL_HANDLER ":");
+		command = uri + strlen( PROTOCOL_HANDLER ":" );
 	}
 	else
 	{
-		Com_Printf ("Sys_ParseProtocolUri: unsupported protocol.\n");
+		Com_Printf( "Sys_ParseProtocolUri: unsupported protocol.\n" );
 		return NULL;
 	}
-	if (command[0] == '\0') {
+	if ( command[0] == '\0' )
+	{
 		return NULL;
 	}
-	Com_Printf ("Sys_ParseProtocolUri: %s\n", command);
+	Com_Printf( "Sys_ParseProtocolUri: %s\n", command );
 
 	// At the moment, only "connect/hostname:port" is supported
 	// For safety reasons, the "hostname:port" part can only
 	// contain characters from [a-zA-Z0-9.:-]
-	if (strstr(command, "connect/") != command)
+	if ( strstr( command, "connect/" ) != command )
 	{
-		Com_Printf ("Sys_ParseProtocolUri: unsupported command.\n");
+		Com_Printf( "Sys_ParseProtocolUri: unsupported command.\n" );
 		return NULL;
 	}
-	char *arg = strchr(command, '/');
-	if (arg == NULL || arg[1] == '\0' || arg[1] == '?')
+	char *arg = strchr( command, '/' );
+	if ( arg == NULL || arg[1] == '\0' || arg[1] == '?' )
 	{
-		Com_Printf ("Sys_ParseProtocolUri: missing argument.\n");
+		Com_Printf( "Sys_ParseProtocolUri: missing argument.\n" );
 		return NULL;
 	}
 	*arg = ' ';
 	arg++;
 
 	// Check for any unsupported characters
-	for (int i=0; arg[i] != '\0'; i++)
+	for ( int i=0; arg[i] != '\0'; i++ )
 	{
-		if (arg[i] == '?') {
+		if ( arg[i] == '?' )
+		{
 			// For forwards compatibility, any query string parameters are ignored (e.g. "?password=abcd")
 			// However, these are not passed on macOS, so it may be a bad idea to add them.
 			arg[i] = '\0';
 			break;
 		}
 
-		if (isalpha(arg[i]) == 0 && isdigit(arg[i]) == 0
-		 && arg[i] != '.' && arg[i] != ':' && arg[i] != '-')
+		if ( isalpha( arg[i] ) == 0 && isdigit( arg[i] ) == 0
+		 && arg[i] != '.' && arg[i] != ':' && arg[i] != '-' )
 		{
-			Com_Printf ("Sys_ParseProtocolUri: hostname contains unsupported characters.\n");
+			Com_Printf( "Sys_ParseProtocolUri: hostname contains unsupported characters.\n" );
 			return NULL;
 		}
 	}
 
-	return CopyString(command);
+	return CopyString( command );
 }
 #endif
 
@@ -833,16 +844,15 @@ int main( int argc, char **argv )
 	NET_Init( );
 
 #ifdef PROTOCOL_HANDLER
-#ifdef __APPLE__
 	Sys_InitProtocolHandler( );
-#else
-	if (argc > 1)
+#ifndef __APPLE__
+	if ( argc > 1 )
 	{
-		char *command = Sys_ParseProtocolUri(argv[1]);
-		if (command != NULL)
+		char *command = Sys_ParseProtocolUri( argv[1] );
+		if ( command != NULL )
 		{
-			int bufsize = strlen(command)+1;
-			Com_QueueEvent(0, SE_CONSOLE, 0, 0, bufsize, (void*) command);
+			int bufsize = strlen( command ) + 1;
+			Com_QueueEvent( 0, SE_CONSOLE, 0, 0, bufsize, (void*) command );
 		}
 	}
 #endif

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -651,7 +651,7 @@ See sys_osx.m for macOS implementation.
 =================
 */
 #ifndef __APPLE__
-void Sys_InitProtocolHandler( )
+void Sys_InitProtocolHandler( void )
 {
 }
 #endif
@@ -668,13 +668,15 @@ At the moment only the "connect" command is supported.
 */
 char *Sys_ParseProtocolUri( char *uri )
 {
+	char *command, *arg;
+	int i;
+
 	// Both "quake3://" and "quake3:" can be used
-	char *command;
-	if ( strstr( uri, PROTOCOL_HANDLER "://" ) == uri )
+	if ( !Q_strncmp( uri, PROTOCOL_HANDLER "://", strlen( PROTOCOL_HANDLER "://" ) ) )
 	{
 		command = uri + strlen( PROTOCOL_HANDLER "://" );
 	}
-	else if ( strstr(uri, PROTOCOL_HANDLER ":" ) == uri )
+	else if ( !Q_strncmp(uri, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
 	{
 		command = uri + strlen( PROTOCOL_HANDLER ":" );
 	}
@@ -692,12 +694,12 @@ char *Sys_ParseProtocolUri( char *uri )
 	// At the moment, only "connect/hostname:port" is supported
 	// For safety reasons, the "hostname:port" part can only
 	// contain characters from [a-zA-Z0-9.:-]
-	if ( strstr( command, "connect/" ) != command )
+	if ( Q_strncmp( command, "connect/", strlen( "connect/" ) ) )
 	{
 		Com_Printf( "Sys_ParseProtocolUri: unsupported command.\n" );
 		return NULL;
 	}
-	char *arg = strchr( command, '/' );
+	arg = strchr( command, '/' );
 	if ( arg == NULL || arg[1] == '\0' || arg[1] == '?' )
 	{
 		Com_Printf( "Sys_ParseProtocolUri: missing argument.\n" );
@@ -707,7 +709,7 @@ char *Sys_ParseProtocolUri( char *uri )
 	arg++;
 
 	// Check for any unsupported characters
-	for ( int i=0; arg[i] != '\0'; i++ )
+	for ( i=0; arg[i] != '\0'; i++ )
 	{
 		if ( arg[i] == '?' )
 		{

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -130,8 +130,9 @@ char *Sys_StripAppBundle( char *dir )
 	{
 		return;
 	}
-	int bufsize = strlen( command ) + 1;
-	Com_QueueEvent( 0, SE_CONSOLE, 0, 0, bufsize, (void*) command );
+	char *buf = CopyString( command );
+	free( command );
+	Com_QueueEvent( 0, SE_CONSOLE, 0, 0, strlen( buf ) + 1, (void*) buf );
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -144,7 +144,7 @@ char *Sys_StripAppBundle( char *dir )
 
 @end
 
-void Sys_InitProtocolHandler( )
+void Sys_InitProtocolHandler( void )
 {
 	[NSApplication sharedApplication];
 

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -122,38 +122,40 @@ char *Sys_StripAppBundle( char *dir )
 
 @implementation AppDelegate
 
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent {
-  NSString *input = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-  char str [input.length];
-  strcpy(str, input.UTF8String);
+- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent
+{
+	NSString *input = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+	char str [input.length];
+	strcpy( str, input.UTF8String );
 
-  char *command = Sys_ParseProtocolUri(str);
-  if (command == NULL) {
-    return;
-  }
-  int bufsize = strlen(command)+1;
-  Com_QueueEvent(0, SE_CONSOLE, 0, 0, bufsize, (void*) command);
+	char *command = Sys_ParseProtocolUri( str );
+	if ( command == NULL )
+	{
+		return;
+	}
+	int bufsize = strlen( command ) + 1;
+	Com_QueueEvent( 0, SE_CONSOLE, 0, 0, bufsize, (void*) command );
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    [NSApp stop:nil];
+	[NSApp stop:nil];
 }
 
 @end
 
-void Sys_InitProtocolHandler()
+void Sys_InitProtocolHandler( )
 {
-  [NSApplication sharedApplication];
+	[NSApplication sharedApplication];
 
-  AppDelegate *appDelegate = [AppDelegate new];
-  NSAppleEventManager *sharedAppleEventManager = [NSAppleEventManager new];
-  [sharedAppleEventManager setEventHandler:appDelegate
-                               andSelector:@selector(handleAppleEvent:withReplyEvent:)
-                             forEventClass:kInternetEventClass
-                                andEventID:kAEGetURL];
+	AppDelegate *appDelegate = [AppDelegate new];
+	NSAppleEventManager *sharedAppleEventManager = [NSAppleEventManager new];
+	[sharedAppleEventManager setEventHandler:appDelegate
+	                             andSelector:@selector(handleAppleEvent:withReplyEvent:)
+	                           forEventClass:kInternetEventClass
+	                              andEventID:kAEGetURL];
 
-  [NSApp setDelegate:appDelegate];
-  [NSApp run];
+	[NSApp setDelegate:appDelegate];
+	[NSApp run];
 }
 #endif

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -34,6 +34,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
 
+#ifdef PROTOCOL_HANDLER
+char *protocolCommand = NULL;
+#endif
+
 /*
 ==============
 Sys_Dialog
@@ -117,6 +121,7 @@ char *Sys_StripAppBundle( char *dir )
 }
 
 #ifdef PROTOCOL_HANDLER
+
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 @end
 
@@ -125,14 +130,7 @@ char *Sys_StripAppBundle( char *dir )
 - (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent
 {
 	NSString *input = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-	char *command = Sys_ParseProtocolUri( input.UTF8String );
-	if ( command == NULL )
-	{
-		return;
-	}
-	char *buf = CopyString( command );
-	free( command );
-	Com_QueueEvent( 0, SE_CONSOLE, 0, 0, strlen( buf ) + 1, (void*) buf );
+	protocolCommand = Sys_ParseProtocolUri( input.UTF8String );
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
@@ -142,7 +140,7 @@ char *Sys_StripAppBundle( char *dir )
 
 @end
 
-void Sys_InitProtocolHandler( void )
+char *Sys_InitProtocolHandler( void )
 {
 	[NSApplication sharedApplication];
 
@@ -155,5 +153,8 @@ void Sys_InitProtocolHandler( void )
 
 	[NSApp setDelegate:appDelegate];
 	[NSApp run];
+
+	return protocolCommand;
 }
+
 #endif

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -125,10 +125,7 @@ char *Sys_StripAppBundle( char *dir )
 - (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent
 {
 	NSString *input = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-	char str [input.length];
-	strcpy( str, input.UTF8String );
-
-	char *command = Sys_ParseProtocolUri( str );
+	char *command = Sys_ParseProtocolUri( input.UTF8String );
 	if ( command == NULL )
 	{
 		return;

--- a/make-macosx-app.sh
+++ b/make-macosx-app.sh
@@ -196,6 +196,7 @@ CONTENTS_FOLDER_PATH="${WRAPPER_NAME}/Contents"
 UNLOCALIZED_RESOURCES_FOLDER_PATH="${CONTENTS_FOLDER_PATH}/Resources"
 EXECUTABLE_FOLDER_PATH="${CONTENTS_FOLDER_PATH}/MacOS"
 EXECUTABLE_NAME="${PRODUCT_NAME}"
+PROTOCOL_HANDLER="quake3"
 
 # loop through the architectures to build string lists for each universal binary
 for ARCH in $SEARCH_ARCHS; do
@@ -378,6 +379,21 @@ if [ -n "${MACOSX_DEPLOYMENT_TARGET_PPC}" ] || [ -n "${MACOSX_DEPLOYMENT_TARGET_
 	PLIST="${PLIST}
     </dict>"
 fi
+
+	if [ -n "${PROTOCOL_HANDLER}" ]; then
+	PLIST="${PLIST}
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>${PRODUCT_NAME}</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>${PROTOCOL_HANDLER}</string>
+        </array>
+      </dict>
+    </array>"
+	fi
 
 PLIST="${PLIST}
     <key>NSHumanReadableCopyright</key>

--- a/misc/nsis/ioquake3.nsi.in
+++ b/misc/nsis/ioquake3.nsi.in
@@ -45,7 +45,7 @@ OutFile "ioquake3-XXXVERSIONXXX-XXXRELEASEXXX.x86.exe"
 
 !insertmacro MULTIUSER_PAGE_INSTALLMODE
 ;!insertmacro MUI_PAGE_LICENSE "../../COPYING.txt"
-!define MUI_COMPONENTSPAGE_NODESC
+!define MUI_COMPONENTSPAGE_SMALLDESC
 !insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -71,7 +71,7 @@ Function un.onInit
 FunctionEnd
 
 ; The stuff to install
-Section "ioquake3 (required)"
+Section "ioquake3 (required)" ioquake3
 
   SectionIn RO
 
@@ -124,7 +124,7 @@ Section "ioquake3 (required)"
 SectionEnd
 
 ; Optional section (can be disabled by the user)
-Section "Start Menu Shortcuts"
+Section "Start Menu Shortcuts" StartMenuShortcuts
 
   CreateDirectory "$SMPROGRAMS\ioquake3"
   CreateShortCut "$SMPROGRAMS\ioquake3\Uninstall.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
@@ -132,7 +132,7 @@ Section "Start Menu Shortcuts"
 
 SectionEnd
 
-Section "Protocol Handler"
+Section "Protocol Handler" ProtocolHandler
 
   WriteRegStr SHCTX "Software\Classes\quake3" "CustomUrlApplication" "$INSTDIR\ioquake3.x86.exe"
   WriteRegStr SHCTX "Software\Classes\quake3" "CustomUrlArguments" '"%1"'
@@ -142,7 +142,7 @@ Section "Protocol Handler"
 
 SectionEnd
 
-Section "SDL2.dll"
+Section "SDL2.dll" SDL
 
   SetOutPath $INSTDIR
 
@@ -151,7 +151,7 @@ Section "SDL2.dll"
 SectionEnd
 
 !ifdef USE_OPENAL_DLOPEN
-Section "OpenAL-Soft library"
+Section "OpenAL-Soft library" OpenAL
 
   SetOutPath $INSTDIR
 
@@ -161,7 +161,7 @@ SectionEnd
 !endif
 
 !ifdef USE_CURL_DLOPEN
-Section "libcurl"
+Section "libcurl" libcurl
 
   SetOutPath $INSTDIR
 
@@ -231,3 +231,16 @@ Section "Uninstall"
   RMDir "$INSTDIR"
 
 SectionEnd
+
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${ioquake3} "The game itself."
+  !insertmacro MUI_DESCRIPTION_TEXT ${StartMenuShortcuts} "Shortcuts to ioquake3 in the start menu."
+  !insertmacro MUI_DESCRIPTION_TEXT ${ProtocolHandler} "The protocol handler lets you connect to a game by clicking links in a web browser."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SDL} "SDL files."
+!ifdef USE_OPENAL_DLOPEN
+  !insertmacro MUI_DESCRIPTION_TEXT ${OpenAL} "OpenAL files."
+!endif
+!ifdef USE_CURL_DLOPEN
+  !insertmacro MUI_DESCRIPTION_TEXT ${libcurl} "libcurl files."
+!endif
+!insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/misc/nsis/ioquake3.nsi.in
+++ b/misc/nsis/ioquake3.nsi.in
@@ -132,6 +132,16 @@ Section "Start Menu Shortcuts"
 
 SectionEnd
 
+Section "Protocol Handler"
+
+  WriteRegStr SHCTX "Software\Classes\quake3" "CustomUrlApplication" "$INSTDIR\ioquake3.x86.exe"
+  WriteRegStr SHCTX "Software\Classes\quake3" "CustomUrlArguments" '"%1"'
+  WriteRegStr SHCTX "Software\Classes\quake3" "URL Protocol" ""
+  WriteRegStr SHCTX "Software\Classes\quake3\DefaultIcon" "" "$INSTDIR\ioquake3.x86.exe,0"
+  WriteRegStr SHCTX "Software\Classes\quake3\shell\open\command" "" '"$INSTDIR\ioquake3.x86.exe" "%1"'
+
+SectionEnd
+
 Section "SDL2.dll"
 
   SetOutPath $INSTDIR
@@ -169,6 +179,7 @@ Section "Uninstall"
   ; Remove registry keys
   DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\ioquake3"
   DeleteRegKey SHCTX "Software\ioquake3"
+  DeleteRegKey SHCTX "Software\Classes\quake3"
 
   ; Remove files and uninstaller
   Delete $INSTDIR\baseq3\cgamex86.dll

--- a/misc/nsis/ioquake3.nsi.in
+++ b/misc/nsis/ioquake3.nsi.in
@@ -138,7 +138,7 @@ Section "Protocol Handler" ProtocolHandler
   WriteRegStr SHCTX "Software\Classes\quake3" "CustomUrlArguments" '"%1"'
   WriteRegStr SHCTX "Software\Classes\quake3" "URL Protocol" ""
   WriteRegStr SHCTX "Software\Classes\quake3\DefaultIcon" "" "$INSTDIR\ioquake3.x86.exe,0"
-  WriteRegStr SHCTX "Software\Classes\quake3\shell\open\command" "" '"$INSTDIR\ioquake3.x86.exe" "%1"'
+  WriteRegStr SHCTX "Software\Classes\quake3\shell\open\command" "" '"$INSTDIR\ioquake3.x86.exe" --uri "%1"'
 
 SectionEnd
 

--- a/misc/nsis/ioquake3.nsi.in
+++ b/misc/nsis/ioquake3.nsi.in
@@ -233,9 +233,9 @@ Section "Uninstall"
 SectionEnd
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-  !insertmacro MUI_DESCRIPTION_TEXT ${ioquake3} "The game itself."
-  !insertmacro MUI_DESCRIPTION_TEXT ${StartMenuShortcuts} "Shortcuts to ioquake3 in the start menu."
-  !insertmacro MUI_DESCRIPTION_TEXT ${ProtocolHandler} "The protocol handler lets you connect to a game by clicking links in a web browser."
+  !insertmacro MUI_DESCRIPTION_TEXT ${ioquake3} "The game executables."
+  !insertmacro MUI_DESCRIPTION_TEXT ${StartMenuShortcuts} "Create shortcuts in the start menu."
+  !insertmacro MUI_DESCRIPTION_TEXT ${ProtocolHandler} "The protocol handler lets you connect to a game by clicking a link in a web browser."
   !insertmacro MUI_DESCRIPTION_TEXT ${SDL} "SDL files."
 !ifdef USE_OPENAL_DLOPEN
   !insertmacro MUI_DESCRIPTION_TEXT ${OpenAL} "OpenAL files."

--- a/misc/setup/ioquake3.desktop
+++ b/misc/setup/ioquake3.desktop
@@ -1,9 +1,10 @@
 [Desktop Entry]
 Name=ioquake3
-Exec=ioquake3
+Exec=ioquake3 %u
 Icon=quake3
 Type=Application
 Terminal=false
 Encoding=UTF-8
 Categories=Game;ActionGame;
+MimeType=x-scheme-handler/quake3;
 X-SuSE-translate=false

--- a/misc/setup/ioquake3.desktop
+++ b/misc/setup/ioquake3.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=ioquake3
-Exec=ioquake3 %u
+Exec=ioquake3 --uri %u
 Icon=quake3
 Type=Application
 Terminal=false


### PR DESCRIPTION
This lets the user click a link in a web browser to very easily join a Quake 3 multiplayer game. As browser-based matchmaking websites become more popular, this makes it a lot more convenient and simple to play Quake 3 with others.

The links have the following URI format: `quake3://connect/example.com:27950`. The format has been designed to be flexible to allow more types of links in the future and avoiding having to make a breaking change. At the moment, `connect` is the only supported command.

Just imagine if each of the servers on the page https://www.quakeservers.net/quake3/servers/ had a button next to it that said <kbd>Join Server</kbd>. I think that would make it easier to both attract new players, and keep them engaged in the longer term.

When you click a link, you will see a prompt like the following:

![prompt](https://user-images.githubusercontent.com/1991151/148665932-8c03e77c-74a7-4478-9f6f-2642db8fe851.png)

Just click <kbd>Open Link</kbd> and you'll be connected to the server. Simple!

An example of a mod/website that already does this is https://efservers.com/. The only difficulty there is that you have to make further modifications to your system and install a program that sits in between the website and the game. If we can get protocol handler support added directly into ioq3 then the steps that a user has to follow is minimized and the whole process is simpler and more user friendly.

The efservers website has only supported Windows. Recently I contributed handlers for Linux and macOS. My hope is that we can get this added to ioq3, and then I will work to update Lilium Voyager and Tulip Voyager in a way that supports this new protocol handler format, in addition to the current format that efservers is currently using.

I have tested this on Windows, Linux, and macOS, and it works very well on all of them. For Windows you need to create registry entries (the installer creates them if you don't unselect "Protocol Handler"). For Linux you need to install the updated `.desktop` file. For macOS you just need to drop the bundle in `/Applications` like normal.

The second commit adds descriptions to the Windows installer. I think I really need that to explain what a "Protocol handler" is, and I like the result.

![Windows installer](https://user-images.githubusercontent.com/1991151/148665733-831ec190-a53a-4360-96aa-0fe058aa190a.png)

As a final note, I found it extremely hard to figure out how to compile and build on Windows. Even worse since the wiki is down. I eventually found it on archive.org (https://web.archive.org/web/20190506050817/http://wiki.ioquake3.org/Building_ioQuake3). I first tried to use Cygwin but failed. Then I tried msys2 and got it working but I had to mess with a lot of files. Lots that could be improved here. I should probably have abandoned my attempts and just relied on GitHub Actions for Windows builds. 🤷 

Please let me know what you think. :)
