### PR TITLE
Fix building QVMs on Linux with Windows line endings

### DIFF
--- a/code/tools/lcc/cpp/lex.c
+++ b/code/tools/lcc/cpp/lex.c
@@ -511,6 +511,25 @@ foldline(Source *s)
 	return 0;
 }
 
+// This doesn't have proper tracking across read() to only remove \r from \r\n sequence.
+// The lexer doesn't correctly handle standalone \r anyway though.
+int
+crlf_to_lf(unsigned char *buf, int n) {
+	int i, count;
+
+	count = 0;
+
+	for (i = 0; i < n; i++) {
+		if (buf[i] == '\r') {
+			continue;
+		}
+
+		buf[count++] = buf[i];
+	}
+
+	return count;
+}
+
 int
 fillbuf(Source *s)
 {
@@ -521,6 +540,7 @@ fillbuf(Source *s)
 		error(FATAL, "Input buffer overflow");
 	if (s->fd<0 || (n=read(s->fd, (char *)s->inl, INS/8)) <= 0)
 		n = 0;
+	n = crlf_to_lf(s->inl, n);
 	if ((*s->inp&0xff) == EOB) /* sentinel character appears in input */
 		*s->inp = EOFC;
 	s->inl += n;

--- a/code/tools/lcc/cpp/unix.c
+++ b/code/tools/lcc/cpp/unix.c
@@ -65,6 +65,9 @@ setup(int argc, char **argv)
 		fp = (char*)newstring((uchar*)argv[optind], strlen(argv[optind]), 0);
 		if ((fd = open(fp, 0)) <= 0)
 			error(FATAL, "Can't open input file %s", fp);
+#ifdef WIN32
+		_setmode(fd, _O_BINARY);
+#endif
 	}
 	if (optind+1<argc) {
 		int fdo;
@@ -75,6 +78,9 @@ setup(int argc, char **argv)
 #endif
 		if (fdo<0)
 			error(FATAL, "Can't open output file %s", argv[optind+1]);
+#ifdef WIN32
+		_setmode(fdo, _O_BINARY);
+#endif
 		dup2(fdo, 1);
 	}
 	if(Mflag)

--- a/code/tools/lcc/lburg/gram.c
+++ b/code/tools/lcc/lburg/gram.c
@@ -1553,12 +1553,32 @@ static char buf[BUFSIZ], *bp = buf;
 static int ppercent = 0;
 static int code = 0;
 
+static void crlf_to_lf(char *buf, int bufmax) {
+	int i, count;
+
+	count = 0;
+
+	for (i = 0; i < bufmax; i++) {
+		if (buf[i] == '\r' && buf[i+1] == '\n') {
+			// skip '\r'
+			continue;
+		}
+
+		buf[count++] = buf[i];
+
+		if (buf[i] == '\0') {
+			break;
+		}
+	}
+}
+
 static int get(void) {
 	if (*bp == 0) {
 		bp = buf;
 		*bp = 0;
 		if (fgets(buf, sizeof buf, infp) == NULL)
 			return EOF;
+		crlf_to_lf(buf, sizeof buf);
 		yylineno++;
 		while (buf[0] == '%' && buf[1] == '{' && buf[2] == '\n') {
 			for (;;) {
@@ -1566,6 +1586,7 @@ static int get(void) {
 					yywarn("unterminated %{...%}\n");
 					return EOF;
 				}
+				crlf_to_lf(buf, sizeof buf);
 				yylineno++;
 				if (strcmp(buf, "%}\n") == 0)
 					break;
@@ -1573,6 +1594,7 @@ static int get(void) {
 			}
 			if (fgets(buf, sizeof buf, infp) == NULL)
 				return EOF;
+			crlf_to_lf(buf, sizeof buf);
 			yylineno++;
 		}
 	}

--- a/code/tools/lcc/lburg/gram.y
+++ b/code/tools/lcc/lburg/gram.y
@@ -70,12 +70,32 @@ static char buf[BUFSIZ], *bp = buf;
 static int ppercent = 0;
 static int code = 0;
 
+static void crlf_to_lf(char *buf, int bufmax) {
+	int i, count;
+
+	count = 0;
+
+	for (i = 0; i < bufmax; i++) {
+		if (buf[i] == '\r' && buf[i+1] == '\n') {
+			// skip '\r'
+			continue;
+		}
+
+		buf[count++] = buf[i];
+
+		if (buf[i] == '\0') {
+			break;
+		}
+	}
+}
+
 static int get(void) {
 	if (*bp == 0) {
 		bp = buf;
 		*bp = 0;
 		if (fgets(buf, sizeof buf, infp) == NULL)
 			return EOF;
+		crlf_to_lf(buf, sizeof buf);
 		yylineno++;
 		while (buf[0] == '%' && buf[1] == '{' && buf[2] == '\n') {
 			for (;;) {
@@ -83,6 +103,7 @@ static int get(void) {
 					yywarn("unterminated %{...%}\n");
 					return EOF;
 				}
+				crlf_to_lf(buf, sizeof buf);
 				yylineno++;
 				if (strcmp(buf, "%}\n") == 0)
 					break;
@@ -90,6 +111,7 @@ static int get(void) {
 			}
 			if (fgets(buf, sizeof buf, infp) == NULL)
 				return EOF;
+			crlf_to_lf(buf, sizeof buf);
 			yylineno++;
 		}
 	}

--- a/code/tools/lcc/lburg/lburg.c
+++ b/code/tools/lcc/lburg/lburg.c
@@ -56,14 +56,14 @@ int main(int argc, char *argv[]) {
 		} else if (infp == NULL) {
 			if (strcmp(argv[i], "-") == 0)
 				infp = stdin;
-			else if ((infp = fopen(argv[i], "r")) == NULL) {
+			else if ((infp = fopen(argv[i], "rb")) == NULL) {
 				yyerror("%s: can't read `%s'\n", argv[0], argv[i]);
 				exit(1);
 			}
 		} else if (outfp == NULL) {
 			if (strcmp(argv[i], "-") == 0)
 				outfp = stdout;
-			if ((outfp = fopen(argv[i], "w")) == NULL) {
+			if ((outfp = fopen(argv[i], "wb")) == NULL) {
 				yyerror("%s: can't write `%s'\n", argv[0], argv[i]);
 				exit(1);
 			}


### PR DESCRIPTION
On non-Windows, compiling QVM tools failed if [dagcheck.md](https://github.com/ioquake/ioq3/blob/main/code/tools/lcc/src/dagcheck.md) had CRLF line endings and compiling QVMs failed if game source had CRLF line endings.

Also made Windows open the files as binary (no automatic CRLF to LF) so it behaves the same as on non-Windows.

----

If code/tools/lcc/src/dagcheck.md has CRLF line endings, fails to compile QVM tools.

```
LBURG code/tools/lcc/src/dagcheck.md
line 1: invalid character `%'
line 1: invalid character `{'
line 1: invalid character `\015'
line 2: invalid character `#'
line 2: syntax error
line 2: invalid character `\015'
line 3: syntax error
line 3: invalid character `;'
line 3: invalid character `\015'
...
```

If QVM tools compiled but game source has CRLF line endings, it fails to compile.

```
CGAME_Q3LCC code/cgame/cg_main.c
cpp: code/cgame/cg_main.c:24 Syntax error in #include
cpp: code/cgame/cg_main.c:26 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:68 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:161 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:178 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:189 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:269 Syntax error in #ifdef/#ifndef
cpp: code/cgame/cg_main.c:271 Syntax error in #else
cpp: code/cgame/cg_main.c:273 Syntax error in #endif
...
```