### PR TITLE
Fix running on Windows XP

### DIFF
--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -20,6 +20,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+// Use EnumProcesses() with Windows XP compatibility
+#define PSAPI_VERSION 1
+
 #include "../qcommon/q_shared.h"
 #include "../qcommon/qcommon.h"
 #include "sys_local.h"


### PR DESCRIPTION
Newer mingw-w64 changed default Windows version compatibility. Need to specify older behavior for EnumProcesses() to avoid "missing K32EnumProcesses()" runtime error.

Reported at [the ioquake3 forum](https://discourse.ioquake.org/t/how-to-run-ioquake3-on-windows-me-and-xp/1860/4).