### PR TITLE
Use nanosleep(2) instead of usleep(3)

### DIFF
--- a/code/autoupdater/autoupdater.c
+++ b/code/autoupdater/autoupdater.c
@@ -939,7 +939,7 @@ static void waitToApplyUpdates(void)
             read(3, &x, sizeof (x));
             info("Pipe has closed, waiting for process to fully go away now.");
             while (kill(options.waitforprocess, 0) == 0) {
-                nanosleep(&req);
+                nanosleep(&req, NULL);
             }
             #endif
         }

--- a/code/autoupdater/autoupdater.c
+++ b/code/autoupdater/autoupdater.c
@@ -933,10 +933,13 @@ static void waitToApplyUpdates(void)
                OS forcibly closes the pipe), we will unblock. Then we can loop on
                kill() until the process is truly gone. */
             int x = 0;
+            struct timespec req;
+            req.tv_sec = 0;
+            req.tv_nsec = 100000000;
             read(3, &x, sizeof (x));
             info("Pipe has closed, waiting for process to fully go away now.");
             while (kill(options.waitforprocess, 0) == 0) {
-                usleep(100000);
+                nanosleep(&req);
             }
             #endif
         }

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -38,6 +38,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <fcntl.h>
 #include <fenv.h>
 #include <sys/wait.h>
+#include <time.h>
 
 qboolean stdinIsATTY;
 
@@ -552,7 +553,10 @@ void Sys_Sleep( int msec )
 		if( msec < 0 )
 			msec = 10;
 
-		usleep( msec * 1000 );
+		struct timespec req;
+		req.tv_sec = msec/1000;
+		req.tv_nsec = (msec%1000)*1000000;
+		nanosleep(&req, NULL);
 	}
 }
 

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -549,11 +549,12 @@ void Sys_Sleep( int msec )
 	}
 	else
 	{
+		struct timespec req;
+
 		// With nothing to select() on, we can't wait indefinitely
 		if( msec < 0 )
 			msec = 10;
 
-		struct timespec req;
 		req.tv_sec = msec/1000;
 		req.tv_nsec = (msec%1000)*1000000;
 		nanosleep(&req, NULL);


### PR DESCRIPTION
usleep(3) was declared obsolete in POSIX.1-2001 and removed in POSIX.1-2008 and nanosleep(2) was recommended to be used instead.