### PR TITLE
Fix rare patch collision issue that occurs on modern builds and not original quake3 binaries

### DIFF
--- a/code/qcommon/cm_polylib.c
+++ b/code/qcommon/cm_polylib.c
@@ -440,9 +440,9 @@ void ChopWindingInPlace (winding_t **inout, vec3_t normal, vec_t dist, vec_t eps
 		dot = DotProduct (in->p[i], normal);
 		dot -= dist;
 		dists[i] = dot;
-		if (dot > epsilon)
+		if ((dot + 0.0005) > epsilon)
 			sides[i] = SIDE_FRONT;
-		else if (dot < -epsilon)
+		else if ((dot - 0.0005) < -epsilon)
 			sides[i] = SIDE_BACK;
 		else
 		{


### PR DESCRIPTION
It's very similar to issue #186.

SSE and earlier (FP87) have different precision than SSE2/above. A very tiny difference in value can cause some windings (and planes) not to be created at all, resulting in collision issues compared to the original game, such as players falling through the ground.

This bug is infrequent, not sure if anyone else has experienced it (we have).

I didn't try all quake 3 maps.