### PR TITLE
Fix network buffer overflow and clean up strncpy()

### DIFF
--- a/code/botlib/be_aas_bspq3.c
+++ b/code/botlib/be_aas_bspq3.c
@@ -286,8 +286,7 @@ int AAS_ValueForBSPEpairKey(int ent, char *key, char *value, int size)
 	{
 		if (!strcmp(epair->key, key))
 		{
-			strncpy(value, epair->value, size-1);
-			value[size-1] = '\0';
+			Q_strncpyz(value, epair->value, size);
 			return qtrue;
 		} //end if
 	} //end for

--- a/code/botlib/be_ai_char.c
+++ b/code/botlib/be_ai_char.c
@@ -758,8 +758,7 @@ void Characteristic_String(int character, int index, char *buf, int size)
 	//an integer will be converted to a float
 	if (ch->c[index].type == CT_STRING)
 	{
-		strncpy(buf, ch->c[index].value.string, size-1);
-		buf[size-1] = '\0';
+		Q_strncpyz(buf, ch->c[index].value.string, size);
 	} //end if
 	else
 	{

--- a/code/botlib/be_ai_chat.c
+++ b/code/botlib/be_ai_chat.c
@@ -1499,8 +1499,7 @@ void BotMatchVariable(bot_match_t *match, int variable, char *buf, int size)
 		if (match->variables[variable].length < size)
 			size = match->variables[variable].length+1;
 		assert( match->variables[variable].offset >= 0 );
-		strncpy(buf, &match->string[ (int) match->variables[variable].offset], size-1);
-		buf[size-1] = '\0';
+		Q_strncpyz(buf, &match->string[ (int) match->variables[variable].offset], size);
 	} //end if
 	else
 	{
@@ -2846,8 +2845,7 @@ void BotGetChatMessage(int chatstate, char *buf, int size)
 	if (!cs) return;
 
 	BotRemoveTildes(cs->chatmessage);
-	strncpy(buf, cs->chatmessage, size-1);
-	buf[size-1] = '\0';
+	Q_strncpyz(buf, cs->chatmessage, size);
 	//clear the chat message from the state
 	strcpy(cs->chatmessage, "");
 } //end of the function BotGetChatMessage
@@ -2883,9 +2881,7 @@ void BotSetChatName(int chatstate, char *name, int client)
 	cs = BotChatStateFromHandle(chatstate);
 	if (!cs) return;
 	cs->client = client;
-	Com_Memset(cs->name, 0, sizeof(cs->name));
-	strncpy(cs->name, name, sizeof(cs->name)-1);
-	cs->name[sizeof(cs->name)-1] = '\0';
+	Q_strncpyz(cs->name, name, sizeof(cs->name));
 } //end of the function BotSetChatName
 //===========================================================================
 //

--- a/code/botlib/be_interface.c
+++ b/code/botlib/be_interface.c
@@ -235,8 +235,7 @@ int Export_BotLibVarGet(const char *var_name, char *value, int size)
 	char *varvalue;
 
 	varvalue = LibVarGetString(var_name);
-	strncpy(value, varvalue, size-1);
-	value[size-1] = '\0';
+	Q_strncpyz(value, varvalue, size);
 	return BLERR_NOERROR;
 } //end of the function Export_BotLibVarGet
 //===========================================================================

--- a/code/botlib/l_struct.c
+++ b/code/botlib/l_struct.c
@@ -221,9 +221,7 @@ int ReadString(source_t *source, fielddef_t *fd, void *p)
 	//remove the double quotes
 	StripDoubleQuotes(token.string);
 	//copy the string
-	strncpy((char *) p, token.string, MAX_STRINGFIELD-1);
-	//make sure the string is closed with a zero
-	((char *)p)[MAX_STRINGFIELD-1] = '\0';
+	Q_strncpyz((char *) p, token.string, MAX_STRINGFIELD);
 	//
 	return 1;
 } //end of the function ReadString

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -241,26 +241,36 @@ void CG_ShaderStateChanged(void) {
 	char timeOffset[16];
 	const char *o;
 	char *n,*t;
+	int length;
 
 	o = CG_ConfigString( CS_SHADERSTATE );
 	while (o && *o) {
 		n = strstr(o, "=");
 		if (n && *n) {
-			strncpy(originalShader, o, n-o);
-			originalShader[n-o] = 0;
+			length = n-o+1;
+			if (length > sizeof(originalShader)) {
+				length = sizeof(originalShader);
+			}
+			Q_strncpyz(originalShader, o, length);
 			n++;
 			t = strstr(n, ":");
 			if (t && *t) {
-				strncpy(newShader, n, t-n);
-				newShader[t-n] = 0;
+				length = t-n+1;
+				if (length > sizeof(newShader)) {
+					length = sizeof(newShader);
+				}
+				Q_strncpyz(newShader, n, length);
 			} else {
 				break;
 			}
 			t++;
 			o = strstr(t, "@");
 			if (o) {
-				strncpy(timeOffset, t, o-t);
-				timeOffset[o-t] = 0;
+				length = o-t+1;
+				if (length > sizeof(timeOffset)) {
+					length = sizeof(timeOffset);
+				}
+				Q_strncpyz(timeOffset, t, length);
 				o++;
 				trap_R_RemapShader( originalShader, newShader, timeOffset );
 			}

--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -237,8 +237,7 @@ char *BotMapTitle(void) {
 
 	trap_GetServerinfo(info, sizeof(info));
 
-	strncpy(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname)-1);
-	mapname[sizeof(mapname)-1] = '\0';
+	Q_strncpyz(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname));
 
 	return mapname;
 }

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -1105,8 +1105,7 @@ void BotMatch_JoinSubteam(bot_state_t *bs, bot_match_t *match) {
 	//get the sub team name
 	trap_BotMatchVariable(match, TEAMNAME, teammate, sizeof(teammate));
 	//set the sub team name
-	strncpy(bs->subteam, teammate, 32);
-	bs->subteam[31] = '\0';
+	Q_strncpyz(bs->subteam, teammate, sizeof(bs->subteam));
 	//
 	trap_BotMatchVariable(match, NETNAME, netname, sizeof(netname));
 	BotAI_BotInitialChat(bs, "joinedteam", teammate, NULL);
@@ -1297,8 +1296,7 @@ void BotMatch_StartTeamLeaderShip(bot_state_t *bs, bot_match_t *match) {
 	if (match->subtype & ST_I) {
 		//get the team mate that will be the team leader
 		trap_BotMatchVariable(match, NETNAME, teammate, sizeof(teammate));
-		strncpy(bs->teamleader, teammate, sizeof(bs->teamleader));
-		bs->teamleader[sizeof(bs->teamleader)-1] = '\0';
+		Q_strncpyz(bs->teamleader, teammate, sizeof(bs->teamleader));
 	}
 	//chats for someone else
 	else {

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -1397,8 +1397,7 @@ char *ClientName(int client, char *name, int size) {
 		return "[client out of range]";
 	}
 	trap_GetConfigstring(CS_PLAYERS+client, buf, sizeof(buf));
-	strncpy(name, Info_ValueForKey(buf, "n"), size-1);
-	name[size-1] = '\0';
+	Q_strncpyz(name, Info_ValueForKey(buf, "n"), size);
 	Q_CleanStr( name );
 	return name;
 }
@@ -1416,8 +1415,7 @@ char *ClientSkin(int client, char *skin, int size) {
 		return "[client out of range]";
 	}
 	trap_GetConfigstring(CS_PLAYERS+client, buf, sizeof(buf));
-	strncpy(skin, Info_ValueForKey(buf, "model"), size-1);
-	skin[size-1] = '\0';
+	Q_strncpyz(skin, Info_ValueForKey(buf, "model"), size);
 	return skin;
 }
 
@@ -1520,8 +1518,7 @@ char *EasyClientName(int client, char *buf, int size) {
 			memmove(ptr, ptr+1, strlen(ptr + 1)+1);
 		}
 	}
-	strncpy(buf, name, size-1);
-	buf[size-1] = '\0';
+	Q_strncpyz(buf, name, size);
 	return buf;
 }
 
@@ -3692,8 +3689,7 @@ void BotMapScripts(bot_state_t *bs) {
 
 	trap_GetServerinfo(info, sizeof(info));
 
-	strncpy(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname)-1);
-	mapname[sizeof(mapname)-1] = '\0';
+	Q_strncpyz(mapname, Info_ValueForKey( info, "mapname" ), sizeof(mapname));
 
 	if (!Q_stricmp(mapname, "q3tourney6") || !Q_stricmp(mapname, "q3tourney6_ctf") || !Q_stricmp(mapname, "mpq3tourney6")) {
 		vec3_t mins = {694, 200, 480}, maxs = {968, 472, 680};

--- a/code/game/ai_team.c
+++ b/code/game/ai_team.c
@@ -1956,8 +1956,7 @@ void BotTeamAI(bot_state_t *bs) {
 				trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
 				BotSayVoiceTeamOrder(bs, -1, VOICECHAT_STARTLEADER);
 				ClientName(bs->client, netname, sizeof(netname));
-				strncpy(bs->teamleader, netname, sizeof(bs->teamleader));
-				bs->teamleader[sizeof(bs->teamleader)-1] = '\0';
+				Q_strncpyz(bs->teamleader, netname, sizeof(bs->teamleader));
 				bs->becometeamleader_time = 0;
 			}
 			return;

--- a/code/server/sv_rankings.c
+++ b/code/server/sv_rankings.c
@@ -138,8 +138,7 @@ void SV_RankBegin( char *gamekey )
 
 	// initialize rankings
 	GRankLogLevel( GRLOG_OFF );
-	memset(SV_RankGameKey,0,sizeof(SV_RankGameKey));
-	strncpy(SV_RankGameKey,gamekey,sizeof(SV_RankGameKey)-1);
+	Q_strncpyz(SV_RankGameKey,gamekey,sizeof(SV_RankGameKey));
 	init = GRankInit( 1, SV_RankGameKey, GR_OPT_POLL, GR_OPT_END );
 	s_server_context = init.context;
 	s_rankings_contexts++;

--- a/code/ui/ui_shared.c
+++ b/code/ui/ui_shared.c
@@ -3001,6 +3001,7 @@ void Item_Text_Wrapped_Paint(itemDef_t *item) {
 	char text[1024];
 	const char *p, *start, *textPtr;
 	char buff[1024];
+	int length;
 	int width, height;
 	float x, y;
 	vec4_t color;
@@ -3032,11 +3033,14 @@ void Item_Text_Wrapped_Paint(itemDef_t *item) {
 	start = textPtr;
 	p = strchr(textPtr, '\r');
 	while (p && *p) {
-		strncpy(buff, start, p-start+1);
-		buff[p-start] = '\0';
+		length = p-start+1;
+		if (length > sizeof(buff)) {
+			length = sizeof(buff);
+		}
+		Q_strncpyz(buff, start, length);
 		DC->drawText(x, y, item->textscale, color, buff, 0, 0, item->textStyle);
 		y += height + 5;
-		start += p - start + 1;
+		start += length;
 		p = strchr(p+1, '\r');
 	}
 	DC->drawText(x, y, item->textscale, color, start, 0, 0, item->textStyle);


### PR DESCRIPTION
Fixed a possible buffer overflow reading CS_SHADERSTATE in CGame.

The code was a inconsistent mix of strncpy() with manual NUL and Q_strncpyz(). Use Q_strncpyz() if possible.

These commits were cherry-picked from #659 PR draft.