### PR TITLE
OpenGL2: Fix still projecting sun shadows onto nothing

### DIFF
--- a/code/renderergl2/glsl/shadowmask_fp.glsl
+++ b/code/renderergl2/glsl/shadowmask_fp.glsl
@@ -103,7 +103,7 @@ void main()
 
 	vec4 shadowpos = u_ShadowMvp * biasPos;
 
-	if ( depth >= 1.0 - DEPTH_MAX_ERROR )
+	if ( depth >= 0.999 )
 	{
 		result = 1.0;
 	}


### PR DESCRIPTION
This fixes #680 on more hardware as per https://github.com/PadWorld-Entertainment/worldofpadman/issues/266.

Increase the range for clamping the screen shadow depth to 1.0 (nothing drawn). Old epsilon ~0.00000006, new 0.001. This fixes it on another computer.