### PR TITLE
fix: don't make plasmagun explosion on body

### DIFF
--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1950,7 +1950,6 @@ void CG_MissileHitPlayer( int weapon, vec3_t origin, vec3_t dir, int entityNum )
 	switch ( weapon ) {
 	case WP_GRENADE_LAUNCHER:
 	case WP_ROCKET_LAUNCHER:
-	case WP_PLASMAGUN:
 	case WP_BFG:
 #ifdef MISSIONPACK
 	case WP_NAILGUN:


### PR DESCRIPTION
This partially reverts f011fe991416400b2332ff6aafdc9ff70a76922c,
i.e. makes the plasmagun behave as in the original Quake III.

That commit refers to "Bug 5066", but it's not clear
where the bug tracker is, and what was the discussion behind that.

The plasmagun explosion on body (flesh) hit
makes quite a big difference gameplay-wise,
due to its visibility impact, you cannot see the player being hit
too well.

For reference, in Quake Live the plasmagun also doesn't make
its original explosion effect on body hit,
but BFG does.
So this commit also hopefully brings the behavior in line
with the intent of the Quake III authors.
