### PR TITLE
fix: increase `s_alDopplerFactor` 1 -> 5

### DIFF
--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -2508,7 +2508,7 @@ qboolean S_AL_Init( soundInterface_t *si )
 	s_alPrecache = Cvar_Get( "s_alPrecache", "1", CVAR_ARCHIVE );
 	s_alGain = Cvar_Get( "s_alGain", "1.0", CVAR_ARCHIVE );
 	s_alSources = Cvar_Get( "s_alSources", "96", CVAR_ARCHIVE );
-	s_alDopplerFactor = Cvar_Get( "s_alDopplerFactor", "1.0", CVAR_ARCHIVE );
+	s_alDopplerFactor = Cvar_Get( "s_alDopplerFactor", "5.0", CVAR_ARCHIVE );
 	s_alDopplerSpeed = Cvar_Get( "s_alDopplerSpeed", "9000", CVAR_ARCHIVE );
 	s_alMinDistance = Cvar_Get( "s_alMinDistance", "120", CVAR_CHEAT );
 	s_alMaxDistance = Cvar_Get("s_alMaxDistance", "1024", CVAR_CHEAT);


### PR DESCRIPTION
Partially addresses https://github.com/ioquake/ioq3/issues/802.

This makes the Doppler effect with `s_useOpenAL 1`
sound more like that of the original sound library.
With the value of 1 it's basically unnoticeable.
It's still not quite the same, i.e. it's not as powerful
when a rocket flies very close by, but it's better.
Setting a value higher than 5 makes rockets
sound a little more intense and closer to the original,
but then plasmagun gets perhaps too loud,
and also the sound looping becomes too obvious.
