### PR TITLE
Build QVMs even if there is no QVM JIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1069,7 +1069,6 @@ endif
 
 ifneq ($(HAVE_VM_COMPILED),true)
   BASE_CFLAGS += -DNO_VM_COMPILED
-  BUILD_GAME_QVM=0
 endif
 
 TARGETS =


### PR DESCRIPTION
The QVM interpreter works on all platforms. If building QVMs is an issue, that should probably be handled separate from whether there is a QVM JIT compiler.

This enables building QVMs by default on Linux arm64.