### PR TITLE
Workaround macOS dmg build error with CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         success=0
         max_tries=10
         for i in $(seq $max_tries); do
-         cpack --build build/CPackConfig.cmake -B build/installer --verbose && success=1
+         cpack --config build/CPackConfig.cmake -B build/installer --verbose && success=1
          if test $success = 1; then
           break
          fi


### PR DESCRIPTION
Retry the macOS workflow multiple times in order to work around this issue with CMake: 
https://gitlab.kitware.com/cmake/cmake/-/issues/25671

Solution stolen wholesale from SDL and @madebr 
https://github.com/libsdl-org/SDL/pull/9816