### PR TITLE
Update build.yml to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         path: build/*.zip
   macos:
     name: macOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Compile


### PR DESCRIPTION
macos-12 is outdated, this commit simply updates the build.yml file to attempt to use macos-13

see https://github.com/actions/runner-images/issues/10721 for more details on this change.