### PR TITLE
Use SDL event for protocol handler on macOS

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1168,6 +1168,28 @@ static void IN_ProcessEvents( void )
 				}
 				break;
 
+#if defined(PROTOCOL_HANDLER) && defined(__APPLE__)
+			case SDL_DROPFILE:
+				{
+					char *filename = e.drop.file;
+
+					// Handle macOS open URL event. URL protocol scheme must be set in Info.plist.
+					if( !Q_strncmp( filename, PROTOCOL_HANDLER ":", strlen( PROTOCOL_HANDLER ":" ) ) )
+					{
+						char *protocolCommand = Sys_ParseProtocolUri( filename );
+
+						if( protocolCommand )
+						{
+							Cbuf_ExecuteText( EXEC_APPEND, va( "%s\n", protocolCommand ) );
+							free( protocolCommand );
+						}
+					}
+
+					SDL_free( filename );
+				}
+				break;
+#endif
+
 			default:
 				break;
 		}
@@ -1249,6 +1271,10 @@ void IN_Init( void *windowData )
 
 	in_joystick = Cvar_Get( "in_joystick", "0", CVAR_ARCHIVE|CVAR_LATCH );
 	in_joystickThreshold = Cvar_Get( "joy_threshold", "0.15", CVAR_ARCHIVE );
+
+#if defined(PROTOCOL_HANDLER) && defined(__APPLE__)
+	SDL_EventState( SDL_DROPFILE, SDL_ENABLE );
+#endif
 
 	SDL_StartTextInput( );
 

--- a/code/sys/sys_local.h
+++ b/code/sys/sys_local.h
@@ -66,6 +66,5 @@ int Sys_PID( void );
 qboolean Sys_PIDIsRunning( int pid );
 
 #ifdef PROTOCOL_HANDLER
-char *Sys_InitProtocolHandler( void );
 char *Sys_ParseProtocolUri( const char *uri );
 #endif

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -645,20 +645,6 @@ void Sys_ParseArgs( int argc, char **argv )
 #ifdef PROTOCOL_HANDLER
 /*
 =================
-Sys_InitProtocolHandler
-
-See sys_osx.m for macOS implementation.
-=================
-*/
-#ifndef __APPLE__
-char *Sys_InitProtocolHandler( void )
-{
-	return NULL;
-}
-#endif
-
-/*
-=================
 Sys_ParseProtocolUri
 
 This parses a protocol URI, e.g. "quake3://connect/example.com:27950"
@@ -716,9 +702,9 @@ char *Sys_ParseProtocolUri( const char *uri )
 			}
 		}
 
-		bufsize = strlen( "+connect " ) + i + 1;
+		bufsize = strlen( "connect " ) + i + 1;
 		out = malloc( bufsize );
-		strcpy( out, "+connect " );
+		strcpy( out, "connect " );
 		strncat( out, uri, i );
 		return out;
 	}
@@ -815,10 +801,6 @@ int main( int argc, char **argv )
 
 	Sys_PlatformInit( );
 
-#ifdef PROTOCOL_HANDLER
-	protocolCommand = Sys_InitProtocolHandler( );
-#endif
-
 	// Set the initial time base
 	Sys_Milliseconds( );
 
@@ -865,6 +847,7 @@ int main( int argc, char **argv )
 #ifdef PROTOCOL_HANDLER
 	if ( protocolCommand != NULL )
 	{
+		Q_strcat( commandLine, sizeof( commandLine ), "+" );
 		Q_strcat( commandLine, sizeof( commandLine ), protocolCommand );
 		free( protocolCommand );
 	}

--- a/code/sys/sys_osx.m
+++ b/code/sys/sys_osx.m
@@ -34,10 +34,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
 
-#ifdef PROTOCOL_HANDLER
-char *protocolCommand = NULL;
-#endif
-
 /*
 ==============
 Sys_Dialog
@@ -119,42 +115,3 @@ char *Sys_StripAppBundle( char *dir )
 	Q_strncpyz(cwd, Sys_Dirname(cwd), sizeof(cwd));
 	return cwd;
 }
-
-#ifdef PROTOCOL_HANDLER
-
-@interface AppDelegate : NSObject <NSApplicationDelegate>
-@end
-
-@implementation AppDelegate
-
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent
-{
-	NSString *input = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
-	protocolCommand = Sys_ParseProtocolUri( input.UTF8String );
-}
-
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
-{
-	[NSApp stop:nil];
-}
-
-@end
-
-char *Sys_InitProtocolHandler( void )
-{
-	[NSApplication sharedApplication];
-
-	AppDelegate *appDelegate = [AppDelegate new];
-	NSAppleEventManager *sharedAppleEventManager = [NSAppleEventManager new];
-	[sharedAppleEventManager setEventHandler:appDelegate
-	                             andSelector:@selector(handleAppleEvent:withReplyEvent:)
-	                           forEventClass:kInternetEventClass
-	                              andEventID:kAEGetURL];
-
-	[NSApp setDelegate:appDelegate];
-	[NSApp run];
-
-	return protocolCommand;
-}
-
-#endif


### PR DESCRIPTION
Use SDL's SDL_DROPFILE event to receive URLs to handle on macOS for URL protocol schemes listed in the AppBundle Info.plist. This also handles URLs while the game is running (connect to new server) instead of nothing happening when clicking a link while the game is running.

This fixes the macOS client and server being completely unusable when run from a terminal. They blocked forever in `[NSApp run];` which was called by Sys_InitProtocolHandler(). `applicationDidFinishLaunching` was never called to exit the NSApp run loop.

I didn't manage to find a way to know whether it was run from terminal or launch services (?) to not enter `[NSApp run]` or another way to allow bailing out of `[NSApp run]`. So use the SDL event instead.