### PR TITLE
Update macOS version for GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         path: build/*.zip
   macos:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
     - name: Compile


### PR DESCRIPTION
macOS 11 runner image is scheduled to be removed next month. [GitHub notice](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/)