### PR TITLE
Workaround strncpy() in OpenArena QVMs

### DIFF
--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -618,7 +618,14 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Com_Memcpy( VMA(1), VMA(2), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		{
+			char *dest = VMA(1);
+			char *src = VMA(2);
+
+			if ( dest != src ) {
+				strncpy( dest, src, args[3] );
+			}
+		}
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -1005,7 +1005,14 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		{
+			char *dest = VMA(1);
+			char *src = VMA(2);
+
+			if ( dest != src ) {
+				strncpy( dest, src, args[3] );
+			}
+		}
 		return args[1];
 
 	case UI_SIN:

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -809,7 +809,14 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 		return 0;
 
 	case TRAP_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		{
+			char *dest = VMA(1);
+			char *src = VMA(2);
+
+			if ( dest != src ) {
+				strncpy( dest, src, args[3] );
+			}
+		}
 		return args[1];
 
 	case TRAP_SIN:


### PR DESCRIPTION
Changes in the macOS 10.9 SDK and glibc 2.37 broke overlapping dest and src
in strncpy() used by OpenArena QVMs. (Technically it was undefined behavior.)

This PR changes the QVM strncpy() syscall to not alter the dest if dest and src are equal. This fixes weapon barrel models for OpenArena 0.8.8.

----

Arguably it should fill the end of the dest buffer past the NUL-terminator with 0 bytes as per strncpy() definition. However nothing in Quake 3 is likely to depend on this and this case is undefined behavior.

This replaces my previous over-engineered PR #659.