### PR TITLE
OpenGL2: Fix merged lightmaps using tcGen environment

### DIFF
--- a/code/renderergl2/tr_bsp.c
+++ b/code/renderergl2/tr_bsp.c
@@ -617,7 +617,7 @@ static shader_t *ShaderForShaderNum( int shaderNum, int lightmapNum ) {
 		lightmapNum = LIGHTMAP_WHITEIMAGE;
 	}
 
-	shader = R_FindShader( dsh->shader, lightmapNum, qtrue );
+	shader = R_FindShaderEx( dsh->shader, FatLightmap( lightmapNum ), qtrue, lightmapNum );
 
 	// if the shader had errors, just use default shader
 	if ( shader->defaultShader ) {
@@ -706,7 +706,7 @@ static void ParseFace( dsurface_t *ds, drawVert_t *verts, float *hdrVertColors, 
 	surf->fogIndex = LittleLong( ds->fogNum ) + 1;
 
 	// get shader value
-	surf->shader = ShaderForShaderNum( ds->shaderNum, FatLightmap(realLightmapNum) );
+	surf->shader = ShaderForShaderNum( ds->shaderNum, realLightmapNum );
 	if ( r_singleShader->integer && !surf->shader->isSky ) {
 		surf->shader = tr.defaultShader;
 	}
@@ -813,7 +813,7 @@ static void ParseMesh ( dsurface_t *ds, drawVert_t *verts, float *hdrVertColors,
 	surf->fogIndex = LittleLong( ds->fogNum ) + 1;
 
 	// get shader value
-	surf->shader = ShaderForShaderNum( ds->shaderNum, FatLightmap(realLightmapNum) );
+	surf->shader = ShaderForShaderNum( ds->shaderNum, realLightmapNum );
 	if ( r_singleShader->integer && !surf->shader->isSky ) {
 		surf->shader = tr.defaultShader;
 	}

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1995,6 +1995,7 @@ const void *RB_TakeVideoFrameCmd( const void *data );
 // tr_shader.c
 //
 shader_t	*R_FindShader( const char *name, int lightmapIndex, qboolean mipRawImage );
+shader_t	*R_FindShaderEx( const char *name, int lightmapIndex, qboolean mipRawImage, int realLightmapIndex );
 shader_t	*R_GetShaderByHandle( qhandle_t hShader );
 shader_t	*R_GetShaderByState( int index, long *cycleTime );
 shader_t *R_FindShaderByName( const char *name );

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -30,6 +30,7 @@ static char *s_shaderText;
 static	shaderStage_t	stages[MAX_SHADER_STAGES];		
 static	shader_t		shader;
 static	texModInfo_t	texMods[MAX_SHADER_STAGES][TR_MAX_TEXMODS];
+static	int				shader_realLightmapIndex;
 
 #define FILE_HASH_SIZE		1024
 static	shader_t*		hashTable[FILE_HASH_SIZE];
@@ -2929,7 +2930,7 @@ static void FixFatLightmapTexCoords(void)
 		return;
 	}
 
-	lightmapnum = shader.lightmapIndex;
+	lightmapnum = shader_realLightmapIndex;
 
 	if (tr.worldDeluxeMapping)
 		lightmapnum >>= 1;
@@ -2987,7 +2988,7 @@ static void FixFatLightmapTexCoords(void)
 InitShader
 ===============
 */
-static void InitShader( const char *name, int lightmapIndex ) {
+static void InitShaderEx( const char *name, int lightmapIndex, int realLightmapIndex ) {
 	int i;
 
 	// clear the global shader
@@ -2996,6 +2997,7 @@ static void InitShader( const char *name, int lightmapIndex ) {
 
 	Q_strncpyz( shader.name, name, sizeof( shader.name ) );
 	shader.lightmapIndex = lightmapIndex;
+	shader_realLightmapIndex = realLightmapIndex;
 
 	for ( i = 0 ; i < MAX_SHADER_STAGES ; i++ ) {
 		stages[i].bundle[0].texMods = texMods[i];
@@ -3014,6 +3016,10 @@ static void InitShader( const char *name, int lightmapIndex ) {
 			stages[i].specularScale[3] = r_baseGloss->value;
 		}
 	}
+}
+
+static void InitShader( const char *name, int lightmapIndex ) {
+	InitShaderEx( name, lightmapIndex, lightmapIndex );
 }
 
 /*
@@ -3337,6 +3343,10 @@ most world construction surfaces.
 ===============
 */
 shader_t *R_FindShader( const char *name, int lightmapIndex, qboolean mipRawImage ) {
+	return R_FindShaderEx( name, lightmapIndex, mipRawImage, lightmapIndex );
+}
+
+shader_t *R_FindShaderEx( const char *name, int lightmapIndex, qboolean mipRawImage, int realLightmapIndex ) {
 	char		strippedName[MAX_QPATH];
 	int			hash;
 	char		*shaderText;
@@ -3376,7 +3386,7 @@ shader_t *R_FindShader( const char *name, int lightmapIndex, qboolean mipRawImag
 		}
 	}
 
-	InitShader( strippedName, lightmapIndex );
+	InitShaderEx( strippedName, lightmapIndex, realLightmapIndex );
 
 	//
 	// attempt to define shader from an explicit parameter file

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -2946,12 +2946,14 @@ static void FixFatLightmapTexCoords(void)
 
 		if ( pStage->bundle[0].isLightmap ) {
 			// fix tcMod transform for internal lightmaps, it may be used by q3map2 lightstyles
-			for ( i = 0; i < pStage->bundle[0].numTexMods; i++ ) {
-				tmi = &pStage->bundle[0].texMods[i];
+			if ( pStage->bundle[0].tcGen == TCGEN_LIGHTMAP ) {
+				for ( i = 0; i < pStage->bundle[0].numTexMods; i++ ) {
+					tmi = &pStage->bundle[0].texMods[i];
 
-				if ( tmi->type == TMOD_TRANSFORM ) {
-					tmi->translate[0] /= (float)tr.fatLightmapCols;
-					tmi->translate[1] /= (float)tr.fatLightmapRows;
+					if ( tmi->type == TMOD_TRANSFORM ) {
+						tmi->translate[0] /= (float)tr.fatLightmapCols;
+						tmi->translate[1] /= (float)tr.fatLightmapRows;
+					}
 				}
 			}
 


### PR DESCRIPTION
- Fix the texcoord range for external lightmaps in a shader with an internal lightmap to be 0.0 to 1.0. (With texture repeating it would wrap around and read correctly but clampMap or tcMods might not of worked.)
- Fix merged lightmaps using tcGen environment. (Fixes  #636.)
- Only apply the hack to fix _tcMod transform on internal merged lightmaps_ to tcGen lightmap.