### PR TITLE
Add minimal emscripten support

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -290,6 +290,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #endif
 
+//================================================================== EMSCRIPTEN ===
+
+#ifdef __EMSCRIPTEN__
+
+#define OS_STRING "emscripten"
+#define ID_INLINE inline
+#define PATH_SEP '/'
+
+#define ARCH_STRING "wasm32"
+
+#define Q3_LITTLE_ENDIAN
+
+#define DLL_EXT ".wasm"
+
+#endif
+
 //================================================================== Q3VM ===
 
 #ifdef Q3_VM

--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -398,7 +398,7 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 		int profileMask;
 		int majorVersion;
 		int minorVersion;
-	} contexts[3];
+	} contexts[4];
 	int numContexts, type;
 	const char *glstring;
 	int perChannelColorBits;
@@ -543,6 +543,14 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 		                 ( r_preferOpenGLES->integer == -1 && profileMask == SDL_GL_CONTEXT_PROFILE_ES ) );
 
 		if ( preferOpenGLES ) {
+#ifdef __EMSCRIPTEN__
+			// WebGL 2.0 isn't fully backward compatible so you have to ask for it specifically
+			contexts[numContexts].profileMask = SDL_GL_CONTEXT_PROFILE_ES;
+			contexts[numContexts].majorVersion = 3;
+			contexts[numContexts].minorVersion = 0;
+			numContexts++;
+#endif
+
 			contexts[numContexts].profileMask = SDL_GL_CONTEXT_PROFILE_ES;
 			contexts[numContexts].majorVersion = 2;
 			contexts[numContexts].minorVersion = 0;
@@ -560,6 +568,13 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 		numContexts++;
 
 		if ( !preferOpenGLES ) {
+#ifdef __EMSCRIPTEN__
+			contexts[numContexts].profileMask = SDL_GL_CONTEXT_PROFILE_ES;
+			contexts[numContexts].majorVersion = 3;
+			contexts[numContexts].minorVersion = 0;
+			numContexts++;
+#endif
+
 			contexts[numContexts].profileMask = SDL_GL_CONTEXT_PROFILE_ES;
 			contexts[numContexts].majorVersion = 2;
 			contexts[numContexts].minorVersion = 0;

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -31,6 +31,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <ctype.h>
 #include <errno.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
+
 #ifndef DEDICATED
 #ifdef USE_LOCAL_HEADERS
 #	include "SDL.h"
@@ -863,10 +867,14 @@ int main( int argc, char **argv )
 	signal( SIGTERM, Sys_SigHandler );
 	signal( SIGINT, Sys_SigHandler );
 
+#ifdef __EMSCRIPTEN__
+	emscripten_set_main_loop( Com_Frame, 0, 1 );
+#else
 	while( 1 )
 	{
 		Com_Frame( );
 	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This is a minimal emscripten port that will build and run. It supports the OpenGL2 renderer using WebGL 1.0 and 2.0. It uses the generated html file from emscripten and "--preload-file" to merge all pk3s into a single file that emscripten loads as a VFS.

There is a lot of room to improve different aspects like pk3 loading, html integration, loading game logic from .wasm, and build flags. (Which is to say this is not necessarily better or more complete than the [several](https://github.com/inolen/quakejs) [other](https://github.com/klaussilveira/ioquake3.js) [ports](https://github.com/ioquake/ioq3/pull/658) using emscripten.)

1. Create "baseq3" directory in the same directory as the Makefile.
2. Copy pak[0-8].pk3 into the created "baseq3" directory.
3. Run `/path/to/emsdk.sh` to add emcc to PATH.
4. Run `make PLATFORM=emscripten`
5. Serve the build/release-emscripten-wasm32/ioquake3_opengl2.{html,js,wasm,data} from a web server. (Local files aren't allowed to load wasm.)
6. Load ioquake3_opengl2.html in a web browser from the web server.