### PR TITLE
OpenGL2: Fix sun rays being affected by the viewport size

### DIFF
--- a/code/renderergl2/tr_fbo.c
+++ b/code/renderergl2/tr_fbo.c
@@ -648,10 +648,30 @@ void FBO_FastBlit(FBO_t *src, ivec4_t srcBox, FBO_t *dst, ivec4_t dstBox, int bu
 		int width  = dst ? dst->width  : glConfig.vidWidth;
 		int height = dst ? dst->height : glConfig.vidHeight;
 
+		qglScissor(0, 0, width, height);
+
 		VectorSet4(dstBoxFinal, 0, 0, width, height);
 	}
 	else
 	{
+		ivec4_t scissorBox;
+
+		Vector4Copy(dstBox, scissorBox);
+
+		if (scissorBox[2] < 0)
+		{
+			scissorBox[0] += scissorBox[2];
+			scissorBox[2] = fabsf(scissorBox[2]);
+		}
+
+		if (scissorBox[3] < 0)
+		{
+			scissorBox[1] += scissorBox[3];
+			scissorBox[3] = fabsf(scissorBox[3]);
+		}
+
+		qglScissor(scissorBox[0], scissorBox[1], scissorBox[2], scissorBox[3]);
+
 		VectorSet4(dstBoxFinal, dstBox[0], dstBox[1], dstBox[0] + dstBox[2], dstBox[1] + dstBox[3]);
 	}
 


### PR DESCRIPTION
Using r_drawSunRays 1, r_hdr 0, cg_viewsize 50 caused the sun rays to only draw properly in the bottom right quarter of the world viewport.

The scissor rectangle for the world viewport was applied to the first FBO_FastBlit() in RB_SunRays().

Set glScissor() in FBO_FastBlit() as it's done in FBO_Blit() and FBO_BlitFromTexture(). Sun rays probably worked correctly with r_hdr 1 because the blit for HDR changed the scissor state.

Fixes #305.