### PR TITLE
Don't list mod directories at Windows drive root

### DIFF
--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -346,6 +346,10 @@ void Sys_ListFilteredFiles( const char *basedir, char *subdirs, char *filter, ch
 		return;
 	}
 
+	if ( basedir[0] == '\0' ) {
+		return;
+	}
+
 	if (strlen(subdirs)) {
 		Com_sprintf( search, sizeof(search), "%s/%s", basedir, subdirs );
 	}
@@ -423,6 +427,11 @@ char **Sys_ListFiles( const char *directory, const char *extension, char *filter
 		listCopy[i] = NULL;
 
 		return listCopy;
+	}
+
+	if ( directory[0] == '\0' ) {
+		*numfiles = 0;
+		return NULL;
 	}
 
 	if ( !extension)

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -483,6 +483,10 @@ void Sys_ListFilteredFiles( const char *basedir, char *subdirs, char *filter, ch
 		return;
 	}
 
+	if ( basedir[0] == '\0' ) {
+		return;
+	}
+
 	if (strlen(subdirs)) {
 		Com_sprintf( search, sizeof(search), "%s\\%s\\*", basedir, subdirs );
 	}
@@ -582,6 +586,11 @@ char **Sys_ListFiles( const char *directory, const char *extension, char *filter
 		listCopy[i] = NULL;
 
 		return listCopy;
+	}
+
+	if ( directory[0] == '\0' ) {
+		*numfiles = 0;
+		return NULL;
 	}
 
 	if ( !extension) {


### PR DESCRIPTION
The mod list on Windows would search the root of the drive if fs_basepath, fs_homepath, fs_steampath, or fs_gogpath are blank ("") (which is usually the case).

The issue is in the low-level Sys_ListFiles() but it only affects the mod menu, on Windows. It cannot be abused by console commands to list system files outside of the virtual filesystem.

There are more technical details in the commit message.