### PR TITLE
qcommon: Assume that unknown architectures don't have a JIT for QVMs

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -346,6 +346,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // ARCH_STRING is (mostly) only used for informational purposes, so we allow
 // it to be undefined so that more diverse architectures may be compiled
 #define ARCH_STRING "unknown"
+#define NO_VM_COMPILED
 #endif
 
 #ifndef ID_INLINE


### PR DESCRIPTION
We need specific code for any architecture that does have a JIT, so we can safely assume that any other architecture does not.

---

This is the missing part of #764 that didn't get reimplemented after #769, and fixes the build on otherwise unknown architectures (build-tested on Debian s390x).

It might be clearer to reverse the sense of `NO_VM_COMPILED` and turn it into `HAVE_VM_COMPILED` - I'll open a separate PR for that.