### PR TITLE
OpenGL2: Don't project sun shadows onto nothing

### DIFF
--- a/code/renderergl2/glsl/shadowmask_fp.glsl
+++ b/code/renderergl2/glsl/shadowmask_fp.glsl
@@ -103,14 +103,19 @@ void main()
 
 	vec4 shadowpos = u_ShadowMvp * biasPos;
 
+	if ( depth >= 1.0 - DEPTH_MAX_ERROR )
+	{
+		result = 1.0;
+	}
+	else
 #if defined(USE_SHADOW_CASCADE)
 	if (all(lessThan(abs(shadowpos.xyz), vec3(abs(shadowpos.w)))))
-	{
 #endif
+	{
 		shadowpos.xyz = shadowpos.xyz * (0.5 / shadowpos.w) + vec3(0.5);
 		result = PCF(u_ShadowMap, shadowpos.xy, shadowpos.z);
-#if defined(USE_SHADOW_CASCADE)
 	}
+#if defined(USE_SHADOW_CASCADE)
 	else
 	{
 		shadowpos = u_ShadowMvp2 * biasPos;


### PR DESCRIPTION
Don't project sun shadows (r_forceSun 1) on to view depth equal to 1.0 (nothing drawn or skybox). This caused a full second shadow of the entire level in tr.screenShadowImage. It would move as the camera far plane changed and rotate/stretch strangely as the camera view changed.

It was visible in-game on lightmapped transparent surfaces facing the skybox and happen to overlap the extra shadow of the level.

This affected the glass in wop_padship's underwater room.

----
World of Padman (engine fork) screenshots of wop_padship showing the issue:
"oh there's the problem, there is a phantom ship."
![shot0003](https://github.com/user-attachments/assets/f3ebe64d-09bb-4eb6-b49f-b7e5387af6a5)
![shot0002](https://github.com/user-attachments/assets/e2fba1be-0d1b-44ad-a176-212638d9d560)
(The glass should all be the same brightness.)

ioquake3 with q3dm1 map:
![shot0055](https://github.com/user-attachments/assets/b18afa9e-eaa7-404c-9d76-d046b6f2dd4f)
(All maps had a second shadow in the shadowmap image but I don't know of cases it caused issues.)