### PR TITLE
OpenGL2: Fix updating the loading screen with r_cubeMapping 1

### DIFF
--- a/code/renderergl2/tr_backend.c
+++ b/code/renderergl2/tr_backend.c
@@ -1169,6 +1169,13 @@ const void	*RB_DrawSurfs( const void *data ) {
 			qglGenerateTextureMipmapEXT(cubemap->image->texnum, GL_TEXTURE_CUBE_MAP);
 	}
 
+	// FIXME? backEnd.viewParms doesn't get properly initialized for 2D drawing.
+	// r_cubeMapping 1 generates cubemaps with R_RenderCubemapSide()
+	// and sets isMirror = qtrue. Clear it here to prevent it from leaking
+	// to 2D drawing and causing the loading screen to be culled.
+	backEnd.viewParms.isMirror = qfalse;
+	backEnd.viewParms.flags = 0;
+
 	return (const void *)(cmd + 1);
 }
 


### PR DESCRIPTION
Generating cubemaps set backEnd.viewParms.isMirror = qtrue while the loading screen said 'loading... maps/q3dm1.bsp' and it just stayed like that until done loading (no additional messages or item icons) because all 2D drawing was culled due to flipped culling for isMirror.

This was noticed because a [recent commit](https://github.com/ioquake/ioq3/commit/a81df34905fab89ad478237c269fc26bb1262489) fixed RB_ShowImages() to be drawn to the screen instead of draw into renderFbo and never blit to the screen. Now the loading screen draws over it as expected.