### PR TITLE
Fix bad client reliableAcknowledge DOS exploit

### DIFF
--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1917,7 +1917,7 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg ) {
 	// NOTE: when the client message is fux0red the acknowledgement numbers
 	// can be out of range, this could cause the server to send thousands of server
 	// commands which the server thinks are not yet acknowledged in SV_UpdateServerCommandsToClient
-	if (cl->reliableAcknowledge < cl->reliableSequence - MAX_RELIABLE_COMMANDS) {
+	if ((cl->reliableSequence - cl->reliableAcknowledge >= MAX_RELIABLE_COMMANDS) || (cl->reliableSequence - cl->reliableAcknowledge < 0)) {
 		// usually only hackers create messages like this
 		// it is more annoying for them to let them hanging
 #ifndef NDEBUG


### PR DESCRIPTION
Having a reliableAcknowledge of 0x7FFFFFFF causes a massive loop to be executed in SV_UpdateServerCommandsToClient due to the + 1 overflow.

Original find: https://github.com/callofduty4x/CoD4x_Server/pull/336

on a VPN, so idc about IP
![Animation](https://user-images.githubusercontent.com/751729/232956466-2fb7f2ae-e411-431c-9758-03228f77f45e.gif)


![image](https://user-images.githubusercontent.com/751729/232956860-c5d0bbd9-74d6-47a7-b590-fbf47398ec72.png)
