### PR TITLE
Fix reading non-sequential lumps in AAS files in pk3 files

### DIFF
--- a/code/botlib/be_aas_file.c
+++ b/code/botlib/be_aas_file.c
@@ -300,7 +300,7 @@ char *AAS_LoadAASLump(fileHandle_t fp, int offset, int length, int *lastoffset, 
 	if (offset != *lastoffset)
 	{
 		botimport.Print(PRT_WARNING, "AAS file not sequentially read\n");
-		if (botimport.FS_Seek(fp, offset, FS_SEEK_SET))
+		if (botimport.FS_Seek(fp, offset, FS_SEEK_SET) < 0)
 		{
 			AAS_Error("can't seek to aas lump\n");
 			AAS_DumpAASData();


### PR DESCRIPTION
FS_Seek() doesn't always return 0 on success. If the file in a pk3 file it returns the seek offset. This change doesn't fix any known AAS files.

I found the issue when reviewing https://github.com/ioquake/ioq3/issues/690.