### PR TITLE
Initialize HTTP download library before starting download

### DIFF
--- a/code/client/cl_http.h
+++ b/code/client/cl_http.h
@@ -25,8 +25,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "../qcommon/q_shared.h"
 
-qboolean CL_HTTP_Init( void );
-qboolean CL_HTTP_Available( void );
+void CL_HTTP_Init( void );
+qboolean CL_HTTP_Startup( void );
 void CL_HTTP_Shutdown( void );
 void CL_HTTP_BeginDownload( const char *remoteURL );
 qboolean CL_HTTP_PerformDownload( void );

--- a/code/client/cl_http_curl.c
+++ b/code/client/cl_http_curl.c
@@ -103,12 +103,22 @@ static void *GPA(char *str)
 CL_HTTP_Init
 =================
 */
-qboolean CL_HTTP_Init()
+void CL_HTTP_Init()
+{
+	cl_cURLLib = Cvar_Get("cl_cURLLib", DEFAULT_CURL_LIB, CVAR_ARCHIVE | CVAR_PROTECTED);
+}
+
+/*
+=================
+CL_HTTP_Startup
+
+Loads HTTP support if needed and returns qtrue if available.
+=================
+*/
+qboolean CL_HTTP_Startup()
 {
 	if(cURLLib)
 		return qtrue;
-
-	cl_cURLLib = Cvar_Get("cl_cURLLib", DEFAULT_CURL_LIB, CVAR_ARCHIVE | CVAR_PROTECTED);
 
 	Com_Printf("Loading \"%s\"...", cl_cURLLib->string);
 	if(!(cURLLib = Sys_LoadDll(cl_cURLLib->string, qtrue)))
@@ -117,7 +127,10 @@ qboolean CL_HTTP_Init()
 		// On some linux distributions there is no libcurl.so.3, but only libcurl.so.4. That one works too.
 		if(!(cURLLib = Sys_LoadDll(ALTERNATE_CURL_LIB, qtrue)))
 #endif
-			return qfalse;
+			{
+				Com_Printf( "WARNING: couldn't initialize HTTP download support\n" );
+				return qfalse;
+			}
 	}
 
 	cURLSymbolLoadFailed = qfalse;
@@ -151,16 +164,6 @@ qboolean CL_HTTP_Init()
 	Com_Printf("OK\n");
 
 	return qtrue;
-}
-
-/*
-=================
-CL_HTTP_Available
-=================
-*/
-qboolean CL_HTTP_Available()
-{
-	return cURLLib != NULL;
 }
 
 static void CL_cURL_Cleanup(void)

--- a/code/client/cl_http_windows.c
+++ b/code/client/cl_http_windows.c
@@ -50,30 +50,38 @@ static void DropIf(qboolean condition, const char *fmt, ...)
 CL_HTTP_Init
 =================
 */
-qboolean CL_HTTP_Init()
+void CL_HTTP_Init()
 {
-    OSVERSIONINFO osvi = {sizeof(OSVERSIONINFO)};
-    const char *windowsVersion = GetVersionEx(&osvi) ? va("Windows %lu.%lu (build %lu)",
-                                                          osvi.dwMajorVersion,
-                                                          osvi.dwMinorVersion,
-                                                          osvi.dwBuildNumber)
-                                                     : "Windows";
-
-    hInternet = InternetOpenA(
-        va("%s %s", Q3_VERSION, windowsVersion),
-        INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
-
-    return hInternet != NULL;
 }
 
 /*
 =================
-CL_HTTP_Available
+CL_HTTP_Startup
+
+Loads HTTP support if needed and returns qtrue if available.
 =================
 */
-qboolean CL_HTTP_Available()
+qboolean CL_HTTP_Startup(void)
 {
-    return hInternet != NULL;
+    if ( !hInternet ) {
+        OSVERSIONINFO osvi = {sizeof(OSVERSIONINFO)};
+        const char *windowsVersion = GetVersionEx(&osvi) ? va("Windows %lu.%lu (build %lu)",
+                                                              osvi.dwMajorVersion,
+                                                              osvi.dwMinorVersion,
+                                                              osvi.dwBuildNumber)
+                                                         : "Windows";
+
+        hInternet = InternetOpenA(
+            va("%s %s", Q3_VERSION, windowsVersion),
+            INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
+    }
+
+    if ( !hInternet ) {
+		Com_Printf( "WARNING: couldn't initialize HTTP download support\n" );
+        return qfalse;
+	}
+
+    return qtrue;
 }
 
 /*

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -2282,7 +2282,7 @@ void CL_NextDownload(void)
 					"download redirection, but does not "
 					"have sv_dlURL set\n");
 			}
-			else if(CL_HTTP_Available()) {
+			else if(CL_HTTP_Startup()) {
 				CL_InitDownload(localName);
 				CL_BeginHttpDownload(va("%s/%s",
 					clc.sv_dlURL, remoteName));
@@ -3710,9 +3710,7 @@ void CL_Init( void ) {
 #endif
 
 #ifdef USE_HTTP
-	if(!CL_HTTP_Init()) {
-		Com_Printf("WARNING: couldn't initialize HTTP download support\n");
-	}
+	CL_HTTP_Init();
 #endif
 
 	// cgame might not be initialized before menu is used


### PR DESCRIPTION
Here is an option to fix the HTTP download issues based on restoring the original behavior of initializing the HTTP library when starting downloads. It seems to work based on superficial testing.

- CL_HTTP_Init is still called at client startup to register cvars (currently just cl_cURLLib)
- CL_HTTP_Available is changed to CL_HTTP_Startup, and does actual initialization, but still returns boolean for whether HTTP support is available
- CL_HTTP_Shutdown is still called when downloads complete