### PR TITLE
Only initialise a joystick when they're enabled

### DIFF
--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1285,7 +1285,10 @@ void IN_Init( void *windowData )
 	Cvar_SetValue( "com_unfocused",	!( appState & SDL_WINDOW_INPUT_FOCUS ) );
 	Cvar_SetValue( "com_minimized", appState & SDL_WINDOW_MINIMIZED );
 
-	IN_InitJoystick( );
+	if (in_joystick->integer) { // only initialise joysticks if enabled
+		IN_InitJoystick();
+	}
+
 	Com_DPrintf( "------------------------------------\n" );
 }
 


### PR DESCRIPTION
For some reason this would cause a 10-15 delay on launch on my PC.

I can't see any reason `IN_InitJoystick()` should be called if `in_joystick` is set to `0`, so skip calling it unless the cvar is non-zero.