### PR TITLE
Treat architectures that *do* have a JIT as unusual

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -96,9 +96,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #undef idx64
 #define idx64 1
 #define ARCH_STRING "x86_64"
+#define HAVE_VM_COMPILED
 #elif defined(__aarch64__) || defined(__ARM64__) || defined (_M_ARM64)
 #define ARCH_STRING "arm64"
-#define NO_VM_COMPILED
 #endif
 
 #define Q3_LITTLE_ENDIAN
@@ -124,9 +124,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #if defined( _M_IX86 ) || defined( __i386__ )
 #define ARCH_STRING "x86"
+#define HAVE_VM_COMPILED
 #elif defined(__arm__) || defined(_M_ARM)
 #define ARCH_STRING "arm"
-#define NO_VM_COMPILED
 #endif
 
 #define Q3_LITTLE_ENDIAN
@@ -147,18 +147,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifdef __ppc__
 #define ARCH_STRING "ppc"
 #define Q3_BIG_ENDIAN
+#define HAVE_VM_COMPILED
 #elif defined __i386__
 #define ARCH_STRING "x86"
 #define Q3_LITTLE_ENDIAN
+#define HAVE_VM_COMPILED
 #elif defined __x86_64__
 #undef idx64
 #define idx64 1
 #define ARCH_STRING "x86_64"
 #define Q3_LITTLE_ENDIAN
+#define HAVE_VM_COMPILED
 #elif defined __aarch64__
 #define ARCH_STRING "arm64"
 #define Q3_LITTLE_ENDIAN
-#define NO_VM_COMPILED
 #endif
 
 #define DLL_EXT ".dylib"
@@ -185,20 +187,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #if defined(__x86_64__) || defined(__amd64__)
 # define ARCH_STRING "x86_64"
+# define HAVE_VM_COMPILED
 #elif defined(__i386__)
 # define ARCH_STRING "x86"
+# define HAVE_VM_COMPILED
 #elif defined(__aarch64__)
 # define ARCH_STRING "arm64"
-# define NO_VM_COMPILED
 #elif defined(__arm__)
 # define ARCH_STRING "arm"
+# define HAVE_VM_COMPILED
 #elif defined(__powerpc64__) || defined(__ppc64__)
 # define ARCH_STRING "ppc64"
+# define HAVE_VM_COMPILED
 #elif defined(__powerpc__) || defined(__ppc__)
 # define ARCH_STRING "ppc"
+# define HAVE_VM_COMPILED
 #elif defined(__alpha__)
 # define ARCH_STRING "alpha"
-# define NO_VM_COMPILED
 #endif
 
 #if defined __x86_64__
@@ -240,13 +245,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifdef __i386__
 #define ARCH_STRING "x86"
+#define HAVE_VM_COMPILED
 #elif defined __amd64__
 #undef idx64
 #define idx64 1
 #define ARCH_STRING "x86_64"
+#define HAVE_VM_COMPILED
 #elif defined __axp__
 #define ARCH_STRING "alpha"
-#define NO_VM_COMPILED
 #endif
 
 #if BYTE_ORDER == BIG_ENDIAN
@@ -272,8 +278,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifdef __i386__
 #define ARCH_STRING "x86"
+#define HAVE_VM_COMPILED
 #elif defined __sparc
 #define ARCH_STRING "sparc"
+#define HAVE_VM_COMPILED
 #endif
 
 #if defined( _BIG_ENDIAN )
@@ -295,7 +303,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define PATH_SEP '/'
 
 #define ARCH_STRING "mips"
-#define NO_VM_COMPILED
 
 #define Q3_BIG_ENDIAN // SGI's MIPS are always big endian
 
@@ -312,7 +319,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define PATH_SEP '/'
 
 #define ARCH_STRING "wasm32"
-#define NO_VM_COMPILED
 
 #define Q3_LITTLE_ENDIAN
 
@@ -346,7 +352,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // ARCH_STRING is (mostly) only used for informational purposes, so we allow
 // it to be undefined so that more diverse architectures may be compiled
 #define ARCH_STRING "unknown"
-#define NO_VM_COMPILED
 #endif
 
 #ifndef ID_INLINE

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -346,6 +346,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // ARCH_STRING is (mostly) only used for informational purposes, so we allow
 // it to be undefined so that more diverse architectures may be compiled
 #define ARCH_STRING "unknown"
+#define NO_VM_COMPILED
 #endif
 
 #ifndef ID_INLINE

--- a/code/qcommon/vm.c
+++ b/code/qcommon/vm.c
@@ -653,7 +653,7 @@ vm_t *VM_Create( const char *module, intptr_t (*systemCalls)(intptr_t *),
 
 	vm->compiled = qfalse;
 
-#ifdef NO_VM_COMPILED
+#ifndef HAVE_VM_COMPILED
 	if(interpret >= VMI_COMPILED) {
 		Com_Printf("Architecture doesn't have a bytecode compiler, using interpreter\n");
 		interpret = VMI_BYTECODE;
@@ -838,7 +838,7 @@ intptr_t QDECL VM_Call( vm_t *vm, int callnum, ... )
                             args[8],  args[9], args[10], args[11]);
 	} else {
 #if ( id386 || idsparc ) && !defined __clang__ // calling convention doesn't need conversion in some cases
-#ifndef NO_VM_COMPILED
+#ifdef HAVE_VM_COMPILED
 		if ( vm->compiled )
 			r = VM_CallCompiled( vm, (int*)&callnum );
 		else
@@ -857,7 +857,7 @@ intptr_t QDECL VM_Call( vm_t *vm, int callnum, ... )
 			a.args[i] = va_arg(ap, int);
 		}
 		va_end(ap);
-#ifndef NO_VM_COMPILED
+#ifdef HAVE_VM_COMPILED
 		if ( vm->compiled )
 			r = VM_CallCompiled( vm, &a.callnum );
 		else


### PR DESCRIPTION
* qcommon: Assume that unknown architectures don't have a JIT for QVMs
    
    We need specific code for any architecture that does have a JIT, so we
    can safely assume that any other architecture does not.

* qcommon: Reverse the sense of NO_VM_COMPILED
    
    Instead of defining NO_VM_COMPILED on the unlimited number of CPU
    architectures where we don't have a JIT for QVM bytecode, define
    HAVE_VM_COMPILED on the finite number of architectures where we do
    (x86, PowerPC, Sparc or 32-bit ARM).

---

Alternative to #788, please merge whichever one you like better.