### PR TITLE
Use case-insensitive comparison for all Info_Key functions

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -1221,7 +1221,7 @@ void Info_RemoveKey( char *s, const char *key ) {
 		}
 		*o = 0;
 
-		if (!strcmp (key, pkey) )
+		if (!Q_stricmp (key, pkey) )
 		{
 			memmove(start, s, strlen(s) + 1); // remove this part
 			
@@ -1277,7 +1277,7 @@ void Info_RemoveKey_Big( char *s, const char *key ) {
 		}
 		*o = 0;
 
-		if (!strcmp (key, pkey) )
+		if (!Q_stricmp (key, pkey) )
 		{
 			memmove(start, s, strlen(s) + 1); // remove this part
 			return;


### PR DESCRIPTION
`Info_ValueForKey` performs case-insensitive comparisons on key names, but not other functions like `Info_RemoveKey` (inconsistent).

`Info_SetValueForKey` uses `Info_RemoveKey` when setting a key to a new value.