### PR TITLE
Makefile: fix compilation on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -805,6 +805,8 @@ else # ifdef MINGW
 #############################################################################
 
 ifeq ($(PLATFORM),freebsd)
+  # Use the default C compiler
+  TOOLS_CC=cc
 
   # flags
   BASE_CFLAGS = \


### PR DESCRIPTION
In the Makefile at line 1686, TOOLS_CC is used, which defined to only use gcc (at line 1549). FreeBSD now defaults to Clang, so the build breaks there. This patch addresses this.