### PR TITLE
OpenGL2: Disable the VAO cache by default

### DIFF
--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -228,6 +228,8 @@ cvar_t	*r_saveFontData;
 
 cvar_t	*r_marksOnTriangleMeshes;
 
+cvar_t	*r_vaoCache;
+
 cvar_t	*r_aviMotionJpegQuality;
 cvar_t	*r_screenshotJpegQuality;
 
@@ -1432,6 +1434,8 @@ void R_Register( void )
 	r_shadows = ri.Cvar_Get( "cg_shadows", "1", 0 );
 
 	r_marksOnTriangleMeshes = ri.Cvar_Get("r_marksOnTriangleMeshes", "0", CVAR_ARCHIVE);
+
+	r_vaoCache = ri.Cvar_Get("r_vaoCache", "0", CVAR_ARCHIVE);
 
 	r_aviMotionJpegQuality = ri.Cvar_Get("r_aviMotionJpegQuality", "90", CVAR_ARCHIVE);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "90", CVAR_ARCHIVE);

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1848,6 +1848,8 @@ extern	cvar_t	*r_printShaders;
 
 extern cvar_t	*r_marksOnTriangleMeshes;
 
+extern cvar_t *r_vaoCache;
+
 //====================================================================
 
 static ID_INLINE qboolean ShaderRequiresCPUDeforms(const shader_t * shader)

--- a/code/renderergl2/tr_surface.c
+++ b/code/renderergl2/tr_surface.c
@@ -409,6 +409,9 @@ static qboolean RB_SurfaceVaoCached(int numVerts, srfVert_t *verts, int numIndex
 	qboolean recycleIndexBuffer = qfalse;
 	qboolean endSurface = qfalse;
 
+	if (!r_vaoCache->integer)
+		return qfalse;
+
 	if (!(!ShaderRequiresCPUDeforms(tess.shader) && !tess.shader->isSky && !tess.shader->isPortal))
 		return qfalse;
 


### PR DESCRIPTION
The VAO surface cache uses glBufferSubData and triggers a very slow
path in some GLES implementations. Specifically I have observed 10x
frame times under Emscripten with ANGLE/Metal on macOS and with Mali
on Android.

Supersedes https://github.com/ioquake/ioq3/pull/678, implemented the recommendations from https://github.com/ioquake/ioq3/pull/678#issuecomment-2216812337. I personally don't really know what I'm doing.