### PR TITLE
Prevent SV_DropClient() from being called recursively

### DIFF
--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -659,6 +659,16 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 	// Free all allocated data on the client structure
 	SV_FreeClient(drop);
 
+	// Reset the reliable sequence to the currently acknowledged command
+	// This prevents SV_AddServerCommand() from making another recursive call to SV_DropClient()
+	// if the client lacks sufficient space for another reliable command
+	// it also guarantees that the client receives both the print and disconnect commands
+	drop->reliableSequence = drop->reliableAcknowledge;
+	// Setting the gamestate message number to -1 ensures that SV_AddServerCommand()
+	// will not call SV_DropClient() again, even though it is unlikely the client
+	// will receive many server commands during the drop
+	drop->gamestateMessageNum = -1;
+
 	// tell everyone why they got dropped
 	SV_SendServerCommand( NULL, "print \"%s" S_COLOR_WHITE " %s\n\"", drop->name, reason );
 

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -159,6 +159,12 @@ void SV_AddServerCommand( client_t *client, const char *cmd ) {
 	// we check == instead of >= so a broadcast print added by SV_DropClient()
 	// doesn't cause a recursive drop client
 	if ( client->reliableSequence - client->reliableAcknowledge == MAX_RELIABLE_COMMANDS + 1 ) {
+		if ( client->gamestateMessageNum == -1 )  {
+			// invalid game state message 
+			// this can occur in SV_DropClient() to avoid calling it more than once
+			return;
+		}
+
 		Com_Printf( "===== pending server commands =====\n" );
 		for ( i = client->reliableAcknowledge + 1 ; i <= client->reliableSequence ; i++ ) {
 			Com_Printf( "cmd %5d: %s\n", i, client->reliableCommands[ i & (MAX_RELIABLE_COMMANDS-1) ] );


### PR DESCRIPTION
This fixes an issue where SV_DropClient() would get called twice on the same client if the later gets kicked and has too many reliable commands right while sending a server command in SV_DropClient().
For example when kicking a client, SV_DropClient() gets called and sends server commands (print + disconnect). If the kicked client has too many reliable commands, SV_AddServerCommand() would call SV_DropClient() again on the same client.

This bug can occur as follow:

* SV_CheckTimeouts() is called
  * SV_DropClient() gets called on a client that timed out
    * SV_SendServerCommand() gets called to print stuff
      * SV_AddServerCommand() is called on the client being dropped
        * SV_DropClient() is called because it's exactly the 513th command
          * Print stuff, call VM stuff, send "disconnect", reset the user info...
    * Call VM stuff, send "disconnect", reset the user info...
