### PR TITLE
Increase map limit in Team Arena ui to match q3_ui

### DIFF
--- a/code/ui/ui_gameinfo.c
+++ b/code/ui/ui_gameinfo.c
@@ -136,7 +136,7 @@ void UI_LoadArenas( void ) {
 	int			numdirs;
 	vmCvar_t	arenasFile;
 	char		filename[128];
-	char		dirlist[1024];
+	char		dirlist[4096];
 	char*		dirptr;
 	int			i;
 	int			dirlen;
@@ -152,7 +152,7 @@ void UI_LoadArenas( void ) {
 	}
 
 	// get all arenas from .arena files
-	numdirs = trap_FS_GetFileList("scripts", ".arena", dirlist, 1024 );
+	numdirs = trap_FS_GetFileList("scripts", ".arena", dirlist, 4096 );
 	dirptr  = dirlist;
 	for (i = 0; i < numdirs; i++, dirptr += dirlen+1) {
 		dirlen = strlen(dirptr);

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -611,7 +611,7 @@ typedef struct {
 #define MAX_HEADNAME  32
 #define MAX_TEAMS 64
 #define MAX_GAMETYPES 16
-#define MAX_MAPS 128
+#define MAX_MAPS MAX_ARENAS
 #define MAX_SPMAPS 16
 #define PLAYERS_PER_TEAM 5
 #define MAX_PINGREQUESTS		32


### PR DESCRIPTION
Allow Team Arena UI to read more scripts/*.arena files and allow up to 1024 maps in start server and in-game call vote menu instead of 128.

q3_ui buffer size for scripts/*.arena files was previously increased from 1024 to [2048](https://github.com/ioquake/ioq3/commit/d53eeae4195f6348d1388b39542bdd0c080a3f68) and [4096](https://github.com/ioquake/ioq3/commit/d1f82ed56729b2dc44991e8822d1a959db60529d) but Team Arena was not updated. q3_ui allows number of maps to be up to MAX_ARENAS. This PR raises Team Arena to the same levels.

Requested on the [ioquake3 forum](https://discourse.ioquake.org/t/quake3-team-arena-how-does-one-increase-the-number-of-maps-shown-in-the-menu/3090). It works with the 300 maps I have.