### PR TITLE
Fix Overlapping src and dest for strcpy in Client Code

### DIFF
--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -618,7 +618,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Com_Memcpy( VMA(1), VMA(2), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		CL_Strncpy( VMA(1), VMA(2), args[3] );
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -4708,3 +4708,21 @@ qboolean CL_CDKeyValidate( const char *key, const char *checksum ) {
 	return qfalse;
 #endif
 }
+
+/*
+=================
+CL_Strncpy
+=================
+Safe reimplementation of strncpy against overlapping src & dest
+*/
+
+char *CL_Strncpy(char *dest, const char *src, unsigned long n){
+    unsigned long length = strlen(src);
+    if(n > length){
+        memmove(dest, src, length);
+        memset(dest+length,0,n-length);
+    }else{
+        memmove(dest, src, n);
+    }
+    return dest;
+}

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -1005,7 +1005,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		CL_Strncpy( VMA(1), VMA(2), args[3] );
 		return args[1];
 
 	case UI_SIN:

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -485,6 +485,8 @@ void CL_InitRef( void );
 qboolean CL_CDKeyValidate( const char *key, const char *checksum );
 int CL_ServerStatus( char *serverAddress, char *serverStatusString, int maxLen );
 
+char *CL_Strncpy(char *dest, const char *src, unsigned long n);
+
 qboolean CL_CheckPaused(void);
 
 //


### PR DESCRIPTION
Recently, when playing with OpenArena assets, I noticed some visual glitches (lightning gun beam and  a part of a machine gun are missing). Luckily, another user pinpointed the exact issue, which is a glibc commit:

https://forum.manjaro.org/t/openarena-lightning-gun-beam-not-visible-with-glibc-2-37-x86-64-bug/135312/8

https://sourceware.org/git?p=glibc.git;a=commit;h=642933158e7cf072d873231b1a9bb03291f2b989

An issue on another project concerning the glibc commit (https://sourceware.org/bugzilla/show_bug.cgi?id=30112) shows that this is due to invalidating str*cpy invariant that src and destination cannot overlap.

Indeed,  upon inspection with AddressSanitizer, you can see src and dest arguments of  strncpy overlap in cl_cgame.c and cl_ui.c

This PR adds a safe reimplementation of Strncpy, that is safe against overlapping src and dest and fixes the visual glitches on OpenArena.

