### PR TITLE
Note former maintainers, remove my funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -8,7 +8,7 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ['https://www.patreon.com/icculus', 'https://www.patreon.com/SmileTheory', 'https://ko-fi.com/zturtleman']
+custom: ['https://www.patreon.com/icculus', 'https://www.patreon.com/SmileTheory']
 
 
 #please add your links to this if you've been a long-time contributor!

--- a/README.md
+++ b/README.md
@@ -567,12 +567,15 @@ See opengl2-readme.md for more information.
 
 Maintainers
 
+  * Tim Angus <tim@ngus.net>
+  * Jack "Mr. Nuclear Monster" Slater <jack@ioquake.org>
+
+Former Maintainers
+
   * James Canete <use.less01@gmail.com>
   * Ludwig Nussel <ludwig.nussel@suse.de>
   * Thilo Schulz <arny@ats.s.bawue.de>
-  * Tim Angus <tim@ngus.net>
   * Tony J. White <tjw@tjw.org>
-  * Jack "Mr. Nuclear Monster" Slater <jack@ioquake.org>
   * Zack Middleton <zturtleman@gmail.com>
 
 Significant contributions from


### PR DESCRIPTION
I'm stepping away from ioquake3 due to changes in my software priorities. I will continue my Quake 3 projects separately.

Adding a former maintainers section to the README seems like a good way to reflect this. I'd prefer to remove my funding link.