### PR TITLE
Set the overflow flag when the number of bits written reaches the maximum size

### DIFF
--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -147,7 +147,7 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 		if ( bits&7 ) {
 			int nbits;
 			nbits = bits&7;
-			if ( msg->bit + nbits > msg->maxsize << 3 ) {
+			if ( msg->bit + nbits >= msg->maxsize << 3 ) {
 				msg->overflowed = qtrue;
 				return;
 			}
@@ -162,7 +162,7 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 				Huff_offsetTransmit( &msgHuff.compressor, (value & 0xff), msg->data, &msg->bit, msg->maxsize << 3 );
 				value = (value >> 8);
 
-				if ( msg->bit > msg->maxsize << 3 ) {
+				if ( msg->bit >= msg->maxsize << 3 ) {
 					msg->overflowed = qtrue;
 					return;
 				}


### PR DESCRIPTION
Currently for example, if `bit` is 65536 and `maxsize` is 8192, then `cursize` would be `(65536 >> 3) + 1` = 8193, after the maximum size. (`Netchan_Transmit` would drop an error when trying to send more than 49152 bytes)
This commit simply sets the overflow flag when the number of bits written reaches the maximum size.

I didn't find better solutions. I first found this one solution:
```cpp
msg->cursize = (msg->bit>>3);
if (msg->bit & 7)
  msg->cursize++;
```

However this change must be made in `MSG_ReadBits` as well, which would break compatibility with existing clients.