### PR TITLE
Fix web client vid_restart with r_mode -2

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -438,10 +438,11 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder, qbool
 		if( display < 0 )
 		{
 			ri.Printf( PRINT_DEVELOPER, "SDL_GetWindowDisplayIndex() failed: %s\n", SDL_GetError() );
+			display = 0;
 		}
 	}
 
-	if( display >= 0 && SDL_GetDesktopDisplayMode( display, &desktopMode ) == 0 )
+	if( SDL_GetDesktopDisplayMode( display, &desktopMode ) == 0 )
 	{
 		displayAspect = (float)desktopMode.w / (float)desktopMode.h;
 


### PR DESCRIPTION
If getting the display index of the existing window fails, fallback to the default display size instead of falling back to 640x480.

emscripten r_mode -2 worked on window creation but vid_restart fellback to 640x480.