### PR TITLE
Improve AppStream metainfo

### DIFF
--- a/misc/setup/org.ioquake3.ioquake3.metainfo.xml
+++ b/misc/setup/org.ioquake3.ioquake3.metainfo.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>org.ioquake3.ioquake3</id>
   <launchable type="desktop-id">ioquake3.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <name>ioquake3</name>
   <summary>Free and open-source Quake 3 based engine</summary>
   <description>
@@ -17,18 +17,12 @@
   </description>
   <url type="homepage">https://ioquake3.org</url>
   <url type="bugtracker">https://github.com/ioquake/ioq3/issues</url>
-  <screenshots>
-    <screenshot type="default">
-      <image type="source">TK</image>
-    </screenshot>
-    <screenshot>
-      <image type="source">TK</image>
-    </screenshot>
-  </screenshots>
+  <url type="vcs-browser">https://github.com/ioquake/ioq3</url>
   <developer_name>The ioquake Group</developer_name>
   <content_rating type="oars-1.1">
-    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-realistic">intense</content_attribute>
     <content_attribute id="violence-bloodshed">intense</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
Specify license as GPL-2.0-or-later. It's meant to be an SPDX identifier and [SPDX doesn't have GPL-2.0](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/); Flathub displays it as GPL-2.0-only.

Mark it as realistic violence instead of fantasy based on [OARS generator](https://hughsie.github.io/oars/generate.html): "For example, this would include a user shooting a gun at a human characters." ESRB also lists Quake III Arena as violence, not fantasy violence.

Mark it as intense social-audio because unmoderated voice chat is supported.