### PR TITLE
OpenGL2: Don't mix drawing to default framebuffer and FBO

### DIFF
--- a/code/renderergl2/tr_image.c
+++ b/code/renderergl2/tr_image.c
@@ -2766,7 +2766,7 @@ void R_CreateBuiltinImages( void ) {
 
 		tr.renderImage = R_CreateImage("_render", NULL, width, height, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION | IMGFLAG_CLAMPTOEDGE, hdrFormat);
 
-		if (r_shadowBlur->integer)
+		if (r_shadowBlur->integer || r_hdr->integer)
 			tr.screenScratchImage = R_CreateImage("screenScratch", NULL, width, height, IMGTYPE_COLORALPHA, IMGFLAG_NO_COMPRESSION | IMGFLAG_CLAMPTOEDGE, rgbFormat);
 
 		if (r_shadowBlur->integer || r_ssao->integer)

--- a/code/renderergl2/tr_postprocess.c
+++ b/code/renderergl2/tr_postprocess.c
@@ -447,7 +447,7 @@ static void RB_VBlur(FBO_t *srcFbo, FBO_t *dstFbo, float strength)
 	RB_BlurAxis(srcFbo, dstFbo, strength, qfalse);
 }
 
-void RB_GaussianBlur(float blur)
+void RB_GaussianBlur(FBO_t *srcFbo, FBO_t *dstFbo, float blur)
 {
 	//float mul = 1.f;
 	float factor = Com_Clamp(0.f, 1.f, blur);
@@ -462,7 +462,7 @@ void RB_GaussianBlur(float blur)
 		VectorSet4(color, 1, 1, 1, 1);
 
 		// first, downsample the framebuffer
-		FBO_FastBlit(NULL, NULL, tr.quarterFbo[0], NULL, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		FBO_FastBlit(srcFbo, NULL, tr.quarterFbo[0], NULL, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 		FBO_FastBlit(tr.quarterFbo[0], NULL, tr.textureScratchFbo[0], NULL, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 		// set the alpha channel
@@ -478,6 +478,6 @@ void RB_GaussianBlur(float blur)
 		VectorSet4(srcBox, 0, 0, tr.textureScratchFbo[0]->width, tr.textureScratchFbo[0]->height);
 		VectorSet4(dstBox, 0, 0, glConfig.vidWidth,              glConfig.vidHeight);
 		color[3] = factor;
-		FBO_Blit(tr.textureScratchFbo[0], srcBox, NULL, NULL, dstBox, NULL, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
+		FBO_Blit(tr.textureScratchFbo[0], srcBox, NULL, dstFbo, dstBox, NULL, color, GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA);
 	}
 }

--- a/code/renderergl2/tr_postprocess.h
+++ b/code/renderergl2/tr_postprocess.h
@@ -28,6 +28,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 void RB_ToneMap(FBO_t *hdrFbo, ivec4_t hdrBox, FBO_t *ldrFbo, ivec4_t ldrBox, int autoExposure);
 void RB_BokehBlur(FBO_t *src, ivec4_t srcBox, FBO_t *dst, ivec4_t dstBox, float blur);
 void RB_SunRays(FBO_t *srcFbo, ivec4_t srcBox, FBO_t *dstFbo, ivec4_t dstBox);
-void RB_GaussianBlur(float blur);
+void RB_GaussianBlur(FBO_t *srcFbo, FBO_t *dstFbo, float blur);
 
 #endif


### PR DESCRIPTION
Don't draw the world scene to a separate FBO from the rest of the screen.

This fixes the world scene having HOM instead of seeing through to the previously drawn content. World of Padman uses this to have a separate 3D scene for the sky and world in wop_padship for dynamic skybox.

This also makes r_ext_framebuffer_multisample apply to HUD models instead of depending on r_ext_multisample (which doesn't work on Linux with some Intel graphics).