### PR TITLE
feat: add "RANDOM" bot to "ADD BOTS" menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ set using command line arguments:
                                       cl_aviMotionJpeg is enabled
   r_mode -2                         - This new video mode automatically uses the
                                       desktop resolution.
+  ui_oldUi                          - Try to preserve the old UI look. Remove
+                                      some new items, such as "RANDOM" bot
+                                      in "ADD BOT" menu.
+                                      This only restores _some_ of the changes.
 ```
 
 ## New commands


### PR DESCRIPTION
This utilizes the `addbot random` command.
See commits
- 23a331c9f819a3465b14216096be794f207826e4
- 4b5067cce289b6fd6914e802a9d196a2f2b6178a

![image](https://github.com/user-attachments/assets/787e90fa-a6a9-4b70-b794-e20172aeda44)

I have tested this for a while, and it seems to work alright, also with `set ui_oldUi 1`. With the demo version as well. Adding other bots, scrolling, also works fine.