### PR TITLE
Fix emscripten preload file not working for a symlinked directory

### DIFF
--- a/cmake/platforms/emscripten.cmake
+++ b/cmake/platforms/emscripten.cmake
@@ -32,7 +32,7 @@ if(EMSCRIPTEN_PRELOAD_FILE)
     if(NOT EXISTS "${CMAKE_SOURCE_DIR}/${BASEGAME}")
         message(FATAL_ERROR "No files in '${BASEGAME}' directory for emscripten to preload.")
     endif()
-    list(APPEND CLIENT_LINK_OPTIONS "--preload-file ${BASEGAME}")
+    list(APPEND CLIENT_LINK_OPTIONS --preload-file "${BASEGAME}")
 endif()
 
 set(POST_CLIENT_CONFIGURE_FUNCTION deploy_shell_files)


### PR DESCRIPTION
I tried to add a symlink to my baseq3 directory containing *.pk3 files, and compile with `EMSCRIPTEN_PRELOAD_FILE=1`, but  ioquake3.data was not created, because Make did not properly expand the directory.  