### PR TITLE
Makefile: on Linux use -fvisibility=hidden for everything, not just DLLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ endif
 
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
   WARNINGS_CFLAGS = -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes
-  BASE_CFLAGS = -pipe -DUSE_ICON
+  BASE_CFLAGS = -pipe -DUSE_ICON -fvisibility=hidden
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3
@@ -417,7 +417,7 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
   endif
 
   SHLIBEXT=so
-  SHLIBCFLAGS=-fPIC -fvisibility=hidden
+  SHLIBCFLAGS=-fPIC
   SHLIBLDFLAGS=-shared $(LDFLAGS)
 
   THREAD_LIBS=-lpthread


### PR DESCRIPTION
On typical CPU architectures like x86 and ARM, symbols in the executable are not exported unless you specifically build with `-rdynamic`, but on some architectures every `extern` symbol is exported into the dynamic symbol table by default. This means they will "interpose" in front of symbols of the same name in a library, which is very bad if it was unintentional (for example if the address of `vmCvar_t sv_fps` in OpenArena's `qagame.so` is unexpectedly overwritten with the address of `cvar_t sv_fps` in the ioq3ded executable, a global variable of a different type with a different in-memory layout).

We can avoid this by building everything with hidden visibility, so that only symbols that are intentionally exported (such as `vmMain` and `dllEntry`) are present in the dynamic symbol table. This results in approximately the same semantics that a Windows developer would expect, and in practice is usually what is desired.

Resolves: https://github.com/ioquake/ioq3/issues/765

---

@timangus, I saw that you've already addressed #765 in the CMake build, but for completeness here is the legacy Makefile side of it. (Compiles, otherwise untested.)