### PR TITLE
Fix server compile flags for unzip.c and ioapi.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2987,10 +2987,10 @@ $(B)/ded/%.o: $(ZDIR)/%.c
 	$(DO_THIRDPARTY_DED_CC)
 
 $(B)/ded/ioapi.o: $(CMDIR)/ioapi.c
-	$(DO_THIRDPARTY_CC)
+	$(DO_THIRDPARTY_DED_CC)
 
 $(B)/ded/unzip.o: $(CMDIR)/unzip.c
-	$(DO_THIRDPARTY_CC)
+	$(DO_THIRDPARTY_DED_CC)
 
 $(B)/ded/%.o: $(BLIBDIR)/%.c
 	$(DO_BOT_CC)


### PR DESCRIPTION
Client compile flags are used for server unzip.c and ioapi.c since 124000104e2b9d13d6a416e4c8b2b746436150a8. This corrects it to use server compile flags.