### PR TITLE
Add better directions/error for missing Quake 3 / Team Arena pk3 files

### DIFF
--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -3685,7 +3685,8 @@ static void FS_CheckPak0( void )
 		Com_Error(ERR_FATAL, "%s", errorText);
 	}
 
-	if(!com_standalone->integer && foundTA && (foundTA & ((1<<NUM_TA_PAKS)-1)) != ((1<<NUM_TA_PAKS)-1))
+	if(!com_standalone->integer && (foundTA & ((1<<NUM_TA_PAKS)-1)) != ((1<<NUM_TA_PAKS)-1)
+			&& (!Q_stricmp(fs_gamedirvar->string, BASETA) || !Q_stricmp(fs_basegame->string, BASETA)))
 	{
 		char errorText[MAX_STRING_CHARS] = "";
 

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -724,6 +724,8 @@ Display an error message
 */
 void Sys_ErrorDialog( const char *error )
 {
+	Sys_Print( va( "%s\n", error ) );
+
 	if( Sys_Dialog( DT_YES_NO, va( "%s. Copy console log to clipboard?", error ),
 			"Error" ) == DR_YES )
 	{


### PR DESCRIPTION
This adds better directions for what to do when Quake 3 or Team Arena pk3 files are missing. (Idea inspired by the [org.ioquake3.ioquake3 Flatpak's message](https://github.com/flathub/org.ioquake3.ioquake3/blob/63244a01f9a0e532922f472d2db6e02e80692fc7/ioquake3#L6-L20).)

The files to copy is set based on what files are missing and either a range ("pak3.pk3" through "pak8.pk3") or a list of a pk3s ("pak0.pk3", "pak7.pk3", and "pak8.pk3").

I tested it displayed okay on Linux (zenity), Windows, and macOS. I only took screenshots from Linux.

The error message contains a URL so I made the Windows fatal error dialog "copy to clipboard" option include the error message like Unix-like platform's crashlog.txt.

Existing message when missing all Quake 3 pk3 files:
![Screenshot from 2024-01-21 15-32-53](https://github.com/ioquake/ioq3/assets/405505/02d753fe-32cd-4c9f-b2e1-c4365c58be0f)

New message:
![Screenshot from 2024-01-21 15-05-05](https://github.com/ioquake/ioq3/assets/405505/19b4f0d1-6ced-4c37-ab06-5df099b23f7e)

Steam is (probably still) missing missionpack/pak3.pk3. Using pak[0-2].pk3 would show this message in ioquake3 when launching Team Arena:
![Screenshot from 2024-01-21 15-12-38](https://github.com/ioquake/ioq3/assets/405505/7b7b3da8-8009-42c4-9f7e-ffd6eaf16ac0)

New message:
![Screenshot from 2024-01-21 15-09-23](https://github.com/ioquake/ioq3/assets/405505/541007b1-561a-486c-98e9-376d4cff0ae0)
