### PR TITLE
fix: shotgun not gibbing unless aiming at feet

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ set using command line arguments:
                                       "Network protocols" section below
                                       (startup only)
 
+  g_shotgunGibFix                   - enable the fix for the bug where the
+                                      shotgun doesn't gib unless you aim at the
+                                      feet.
+
   in_joystickNo                     - select which joystick to use
   in_availableJoysticks             - list of available Joysticks
   in_keyboardDebug                  - print keyboard debug info

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -601,7 +601,27 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 
 	self->s.loopSound = 0;
 
-	self->r.maxs[2] = -8;
+	if (!g_shotgunGibFix.integer) {
+		// Executing this line causes a bug where the shotgun doesn't gib
+		// unless you aim at the feet.
+		// See https://github.com/ioquake/ioq3/issues/794.
+		//
+		// Note that without this line (when `g_shotgunGibFix` is enabled),
+		// when shooting at two players standing
+		// behind each other, the second target will take less damage,
+		// because the dead body of the first player will absorb the pellets
+		// until it gets gibbed (that is, up to 4 pellets,
+		// see `GIB_HEALTH` and `DEFAULT_SHOTGUN_DAMAGE`).
+		//
+		// The purpose and the effect of this line is not entirely clear.
+		// Maybe it's to transition the player hitbox
+		// into the "lying down dead" state, make it shorter.
+		// But this is already handled in `PM_CheckDuck`,
+		// so maybe it's just leftover code.
+		// So let's keep this line for now, but put behind a cvar.
+		// See https://github.com/ioquake/ioq3/issues/794.
+		self->r.maxs[2] = -8;
+	}
 
 	// don't allow respawn until the death anim is done
 	// g_forcerespawn may force spawning at some later time

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -724,6 +724,7 @@ extern	vmCvar_t	g_motd;
 extern	vmCvar_t	g_warmup;
 extern	vmCvar_t	g_doWarmup;
 extern	vmCvar_t	g_blood;
+extern	vmCvar_t	g_shotgunGibFix;
 extern	vmCvar_t	g_allowVote;
 extern	vmCvar_t	g_teamAutoJoin;
 extern	vmCvar_t	g_teamForceBalance;

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -69,6 +69,7 @@ vmCvar_t	g_restarted;
 vmCvar_t	g_logfile;
 vmCvar_t	g_logfileSync;
 vmCvar_t	g_blood;
+vmCvar_t	g_shotgunGibFix;
 vmCvar_t	g_podiumDist;
 vmCvar_t	g_podiumDrop;
 vmCvar_t	g_allowVote;
@@ -151,6 +152,7 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_debugAlloc, "g_debugAlloc", "0", 0, 0, qfalse },
 	{ &g_motd, "g_motd", "", 0, 0, qfalse },
 	{ &g_blood, "com_blood", "1", 0, 0, qfalse },
+	{ &g_shotgunGibFix, "g_shotgunGibFix", "0", CVAR_ARCHIVE, 0, qfalse },
 
 	{ &g_podiumDist, "g_podiumDist", "80", 0, 0, qfalse },
 	{ &g_podiumDrop, "g_podiumDrop", "70", 0, 0, qfalse },


### PR DESCRIPTION
Closes https://github.com/ioquake/ioq3/issues/794.

Note that now when shooting at two players
standing behind each other,
the second target will take less damage,
because the dead body of the first player will absorb the pellets
until it gets gibbed (that is, up to 4 pellets,
see `GIB_HEALTH` and `DEFAULT_SHOTGUN_DAMAGE`).

The purpose of the removed line is not entirely clear.
Maybe it's just leftover code,
because the height of a dead body is handled in `PM_CheckDuck`.

Before merging, please verify that this doesn't have
unintented side effects, I am not quite sure.
See the linked issue for details.
