### PR TITLE
asm: Correct GNU stack marker syntax on 32-bit ARM

### DIFF
--- a/code/asm/qasm.h
+++ b/code/asm/qasm.h
@@ -25,7 +25,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../qcommon/q_platform.h"
 
 #ifdef __ELF__
+#if defined(__arm__)
+.section .note.GNU-stack,"",%progbits
+#else
 .section .note.GNU-stack,"",@progbits
+#endif
 #endif
 
 #if defined(__ELF__) || defined(__WIN64__)


### PR DESCRIPTION
In 32-bit ARM assembly, `@` is the equivalent of `//` in C, so the *type* argument is prefixed with `%` instead of the usual `@`.

Reference: https://sourceware.org/binutils/docs/as/Section.html  
Resolves: https://github.com/ioquake/ioq3/issues/778

---

Marked as draft while I log in to a porterbox to confirm that this works, but I think it should.