### PR TITLE
Add Windows ARM platform

### DIFF
--- a/cmake/compilers/msvc.cmake
+++ b/cmake/compilers/msvc.cmake
@@ -6,12 +6,14 @@ endif()
 
 include(utils/arch)
 
-enable_language(ASM_MASM)
+if(ARCH MATCHES "x86" OR ARCH MATCHES "x86_64")
+    enable_language(ASM_MASM)
 
-set(ASM_SOURCES
-    ${SOURCE_DIR}/asm/snapvector.asm
-    ${SOURCE_DIR}/asm/ftola.asm
-)
+    set(ASM_SOURCES
+        ${SOURCE_DIR}/asm/snapvector.asm
+        ${SOURCE_DIR}/asm/ftola.asm
+    )
+endif()
 
 if(ARCH MATCHES "x86_64")
     list(APPEND ASM_SOURCES ${SOURCE_DIR}/asm/vm_x86_64.asm)

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -79,9 +79,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #if defined(_WIN64) || defined(__WIN64__)
 
-#undef idx64
-#define idx64 1
-
 #undef QDECL
 #define QDECL __cdecl
 
@@ -98,7 +95,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define PATH_SEP '\\'
 
 #if defined(__x86_64__) || defined(_M_X64)
+#undef idx64
+#define idx64 1
 #define ARCH_STRING "x86_64"
+#elif defined(__aarch64__) || defined(__ARM64__) || defined (_M_ARM64)
+#define ARCH_STRING "arm64"
+#define NO_VM_COMPILED
 #endif
 
 #define Q3_LITTLE_ENDIAN
@@ -124,6 +126,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #if defined( _M_IX86 ) || defined( __i386__ )
 #define ARCH_STRING "x86"
+#elif defined(__arm__) || defined(_M_ARM)
+#define ARCH_STRING "arm"
+#define NO_VM_COMPILED
 #endif
 
 #define Q3_LITTLE_ENDIAN


### PR DESCRIPTION
This adds support for ARM/ARM64 on Windows. The user will still need to specify SDL2 ARM64 libraries manually.

`cmake -A "arm64" -DUSE_INTERNAL_SDL=OFF -DSDL2_DIR="Path\To\SDL2ARM" -DBUILD_GAME_QVMS=OFF ../`

Compiles successfully 🙂