### PR TITLE
feat: add `g_shotgunMorePellets` cvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ set using command line arguments:
                                       "Network protocols" section below
                                       (startup only)
 
+  g_shotgunMorePellets              - Doubles the amount of pellets that the
+                                      shotgun fires, while keeping the damage
+                                      the same, like in Quake Live. Increases
+                                      the reliability of the shotgun damage.
+                                      Note that client-side this might not be
+                                      visible, due to the usage of a different
+                                      `cgame.vm`.
+
   in_joystickNo                     - select which joystick to use
   in_availableJoysticks             - list of available Joysticks
   in_keyboardDebug                  - print keyboard debug info

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1013,6 +1013,7 @@ typedef struct {
 	char			mapname[MAX_QPATH];
 	char			redTeam[MAX_QPATH];
 	char			blueTeam[MAX_QPATH];
+	qboolean 		g_shotgunMorePellets;
 
 	int				voteTime;
 	int				voteYes;

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -171,6 +171,7 @@ void CG_ParseServerinfo( void ) {
 	trap_Cvar_Set("g_redTeam", cgs.redTeam);
 	Q_strncpyz( cgs.blueTeam, Info_ValueForKey( info, "g_blueTeam" ), sizeof(cgs.blueTeam) );
 	trap_Cvar_Set("g_blueTeam", cgs.blueTeam);
+	cgs.g_shotgunMorePellets = atoi( Info_ValueForKey( info, "g_shotgunMorePellets" ) );
 }
 
 /*

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -2034,6 +2034,7 @@ hit splashes
 */
 static void CG_ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, int otherEntNum ) {
 	int			i;
+	int 		numPellets;
 	float		r, u;
 	vec3_t		end;
 	vec3_t		forward, right, up;
@@ -2044,8 +2045,9 @@ static void CG_ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, int othe
 	PerpendicularVector( right, forward );
 	CrossProduct( forward, right, up );
 
+	numPellets = DEFAULT_SHOTGUN_COUNT * (cgs.g_shotgunMorePellets ? 2 : 1);
 	// generate the "random" spread pattern
-	for ( i = 0 ; i < DEFAULT_SHOTGUN_COUNT ; i++ ) {
+	for ( i = 0 ; i < numPellets ; i++ ) {
 		r = Q_crandom( &seed ) * DEFAULT_SHOTGUN_SPREAD * 16;
 		u = Q_crandom( &seed ) * DEFAULT_SHOTGUN_SPREAD * 16;
 		VectorMA( origin, 8192 * 16, forward, end);

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -712,6 +712,7 @@ extern	vmCvar_t	g_gravity;
 extern	vmCvar_t	g_speed;
 extern	vmCvar_t	g_knockback;
 extern	vmCvar_t	g_quadfactor;
+extern	vmCvar_t	g_shotgunMorePellets;
 extern	vmCvar_t	g_forcerespawn;
 extern	vmCvar_t	g_inactivity;
 extern	vmCvar_t	g_debugMove;

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -54,6 +54,7 @@ vmCvar_t	g_gravity;
 vmCvar_t	g_cheats;
 vmCvar_t	g_knockback;
 vmCvar_t	g_quadfactor;
+vmCvar_t	g_shotgunMorePellets;
 vmCvar_t	g_forcerespawn;
 vmCvar_t	g_inactivity;
 vmCvar_t	g_debugMove;
@@ -142,6 +143,10 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_gravity, "g_gravity", "800", 0, 0, qtrue  },
 	{ &g_knockback, "g_knockback", "1000", 0, 0, qtrue  },
 	{ &g_quadfactor, "g_quadfactor", "3", 0, 0, qtrue  },
+	// So is it supposed to be `g_` or `com_`?
+	// Because these are `CVAR_SERVERINFO` things, the client cannot set them
+	// separately.
+	{ &g_shotgunMorePellets, "g_shotgunMorePellets", "0", CVAR_SERVERINFO, 0, qtrue },
 	{ &g_weaponRespawn, "g_weaponrespawn", "5", 0, 0, qtrue  },
 	{ &g_weaponTeamRespawn, "g_weaponTeamRespawn", "30", 0, 0, qtrue },
 	{ &g_forcerespawn, "g_forcerespawn", "20", 0, 0, qtrue },

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -290,7 +290,7 @@ qboolean ShotgunPellet( vec3_t start, vec3_t end, gentity_t *ent ) {
 		}
 
 		if ( traceEnt->takedamage) {
-			damage = DEFAULT_SHOTGUN_DAMAGE * s_quadFactor;
+			damage = DEFAULT_SHOTGUN_DAMAGE / (g_shotgunMorePellets.integer ? 2 : 1) * s_quadFactor;
 #ifdef MISSIONPACK
 			if ( traceEnt->client && traceEnt->client->invulnerabilityTime > level.time ) {
 				if (G_InvulnerabilityEffect( traceEnt, forward, tr.endpos, impactpoint, bouncedir )) {
@@ -320,6 +320,7 @@ qboolean ShotgunPellet( vec3_t start, vec3_t end, gentity_t *ent ) {
 // this should match CG_ShotgunPattern
 void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *ent ) {
 	int			i;
+	int			numPellets;
 	float		r, u;
 	vec3_t		end;
 	vec3_t		localForward, localRight, localUp;
@@ -332,7 +333,8 @@ void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *ent ) {
 	CrossProduct( localForward, localRight, localUp );
 
 	// generate the "random" spread pattern
-	for ( i = 0 ; i < DEFAULT_SHOTGUN_COUNT ; i++ ) {
+	numPellets = DEFAULT_SHOTGUN_COUNT * (g_shotgunMorePellets.integer ? 2 : 1);
+	for ( i = 0 ; i < numPellets ; i++ ) {
 		r = Q_crandom( &seed ) * DEFAULT_SHOTGUN_SPREAD * 16;
 		u = Q_crandom( &seed ) * DEFAULT_SHOTGUN_SPREAD * 16;
 		VectorMA( origin, 8192 * 16, localForward, end);


### PR DESCRIPTION
For more reliable shotgun damage, as in Quake Live.

TODO:
- [ ] Check whether the cvar is properly initialized, declared and stuff,
  and whether its name makes sense and the prefix shouldn't be `com_` (common).
  I have checked that it works, but I don't have much experience with cvars.

To test this client-side, you can replace `cgame.vm` in `pak8.pk3` with the one that has been build from this MR.
