### PR TITLE
Disable VAO cache under Emscripten

### DIFF
--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -161,6 +161,8 @@ cvar_t	*r_saveFontData;
 
 cvar_t	*r_marksOnTriangleMeshes;
 
+cvar_t *r_disableStaticSurfaceVaoCache;
+
 cvar_t	*r_aviMotionJpegQuality;
 cvar_t	*r_screenshotJpegQuality;
 
@@ -1145,6 +1147,8 @@ void R_Register( void )
 	r_shadows = ri.Cvar_Get( "cg_shadows", "1", 0 );
 
 	r_marksOnTriangleMeshes = ri.Cvar_Get("r_marksOnTriangleMeshes", "0", CVAR_ARCHIVE);
+
+	r_disableStaticSurfaceVaoCache = ri.Cvar_Get("r_disableStaticSurfaceVaoCache", "0", CVAR_ARCHIVE);
 
 	r_aviMotionJpegQuality = ri.Cvar_Get("r_aviMotionJpegQuality", "90", CVAR_ARCHIVE);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "90", CVAR_ARCHIVE);

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -228,6 +228,8 @@ cvar_t	*r_saveFontData;
 
 cvar_t	*r_marksOnTriangleMeshes;
 
+cvar_t	*r_disableStaticSurfaceVaoCache;
+
 cvar_t	*r_aviMotionJpegQuality;
 cvar_t	*r_screenshotJpegQuality;
 
@@ -1432,6 +1434,15 @@ void R_Register( void )
 	r_shadows = ri.Cvar_Get( "cg_shadows", "1", 0 );
 
 	r_marksOnTriangleMeshes = ri.Cvar_Get("r_marksOnTriangleMeshes", "0", CVAR_ARCHIVE);
+
+#ifdef __EMSCRIPTEN__
+	// The vao cache's use of bufferSubData hits pathological slow paths (10x
+	// slower) in some GLES drivers. Two known examples are ANGLE/Metal on
+	// macOS and Mali on Android.
+	r_disableStaticSurfaceVaoCache = ri.Cvar_Get("r_disableStaticSurfaceVaoCache", "1", CVAR_ARCHIVE);
+#else
+	r_disableStaticSurfaceVaoCache = ri.Cvar_Get("r_disableStaticSurfaceVaoCache", "0", CVAR_ARCHIVE);
+#endif
 
 	r_aviMotionJpegQuality = ri.Cvar_Get("r_aviMotionJpegQuality", "90", CVAR_ARCHIVE);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "90", CVAR_ARCHIVE);

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1848,6 +1848,8 @@ extern	cvar_t	*r_printShaders;
 
 extern cvar_t	*r_marksOnTriangleMeshes;
 
+extern cvar_t *r_disableStaticSurfaceVaoCache;
+
 //====================================================================
 
 static ID_INLINE qboolean ShaderRequiresCPUDeforms(const shader_t * shader)

--- a/code/renderergl2/tr_surface.c
+++ b/code/renderergl2/tr_surface.c
@@ -409,6 +409,9 @@ static qboolean RB_SurfaceVaoCached(int numVerts, srfVert_t *verts, int numIndex
 	qboolean recycleIndexBuffer = qfalse;
 	qboolean endSurface = qfalse;
 
+	if (r_disableStaticSurfaceVaoCache->integer)
+		return qfalse;
+
 	if (!(!ShaderRequiresCPUDeforms(tess.shader) && !tess.shader->isSky && !tess.shader->isPortal))
 		return qfalse;
 


### PR DESCRIPTION
The VAO surface cache uses bufferSubData and triggers a very slow path in some GLES implementations. Specifically I have observed 10x frame times with ANGLE/Metal on macOS and with Mali on Android.

Of course disabling the cache is not ideal. But at least this fixes wildly inconsistent frame times for now.