### PR TITLE
Fix GitHub Actions CI deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Dependencies
       run: |
         sudo apt-get update
@@ -15,7 +15,7 @@ jobs:
       run: make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Linux
         path: build/*.zip
@@ -23,14 +23,14 @@ jobs:
     name: Windows
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Compile
       run: |
         choco install zip
         make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Windows
         path: build/*.zip
@@ -38,12 +38,12 @@ jobs:
     name: macOS
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Compile
       run: make release
       env:
         ARCHIVE: 1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: macOS
         path: build/*.zip


### PR DESCRIPTION
The GitHub Actions summary page had the following warning:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.