### PR TITLE
Use SHGetKnownFolderPath instead of SHGetFolderPathA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,7 +668,7 @@ ifdef MINGW
       $(call bin_path, $(TOOLS_MINGW_PREFIX)-gcc))))
   endif
 
-  LIBS= -lws2_32 -lwinmm -lpsapi
+  LIBS= -lws2_32 -lwinmm -lpsapi -lshell32 -lole32
   AUTOUPDATER_LIBS += -lwininet
 
   # clang 3.4 doesn't support this


### PR DESCRIPTION
As title. [`ShGetFolderPathA`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpatha) is an ancient API that we are using to retrieve "special" folder locations on Windows, which is old and crusty and we should stop using it. Here I replace it with [`SHGetKnownFolderPath`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath).

Pros:
* It's not old and crusty
* It doesn't require any nonsense to compile with MSVC
* It doesn't require ludicrous shenanigans to access like dynamically loading a library at runtime
* According to the documentation, we're effectively calling it anyway; might as well cut out the middle man
 
Cons:
* Minimum supported OS goes from XP to Vista
* It's wide string only, so we must convert its results for Q3's purposes