### PR TITLE
Fix framerate throttling in Emscripten builds

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2741,7 +2741,14 @@ void Com_Init( char *commandLine ) {
 	// init commands and vars
 	//
 	com_altivec = Cvar_Get ("com_altivec", "1", CVAR_ARCHIVE);
+#ifdef EMSCRIPTEN
+	// Under Emscripten the browser handles throttling the frame rate.
+	// Manual framerate throttling interacts poorly with Emscripten's
+	// browser-driven event loop. So default throttling to off.
+	com_maxfps = Cvar_Get ("com_maxfps", "0", CVAR_ARCHIVE);
+#else
 	com_maxfps = Cvar_Get ("com_maxfps", "85", CVAR_ARCHIVE);
+#endif
 	com_blood = Cvar_Get ("com_blood", "1", CVAR_ARCHIVE);
 
 	com_logfile = Cvar_Get ("logfile", "0", CVAR_TEMP );

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2741,7 +2741,7 @@ void Com_Init( char *commandLine ) {
 	// init commands and vars
 	//
 	com_altivec = Cvar_Get ("com_altivec", "1", CVAR_ARCHIVE);
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Under Emscripten the browser handles throttling the frame rate.
 	// Manual framerate throttling interacts poorly with Emscripten's
 	// browser-driven event loop. So default throttling to off.

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -1365,8 +1365,15 @@ void R_Register( void )
 	r_dlightBacks = ri.Cvar_Get( "r_dlightBacks", "1", CVAR_ARCHIVE );
 	r_finish = ri.Cvar_Get ("r_finish", "0", CVAR_ARCHIVE);
 	r_textureMode = ri.Cvar_Get( "r_textureMode", "GL_LINEAR_MIPMAP_LINEAR", CVAR_ARCHIVE );
+#ifdef __EMSCRIPTEN__
+	// Under Emscripten we don't throttle framerate with com_maxfps by default, so enable
+	// vsync by default instead.
+	r_swapInterval = ri.Cvar_Get( "r_swapInterval", "1",
+					CVAR_ARCHIVE | CVAR_LATCH );
+#else
 	r_swapInterval = ri.Cvar_Get( "r_swapInterval", "0",
 					CVAR_ARCHIVE | CVAR_LATCH );
+#endif
 	r_gamma = ri.Cvar_Get( "r_gamma", "1", CVAR_ARCHIVE );
 	r_facePlaneCull = ri.Cvar_Get ("r_facePlaneCull", "1", CVAR_ARCHIVE );
 


### PR DESCRIPTION
Default com_maxfps to 0 under Emscripten. Under Emscripten the browser handles throttling the frame rate. Manual framerate throttling interacts poorly with Emscripten's browser-driven event loop.