### PR TITLE
renderergl2: fix lightgrid seams in world lighting

### DIFF
--- a/code/renderergl2/tr_bsp.c
+++ b/code/renderergl2/tr_bsp.c
@@ -2176,6 +2176,10 @@ void R_LoadLightGrid( lump_t *l ) {
 	w->lightGridInverseSize[1] = 1.0f / w->lightGridSize[1];
 	w->lightGridInverseSize[2] = 1.0f / w->lightGridSize[2];
 
+	w->lightGridMaxSize = w->lightGridSize[0];
+	if (w->lightGridSize[1] > w->lightGridMaxSize) w->lightGridMaxSize = w->lightGridSize[1];
+	if (w->lightGridSize[2] > w->lightGridMaxSize) w->lightGridMaxSize = w->lightGridSize[2];
+
 	wMins = w->bmodels[0].bounds[0];
 	wMaxs = w->bmodels[0].bounds[1];
 

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -1186,6 +1186,7 @@ typedef struct {
 	vec3_t		lightGridOrigin;
 	vec3_t		lightGridSize;
 	vec3_t		lightGridInverseSize;
+	float		lightGridMaxSize;
 	int			lightGridBounds[3];
 	byte		*lightGridData;
 	uint16_t	*lightGrid16;


### PR DESCRIPTION
Sample the lightgrid a short distance behind the surface, using half of the map's lightgrid cell size as an offset along the surface normal instead of sampling exactly at the surface where solid/air boundaries make the lightgrid-derived lighting direction unstable. For very shallow angles, blend the sampled direction towards the surface normal to avoid hard transitions.

This reduces abrupt changes in the computed light direction that caused visible seams and creases that were visible with higher r_baseSpecular values.

Fixes #120