### PR TITLE
Update build.yml to replace deprecated windows-2019 with windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         path: build/*.zip
   windows:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     - name: Compile

--- a/code/tools/asm/cmdlib.c
+++ b/code/tools/asm/cmdlib.c
@@ -65,7 +65,7 @@ void ExpandWildcards( int *argc, char ***argv )
 	struct _finddata_t fileinfo;
 	intptr_t	handle;
 	int		i;
-	char	filename[1024];
+	char	filename[2048];
 	char	filebase[1024];
 	char	*path;
 
@@ -338,7 +338,7 @@ char *ExpandGamePath (const char *path)
 char *ExpandPathAndArchive (const char *path)
 {
 	char	*expanded;
-	char	archivename[1024];
+	char	archivename[2048];
 
 	expanded = ExpandPath (path);
 

--- a/code/tools/asm/cmdlib.c
+++ b/code/tools/asm/cmdlib.c
@@ -88,7 +88,7 @@ void ExpandWildcards( int *argc, char ***argv )
 
 		do
 		{
-			sprintf (filename, "%s%s", filebase, fileinfo.name);
+			snprintf (filename, sizeof(filename), "%s%s", filebase, fileinfo.name);
 			ex_argv[ex_argc++] = copystring (filename);
 		} while (_findnext( handle, &fileinfo ) != -1);
 
@@ -126,7 +126,7 @@ void Error( const char *error, ... )
 	vsprintf (text, error,argptr);
 	va_end (argptr);
 
-	sprintf (text2, "%s\nGetLastError() = %i", text, err);
+	snprintf (text2, sizeof(text2), "%s\nGetLastError() = %i", text, err);
     MessageBox(NULL, text2, "Error", 0 /* MB_OK */ );
 
 	exit (1);
@@ -318,7 +318,7 @@ char *ExpandPath (const char *path)
 		strcpy( full, path );
 		return full;
 	}
-	sprintf (full, "%s%s", qdir, path);
+	snprintf (full, sizeof(full), "%s%s", qdir, path);
 	return full;
 }
 
@@ -331,7 +331,7 @@ char *ExpandGamePath (const char *path)
 		strcpy( full, path );
 		return full;
 	}
-	sprintf (full, "%s%s", gamedir, path);
+	snprintf (full, sizeof(full), "%s%s", gamedir, path);
 	return full;
 }
 
@@ -344,7 +344,7 @@ char *ExpandPathAndArchive (const char *path)
 
 	if (archive)
 	{
-		sprintf (archivename, "%s/%s", archivedir, path);
+		snprintf (archivename, sizeof(archivename), "%s/%s", archivedir, path);
 		QCopyFile (expanded, archivename);
 	}
 	return expanded;

--- a/code/tools/asm/q3asm.c
+++ b/code/tools/asm/q3asm.c
@@ -546,7 +546,7 @@ static void DefineSymbol( char *sym, int value ) {
 
 	// add the file prefix to local symbols to guarantee unique
 	if ( sym[0] == '$' ) {
-		sprintf( expanded, "%s_%i", sym, currentFileIndex );
+		snprintf( expanded, sizeof(expanded), "%s_%i", sym, currentFileIndex );
 		sym = expanded;
 	}
 
@@ -602,7 +602,7 @@ static int LookupSymbol( char *sym ) {
 
 	// add the file prefix to local symbols to guarantee unique
 	if ( sym[0] == '$' ) {
-		sprintf( expanded, "%s_%i", sym, currentFileIndex );
+		snprintf( expanded, sizeof(expanded), "%s_%i", sym, currentFileIndex );
 		sym = expanded;
 	}
 

--- a/code/tools/lcc/etc/lcc.c
+++ b/code/tools/lcc/etc/lcc.c
@@ -437,7 +437,7 @@ static char *exists(char *name) {
 			b = b->link;
 			if (b->str[0]) {
 				char buf[1024];
-				sprintf(buf, "%s/%s", b->str, name);
+				snprintf(buf, sizeof(buf), "%s/%s", b->str, name);
 				if (access(buf, 4) == 0)
 					return strsave(buf);
 			} else if (access(name, 4) == 0)

--- a/code/tools/lcc/src/output.c
+++ b/code/tools/lcc/src/output.c
@@ -80,7 +80,7 @@ void vfprint(FILE *f, char *bp, const char *fmt, va_list ap) {
 				  	static char format[] = "%f";
 				  	char buf[128];
 				  	format[1] = *fmt;
-				  	sprintf(buf, format, va_arg(ap, double));
+					snprintf(buf, sizeof(buf), format, va_arg(ap, double));
 				  	bp = outs(buf, f, bp);
 				  }
 ; break;


### PR DESCRIPTION
GitHub is ending support for the windows-2019 runner image and windows-2022 will be the minimum supported version by the end of June, 2025. We need to update before this date. More information about this change is here: https://github.com/actions/runner-images/issues/12045