### PR TITLE
Reduce duplication in FS path search code

### DIFF
--- a/code/botlib/botlib.h
+++ b/code/botlib/botlib.h
@@ -438,7 +438,6 @@ botlib_export_t *GetBotLibAPI( int apiVersion, botlib_import_t *import );
 name:						default:			module(s):			description:
 
 "basedir"					""					-					base directory
-"homedir"					""					be_interface.c		home directory
 "gamedir"					""					be_interface.c		mod game directory
 "basegame"					""					be_interface.c		base game directory
 

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -2233,8 +2233,7 @@ void CL_NextDownload(void)
 	// A download has finished, check whether this matches a referenced checksum
 	if(*clc.downloadName)
 	{
-		char *zippath = FS_BuildOSPath(Cvar_VariableString("fs_homepath"), clc.downloadName, "");
-		zippath[strlen(zippath)-1] = '\0';
+		char *zippath = FS_BaseDir_BuildOSPath(Cvar_VariableString("fs_homepath"), clc.downloadName);
 
 		if(!FS_CompareZipChecksum(zippath))
 			Com_Error(ERR_DROP, "Incorrect checksum for file: %s", clc.downloadName);

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -1342,7 +1342,7 @@ static void CL_UpdateGUID( const char *prefix, int prefix_len )
 	fileHandle_t f;
 	int len;
 
-	len = FS_SV_FOpenFileRead( QKEY_FILE, &f );
+	len = FS_BaseDir_FOpenFileRead( QKEY_FILE, &f );
 	FS_FCloseFile( f );
 
 	if( len != QKEY_SIZE ) 
@@ -2197,7 +2197,7 @@ static void CL_BeginHttpDownload( const char *remoteURL ) {
 	CL_HTTP_BeginDownload(remoteURL);
 	Q_strncpyz(clc.downloadURL, remoteURL, sizeof(clc.downloadURL));
 
-	clc.download = FS_SV_FOpenFileWrite(clc.downloadTempName);
+	clc.download = FS_BaseDir_FOpenFileWrite(clc.downloadTempName);
 	if(!clc.download) {
 		Com_Error(ERR_DROP, "CL_BeginHTTPDownload: failed to open "
 			"%s for writing", clc.downloadTempName);
@@ -2977,7 +2977,7 @@ void CL_Frame ( int msec ) {
 				clc.download = 0;
 			}
 
-			FS_SV_Rename(clc.downloadTempName, clc.downloadName, qfalse);
+			FS_BaseDir_Rename(clc.downloadTempName, clc.downloadName, qfalse);
 			clc.downloadRestart = qtrue;
 			CL_NextDownload();
 		}
@@ -3456,7 +3456,7 @@ static void CL_GenerateQKey(void)
 	unsigned char buff[ QKEY_SIZE ];
 	fileHandle_t f;
 
-	len = FS_SV_FOpenFileRead( QKEY_FILE, &f );
+	len = FS_BaseDir_FOpenFileRead( QKEY_FILE, &f );
 	FS_FCloseFile( f );
 	if( len == QKEY_SIZE ) {
 		Com_Printf( "QKEY found.\n" );
@@ -3471,7 +3471,7 @@ static void CL_GenerateQKey(void)
 		Com_Printf( "QKEY building random string\n" );
 		Com_RandomBytes( buff, sizeof(buff) );
 
-		f = FS_SV_FOpenFileWrite( QKEY_FILE );
+		f = FS_BaseDir_FOpenFileWrite( QKEY_FILE );
 		if( !f ) {
 			Com_Printf( "QKEY could not open %s for write\n",
 				QKEY_FILE );

--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -608,7 +608,7 @@ void CL_ParseDownload ( msg_t *msg ) {
 	// open the file if not opened yet
 	if (!clc.download)
 	{
-		clc.download = FS_SV_FOpenFileWrite( clc.downloadTempName );
+		clc.download = FS_BaseDir_FOpenFileWrite( clc.downloadTempName );
 
 		if (!clc.download) {
 			Com_Printf( "Could not create %s\n", clc.downloadTempName );
@@ -635,7 +635,7 @@ void CL_ParseDownload ( msg_t *msg ) {
 			clc.download = 0;
 
 			// rename the file
-			FS_SV_Rename ( clc.downloadTempName, clc.downloadName, qfalse );
+			FS_BaseDir_Rename ( clc.downloadTempName, clc.downloadName, qfalse );
 		}
 
 		// send intentions now

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -52,7 +52,7 @@ void LAN_LoadCachedServers( void ) {
 	fileHandle_t fileIn;
 	cls.numglobalservers = cls.numfavoriteservers = 0;
 	cls.numGlobalServerAddresses = 0;
-	if (FS_SV_FOpenFileRead("servercache.dat", &fileIn)) {
+	if (FS_BaseDir_FOpenFileRead("servercache.dat", &fileIn)) {
 		FS_Read(&cls.numglobalservers, sizeof(int), fileIn);
 		FS_Read(&cls.numfavoriteservers, sizeof(int), fileIn);
 		FS_Read(&size, sizeof(int), fileIn);
@@ -74,7 +74,7 @@ LAN_SaveServersToCache
 */
 void LAN_SaveServersToCache( void ) {
 	int size;
-	fileHandle_t fileOut = FS_SV_FOpenFileWrite("servercache.dat");
+	fileHandle_t fileOut = FS_BaseDir_FOpenFileWrite("servercache.dat");
 	FS_Write(&cls.numglobalservers, sizeof(int), fileOut);
 	FS_Write(&cls.numfavoriteservers, sizeof(int), fileOut);
 	size = sizeof(cls.globalServers) + sizeof(cls.favoriteServers);

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -1647,9 +1647,6 @@ int BotInitLibrary(void) {
 	//game directory
 	trap_Cvar_VariableStringBuffer("fs_game", buf, sizeof(buf));
 	if (strlen(buf)) trap_BotLibVarSet("gamedir", buf);
-	//home directory
-	trap_Cvar_VariableStringBuffer("fs_homepath", buf, sizeof(buf));
-	if (strlen(buf)) trap_BotLibVarSet("homedir", buf);
 	//
 #ifdef MISSIONPACK
 	trap_BotLibDefine("MISSIONPACK");

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2468,7 +2468,7 @@ void Com_ReadCDKey( const char *filename ) {
 
 	Com_sprintf(fbuffer, sizeof(fbuffer), "%s/q3key", filename);
 
-	FS_SV_FOpenFileRead( fbuffer, &f );
+	FS_BaseDir_FOpenFileRead( fbuffer, &f );
 	if ( !f ) {
 		Com_Memset( cl_cdkey, '\0', 17 );
 		return;
@@ -2498,7 +2498,7 @@ void Com_AppendCDKey( const char *filename ) {
 
 	Com_sprintf(fbuffer, sizeof(fbuffer), "%s/q3key", filename);
 
-	FS_SV_FOpenFileRead( fbuffer, &f );
+	FS_BaseDir_FOpenFileRead( fbuffer, &f );
 	if (!f) {
 		Com_Memset( &cl_cdkey[16], '\0', 17 );
 		return;
@@ -2543,7 +2543,7 @@ static void Com_WriteCDKey( const char *filename, const char *ikey ) {
 #ifndef _WIN32
 	savedumask = umask(0077);
 #endif
-	f = FS_SV_FOpenFileWrite( fbuffer );
+	f = FS_BaseDir_FOpenFileWrite( fbuffer );
 	if ( !f ) {
 		Com_Printf ("Couldn't write CD key to %s.\n", fbuffer );
 		goto out;

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -547,6 +547,10 @@ qboolean FS_CreatePath (const char *OSPath) {
 	char	*ofs;
 	char	path[MAX_OSPATH];
 	
+	if (!OSPath || !*OSPath) {
+		return qfalse;
+	}
+
 	// make absolutely sure that it can't back up the path
 	// FIXME: is c: allowed???
 	if ( strstr( OSPath, ".." ) || strstr( OSPath, "::" ) ) {

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -543,7 +543,7 @@ FS_CreatePath
 Creates any directories needed to store the given filename
 ============
 */
-qboolean FS_CreatePath (char *OSPath) {
+qboolean FS_CreatePath (const char *OSPath) {
 	char	*ofs;
 	char	path[MAX_OSPATH];
 	

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -813,36 +813,6 @@ void FS_BaseDir_Rename( const char *from, const char *to, qboolean safe ) {
 	rename(from_ospath, to_ospath);
 }
 
-
-
-/*
-===========
-FS_Rename
-
-===========
-*/
-void FS_Rename( const char *from, const char *to ) {
-	char			*from_ospath, *to_ospath;
-
-	if ( !fs_searchpaths ) {
-		Com_Error( ERR_FATAL, "Filesystem call made without initialization" );
-	}
-
-	// don't let sound stutter
-	S_ClearSoundBuffer();
-
-	from_ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, from );
-	to_ospath = FS_BuildOSPath( fs_homepath->string, fs_gamedir, to );
-
-	if ( fs_debug->integer ) {
-		Com_Printf( "FS_Rename: %s --> %s\n", from_ospath, to_ospath );
-	}
-
-	FS_CheckFilenameIsMutable( to_ospath, __func__ );
-
-	rename(from_ospath, to_ospath);
-}
-
 /*
 ==============
 FS_FCloseFile

--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -662,12 +662,12 @@ qboolean FS_FileExists(const char *file)
 
 /*
 ================
-FS_SV_FileExists
+FS_BaseDir_FileExists
 
 Tests if the file exists 
 ================
 */
-qboolean FS_SV_FileExists( const char *file )
+qboolean FS_BaseDir_FileExists( const char *file )
 {
 	return FS_FileInPathExists(FS_BaseDir_BuildOSPath(fs_homepath->string, file));
 }
@@ -675,11 +675,11 @@ qboolean FS_SV_FileExists( const char *file )
 
 /*
 ===========
-FS_SV_FOpenFileWrite
+FS_BaseDir_FOpenFileWrite
 
 ===========
 */
-fileHandle_t FS_SV_FOpenFileWrite( const char *filename ) {
+fileHandle_t FS_BaseDir_FOpenFileWrite( const char *filename ) {
 	char *ospath;
 	fileHandle_t	f;
 
@@ -693,7 +693,7 @@ fileHandle_t FS_SV_FOpenFileWrite( const char *filename ) {
 	fsh[f].zipFile = qfalse;
 
 	if ( fs_debug->integer ) {
-		Com_Printf( "FS_SV_FOpenFileWrite: %s\n", ospath );
+		Com_Printf( "FS_BaseDir_FOpenFileWrite: %s\n", ospath );
 	}
 
 	FS_CheckFilenameIsMutable( ospath, __func__ );
@@ -716,13 +716,13 @@ fileHandle_t FS_SV_FOpenFileWrite( const char *filename ) {
 
 /*
 ===========
-FS_SV_FOpenFileRead
+FS_BaseDir_FOpenFileRead
 
 Search for a file somewhere below the home path then base path
 in that order
 ===========
 */
-long FS_SV_FOpenFileRead(const char *filename, fileHandle_t *fp)
+long FS_BaseDir_FOpenFileRead(const char *filename, fileHandle_t *fp)
 {
 	char *ospath;
 	fileHandle_t f = 0;
@@ -756,7 +756,7 @@ long FS_SV_FOpenFileRead(const char *filename, fileHandle_t *fp)
 
 		if ( fs_debug->integer )
 		{
-			Com_Printf( "FS_SV_FOpenFileRead (%s): %s\n", pathVar->name, ospath );
+			Com_Printf( "FS_BaseDir_FOpenFileRead (%s): %s\n", pathVar->name, ospath );
 		}
 
 		fsh[f].handleFiles.file.o = Sys_FOpen( ospath, "rb" );
@@ -779,11 +779,11 @@ long FS_SV_FOpenFileRead(const char *filename, fileHandle_t *fp)
 
 /*
 ===========
-FS_SV_Rename
+FS_BaseDir_Rename
 
 ===========
 */
-void FS_SV_Rename( const char *from, const char *to, qboolean safe ) {
+void FS_BaseDir_Rename( const char *from, const char *to, qboolean safe ) {
 	char			*from_ospath, *to_ospath;
 
 	if ( !fs_searchpaths ) {
@@ -797,7 +797,7 @@ void FS_SV_Rename( const char *from, const char *to, qboolean safe ) {
 	to_ospath = FS_BaseDir_BuildOSPath( fs_homepath->string, to );
 
 	if ( fs_debug->integer ) {
-		Com_Printf( "FS_SV_Rename: %s --> %s\n", from_ospath, to_ospath );
+		Com_Printf( "FS_BaseDir_Rename: %s --> %s\n", from_ospath, to_ospath );
 	}
 
 	if ( safe ) {
@@ -2480,7 +2480,7 @@ void FS_GetModDescription( const char *modDir, char *description, int descriptio
 	FILE			*file;
 
 	Com_sprintf( descPath, sizeof ( descPath ), "%s%cdescription.txt", modDir, PATH_SEP );
-	nDescLen = FS_SV_FOpenFileRead( descPath, &descHandle );
+	nDescLen = FS_BaseDir_FOpenFileRead( descPath, &descHandle );
 
 	if ( nDescLen > 0 ) {
 		file = FS_FileForHandle(descHandle);
@@ -3189,7 +3189,7 @@ qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring ) {
 				// Local name
 				Q_strcat( neededpaks, len, "@");
 				// Do we have one with the same name?
-				if ( FS_SV_FileExists( va( "%s.pk3", fs_serverReferencedPakNames[i] ) ) )
+				if ( FS_BaseDir_FileExists( va( "%s.pk3", fs_serverReferencedPakNames[i] ) ) )
 				{
 					char st[MAX_ZPATH];
 					// We already have one called this, we need to download it to another name
@@ -3216,7 +3216,7 @@ qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring ) {
 				Q_strcat( neededpaks, len, fs_serverReferencedPakNames[i] );
 				Q_strcat( neededpaks, len, ".pk3" );
 				// Do we have one with the same name?
-				if ( FS_SV_FileExists( va( "%s.pk3", fs_serverReferencedPakNames[i] ) ) )
+				if ( FS_BaseDir_FileExists( va( "%s.pk3", fs_serverReferencedPakNames[i] ) ) )
 				{
 					Q_strcat( neededpaks, len, " (local file exists with wrong checksum)");
 				}

--- a/code/qcommon/md5.c
+++ b/code/qcommon/md5.c
@@ -271,7 +271,7 @@ char *Com_MD5File( const char *fn, int length, const char *prefix, int prefix_le
 
 	Q_strncpyz( final, "", sizeof( final ) );
 
-	filelen = FS_SV_FOpenFileRead( fn, &f );
+	filelen = FS_BaseDir_FOpenFileRead( fn, &f );
 
 	if( !f ) {
 		return final;

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -34,8 +34,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #define HOMEPATH_NAME_UNIX		".foo"
   #define HOMEPATH_NAME_WIN			"FooBar"
   #define HOMEPATH_NAME_MACOSX		HOMEPATH_NAME_WIN
-//  #define STEAMPATH_NAME			"Foo Bar"
-//  #define STEAMPATH_APPID         ""
   #define GAMENAME_FOR_MASTER		"foobar"	// must NOT contain whitespace
   #define CINEMATICS_LOGO		"foologo.roq"
   #define CINEMATICS_INTRO		"intro.roq"
@@ -49,10 +47,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #define HOMEPATH_NAME_UNIX		".q3a"
   #define HOMEPATH_NAME_WIN			"Quake3"
   #define HOMEPATH_NAME_MACOSX		HOMEPATH_NAME_WIN
-  #define STEAMPATH_NAME			"Quake 3 Arena"
-  #define STEAMPATH_APPID			"2200"
-  #define GOGPATH_ID				"1441704920"
-  #define MSSTORE_PATH				"Quake 3"
   #define GAMENAME_FOR_MASTER		"Quake3Arena"
   #define CINEMATICS_LOGO		"idlogo.RoQ"
   #define CINEMATICS_INTRO		"intro.RoQ"

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -731,8 +731,6 @@ qboolean FS_InvalidGameDir(const char *gamedir);
 qboolean FS_idPak(char *pak, char *base, int numPaks);
 qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring );
 
-void FS_Rename( const char *from, const char *to );
-
 void FS_Remove( const char *osPath );
 void FS_HomeRemove( const char *homePath );
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -616,8 +616,6 @@ qboolean FS_ConditionalRestart(int checksumFeed, qboolean disconnect);
 void	FS_Restart( int checksumFeed );
 // shutdown and restart the filesystem so changes to fs_gamedir can take effect
 
-void FS_AddGameDirectory( const char *path, const char *dir );
-
 char	**FS_ListFiles( const char *directory, const char *extension, int *numfiles );
 // directory should not have either a leading or trailing /
 // if extension is "/", only subdirectories will be returned

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -645,9 +645,9 @@ fileHandle_t	FS_FOpenFileAppend( const char *filename );
 fileHandle_t	FS_FCreateOpenPipeFile( const char *filename );
 // will properly create any needed paths and deal with seperater character issues
 
-fileHandle_t FS_SV_FOpenFileWrite( const char *filename );
-long		FS_SV_FOpenFileRead( const char *filename, fileHandle_t *fp );
-void	FS_SV_Rename( const char *from, const char *to, qboolean safe );
+fileHandle_t FS_BaseDir_FOpenFileWrite( const char *filename );
+long		FS_BaseDir_FOpenFileRead( const char *filename, fileHandle_t *fp );
+void	FS_BaseDir_Rename( const char *from, const char *to, qboolean safe );
 long		FS_FOpenFileRead( const char *qpath, fileHandle_t *file, qboolean uniqueFILE );
 // if uniqueFILE is true, then a new FILE will be fopened even if the file
 // is found in an already open pak file.  If uniqueFILE is false, you must call

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -625,7 +625,7 @@ void	FS_FreeFileList( char **list );
 
 qboolean FS_FileExists( const char *file );
 
-qboolean FS_CreatePath (char *OSPath);
+qboolean FS_CreatePath (const char *OSPath);
 
 int FS_FindVM(void **startSearch, char *found, int foundlen, const char *name, int enableDll);
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1128,7 +1128,6 @@ char	*Sys_MicrosoftStorePath(void);
 char    *Sys_DefaultAppPath(void);
 #endif
 
-void  Sys_SetDefaultHomePath(const char *path);
 char	*Sys_DefaultHomePath(void);
 const char *Sys_Dirname( char *path );
 const char *Sys_Basename( char *path );

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -629,7 +629,8 @@ qboolean FS_CreatePath (char *OSPath);
 
 int FS_FindVM(void **startSearch, char *found, int foundlen, const char *name, int enableDll);
 
-char   *FS_BuildOSPath( const char *base, const char *game, const char *qpath );
+char	*FS_BaseDir_BuildOSPath( const char *base, const char *qpath );
+char	*FS_BuildOSPath( const char *base, const char *game, const char *qpath );
 qboolean FS_CompareZipChecksum(const char *zipfile);
 
 int		FS_LoadStack( void );

--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -651,7 +651,7 @@ static void SV_RehashBans_f(void)
 
 	Com_sprintf(filepath, sizeof(filepath), "%s/%s", FS_GetCurrentGameDir(), sv_banFile->string);
 
-	if((filelen = FS_SV_FOpenFileRead(filepath, &readfrom)) >= 0)
+	if((filelen = FS_BaseDir_FOpenFileRead(filepath, &readfrom)) >= 0)
 	{
 		if(filelen < 2)
 		{
@@ -730,7 +730,7 @@ static void SV_WriteBans(void)
 	
 	Com_sprintf(filepath, sizeof(filepath), "%s/%s", FS_GetCurrentGameDir(), sv_banFile->string);
 
-	if((writeto = FS_SV_FOpenFileWrite(filepath)))
+	if((writeto = FS_BaseDir_FOpenFileWrite(filepath)))
 	{
 		char writebuf[128];
 		serverBan_t *curban;

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -998,7 +998,7 @@ int SV_WriteDownloadToClient(client_t *cl, msg_t *msg)
 		if ( !(sv_allowDownload->integer & DLF_ENABLE) ||
 			(sv_allowDownload->integer & DLF_NO_UDP) ||
 			idPack || unreferenced ||
-			( cl->downloadSize = FS_SV_FOpenFileRead( cl->downloadName, &cl->download ) ) < 0 ) {
+			( cl->downloadSize = FS_BaseDir_FOpenFileRead( cl->downloadName, &cl->download ) ) < 0 ) {
 			// cannot auto-download file
 			if(unreferenced)
 			{

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -43,18 +43,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 qboolean stdinIsATTY;
 
-// Used to determine where to store user-specific files
-static char homePath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the Steam Quake 3 installation path
-static char steamPath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the GOG Quake 3 installation path
-static char gogPath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the Microsoft Store Quake 3 installation path
-static char microsoftStorePath[MAX_OSPATH] = { 0 };
-
 /*
 ==================
 Sys_DefaultHomePath
@@ -62,6 +50,7 @@ Sys_DefaultHomePath
 */
 char *Sys_DefaultHomePath(void)
 {
+	static char homePath[ MAX_OSPATH ] = { 0 };
 	char *p;
 
 	if( !*homePath && com_homepath != NULL )
@@ -128,22 +117,8 @@ Sys_SteamPath
 */
 char *Sys_SteamPath( void )
 {
-	// Disabled since Steam doesn't let you install Quake 3 on Mac/Linux
-#if 0 //#ifdef STEAMPATH_NAME
-	char *p;
-
-	if( ( p = getenv( "HOME" ) ) != NULL )
-	{
-#ifdef __APPLE__
-		char *steamPathEnd = "/Library/Application Support/Steam/SteamApps/common/" STEAMPATH_NAME;
-#else
-		char *steamPathEnd = "/.steam/steam/SteamApps/common/" STEAMPATH_NAME;
-#endif
-		Com_sprintf(steamPath, sizeof(steamPath), "%s%s", p, steamPathEnd);
-	}
-#endif
-
-	return steamPath;
+	// Steam doesn't let you install Quake 3 on Mac/Linux
+	return "";
 }
 
 /*
@@ -153,8 +128,8 @@ Sys_GogPath
 */
 char *Sys_GogPath( void )
 {
-	// GOG also doesn't let you install Quake 3 on Mac/Linux
-	return gogPath;
+	// GOG doesn't let you install Quake 3 on Mac/Linux
+	return "";
 }
 
 /*
@@ -165,7 +140,7 @@ Sys_MicrosoftStorePath
 char* Sys_MicrosoftStorePath(void)
 {
 	// Microsoft Store doesn't exist on Mac/Linux
-	return microsoftStorePath;
+	return "";
 }
 
 

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -46,18 +46,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define KEY_WOW64_32KEY 0x0200
 #endif
 
-// Used to determine where to store user-specific files
-static char homePath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the Steam Quake 3 installation path
-static char steamPath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the GOG Quake 3 installation path
-static char gogPath[ MAX_OSPATH ] = { 0 };
-
-// Used to store the Microsoft Store Quake 3 installation path
-static char microsoftStorePath[MAX_OSPATH] = { 0 };
-
 #ifndef DEDICATED
 static UINT timerResolution = 0;
 #endif
@@ -102,10 +90,11 @@ Sys_DefaultHomePath
 */
 char *Sys_DefaultHomePath( void )
 {
-	TCHAR szPath[MAX_PATH];
+	static char homePath[ MAX_OSPATH ] = { 0 };
 
 	if(!*homePath && com_homepath)
 	{
+		TCHAR szPath[MAX_PATH];
 
 		if( !SUCCEEDED( SHGetFolderPathA( NULL, CSIDL_APPDATA,
 						NULL, 0, szPath ) ) )
@@ -132,14 +121,20 @@ Sys_SteamPath
 */
 char *Sys_SteamPath( void )
 {
-#if defined(STEAMPATH_NAME) || defined(STEAMPATH_APPID)
+#ifndef STANDALONE
+
+#define STEAMPATH_NAME "Quake 3 Arena"
+#define STEAMPATH_APPID "2200"
+
+	static char steamPath[ MAX_OSPATH ] = { 0 };
+
 	HKEY steamRegKey;
 	DWORD pathLen = MAX_OSPATH;
 	qboolean finishPath = qfalse;
 
-#ifdef STEAMPATH_APPID
 	// Assuming Steam is a 32-bit app
-	if (!steamPath[0] && !RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App " STEAMPATH_APPID, 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steamRegKey))
+	if (!steamPath[0] && !RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App "
+		STEAMPATH_APPID, 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steamRegKey))
 	{
 		pathLen = MAX_OSPATH;
 		if (RegQueryValueEx(steamRegKey, "InstallLocation", NULL, NULL, (LPBYTE)steamPath, &pathLen))
@@ -147,9 +142,7 @@ char *Sys_SteamPath( void )
 
 		RegCloseKey(steamRegKey);
 	}
-#endif
 
-#ifdef STEAMPATH_NAME
 	if (!steamPath[0] && !RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\Valve\\Steam", 0, KEY_QUERY_VALUE, &steamRegKey))
 	{
 		pathLen = MAX_OSPATH;
@@ -162,7 +155,6 @@ char *Sys_SteamPath( void )
 
 		RegCloseKey(steamRegKey);
 	}
-#endif
 
 	if (steamPath[0])
 	{
@@ -174,9 +166,11 @@ char *Sys_SteamPath( void )
 		if (finishPath)
 			Q_strcat(steamPath, MAX_OSPATH, "\\SteamApps\\common\\" STEAMPATH_NAME );
 	}
-#endif
 
 	return steamPath;
+#else
+	return "";
+#endif
 }
 
 /*
@@ -186,7 +180,12 @@ Sys_GogPath
 */
 char *Sys_GogPath( void )
 {
-#ifdef GOGPATH_ID
+#ifndef STANDALONE
+
+#define GOGPATH_ID "1441704920"
+
+	static char gogPath[ MAX_OSPATH ] = { 0 };
+
 	HKEY gogRegKey;
 	DWORD pathLen = MAX_OSPATH;
 
@@ -206,9 +205,11 @@ char *Sys_GogPath( void )
 
 		gogPath[pathLen] = '\0';
 	}
-#endif
 
 	return gogPath;
+#else
+	return "";
+#endif
 }
 
 /*
@@ -218,7 +219,12 @@ Sys_MicrosoftStorePath
 */
 char* Sys_MicrosoftStorePath(void)
 {
-#ifdef MSSTORE_PATH
+#ifndef STANDALONE
+
+#define MSSTORE_PATH "Quake 3"
+
+	static char microsoftStorePath[MAX_OSPATH] = { 0 };
+
 	if (!microsoftStorePath[0]) 
 	{
 		TCHAR szPath[MAX_PATH];
@@ -233,8 +239,11 @@ char* Sys_MicrosoftStorePath(void)
 		// default: C:\Program Files\ModifiableWindowsApps\Quake 3\EN
 		Com_sprintf(microsoftStorePath, sizeof(microsoftStorePath), "%s%cModifiableWindowsApps%c%s%cEN", szPath, PATH_SEP, PATH_SEP, MSSTORE_PATH, PATH_SEP);
 	}
-#endif
+
 	return microsoftStorePath;
+#else
+	return "";
+#endif
 }
 
 /*


### PR DESCRIPTION
For reasons I was looking at how all the various search paths were resolved in the file system code. What I found was quite a lot of repetition and duplication. In fairness it's completely understandable how this has happened, as we've incrementally added support for sourcing data from Steam, GoG, etc. where each addition has no doubt seemed small, but then cumulatively it's become quite hard to read and introduced some scope for obscuring bugs since a fix/change to one bit of code requires that the change is copied throughout. (As an example FS_GetModList doesn't seem to check the macOS .app or Microsoft Store paths, and it probably should.)

In order to address this I've added a global fs_pathVars array that lists all the cvars from which we derive data, in order, which is then looped over as appropriate in the various places that need to. I think it's functionally equivalent, but it probably does some extra and/or fewer checks in some circumstances versus the outgoing code. I've been staring at it too long and can't see any obvious problems, but I'd appreciate if some other sets of eyes look over it before I commit.