### PR TITLE
refactor: `#define DEAD_HEIGHT -8`

### DIFF
--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1275,7 +1275,7 @@ static void PM_CheckDuck (void)
 
 	if (pm->ps->pm_type == PM_DEAD)
 	{
-		pm->maxs[2] = -8;
+		pm->maxs[2] = DEAD_HEIGHT;
 		pm->ps->viewheight = DEAD_VIEWHEIGHT;
 		return;
 	}

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -52,6 +52,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define	DEFAULT_VIEWHEIGHT	26
 #define CROUCH_HEIGHT		16
 #define CROUCH_VIEWHEIGHT	12
+#define DEAD_HEIGHT			-8
 #define	DEAD_VIEWHEIGHT		-16
 
 //

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -601,7 +601,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 
 	self->s.loopSound = 0;
 
-	self->r.maxs[2] = -8;
+	self->r.maxs[2] = DEAD_HEIGHT;
 
 	// don't allow respawn until the death anim is done
 	// g_forcerespawn may force spawning at some later time


### PR DESCRIPTION
From the research conducted in
https://github.com/ioquake/ioq3/issues/794
we can probably conclude that the `self->r.maxs[2] = -8;`
in `player_die()` is related to `pm->maxs[2] = -8;`
in `PM_CheckDuck()`. Let's make this clear with a named constant.

TODO:
- [ ] Merge https://github.com/ioquake/ioq3/pull/827, which this MR is based on.
