### PR TITLE
Revert "Bug 5066 - Plasmagun and BFG don't play the explosion when they hit players, patch by Ensiform"

### DIFF
--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1950,8 +1950,6 @@ void CG_MissileHitPlayer( int weapon, vec3_t origin, vec3_t dir, int entityNum )
 	switch ( weapon ) {
 	case WP_GRENADE_LAUNCHER:
 	case WP_ROCKET_LAUNCHER:
-	case WP_PLASMAGUN:
-	case WP_BFG:
 #ifdef MISSIONPACK
 	case WP_NAILGUN:
 	case WP_CHAINGUN:


### PR DESCRIPTION
related to discussions in https://github.com/ioquake/ioq3/pull/801

This reverts commit f011fe991416400b2332ff6aafdc9ff70a76922c.

tested this on stream, here's a slomo clip with the effect on:
https://www.twitch.tv/mrnuclearmonster/clip/SpinelessSmoothMonkeyPoooound-TWvVqCxRdZlvjwjr

here's a slomo clip where the effect is off (original vanilla quake 3 behavior, at the start of the clip):
https://www.twitch.tv/mrnuclearmonster/clip/MistyCrazyYamWOOP-S27PYNfgGw8rX1Xg

Please use this opportunity to convince me otherwise. I think the only reasonable argument I can think of is that displaying the effect is potentially a bugfix.