### PR TITLE
Update GitHub Actions due to deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Dependencies
       run: |
         sudo apt-get update
@@ -15,7 +15,7 @@ jobs:
       run: make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Linux
         path: build/*.zip
@@ -23,14 +23,14 @@ jobs:
     name: Windows
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Compile
       run: |
         choco install zip
         make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Windows
         path: build/*.zip
@@ -38,12 +38,12 @@ jobs:
     name: macOS
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Compile
       run: make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: macOS
         path: build/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         path: build/*.zip
   macos:
     name: macOS
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Compile


### PR DESCRIPTION
Update GitHub Actions CI to macOS 11 because macOS 10.15 is not available anymore.

Update actions/checkout and actions/upload-artifact to v3 to fix deprecation [warning](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).