### PR TITLE
cmake: Don't override CMAKE_INSTALL_PREFIX if set by user

### DIFF
--- a/cmake/compilers/gnu.cmake
+++ b/cmake/compilers/gnu.cmake
@@ -22,4 +22,6 @@ add_compile_options(-Wno-format-zero-length -Wno-format-nonliteral)
 # that rely on the compiler not optimising them away, so disable it
 add_compile_options(-fno-strict-aliasing)
 
-set(CMAKE_INSTALL_PREFIX /opt/quake3)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX /opt/quake3)
+endif()


### PR DESCRIPTION
The README says that it can be changed, but it was hard-coded here.