### PR TITLE
fix: `s_list` command with `s_useOpenAL 1`

### DIFF
--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -2365,6 +2365,18 @@ S_AL_SoundList
 static
 void S_AL_SoundList( void )
 {
+	int		i;
+	alSfx_t	*sfx;
+	int		size, total;
+
+	total = 0;
+	for (sfx=knownSfx, i=0 ; i<numSfx ; i++, sfx++) {
+		size = sfx->info.samples;
+		total += size;
+		Com_Printf("%6i : %s[%s]\n", size,
+				sfx->filename, sfx->inMemory ? "resident " : "paged out");
+	}
+	Com_Printf ("Total resident: %i\n", total);
 }
 
 #ifdef USE_VOIP


### PR DESCRIPTION
The code is pretty much copy-pasted from `S_Base_SoundList`.
Some things from the original `S_Base_SoundList` are not implemented,
e.g. compression and the final "free memory" line.

I have checked that it works:

<img width="282" height="115" alt="image" src="https://github.com/user-attachments/assets/fff04718-22e2-45f3-8f49-c00e58901850" />

<img width="269" height="117" alt="image" src="https://github.com/user-attachments/assets/961da8ac-df79-4d1b-ba2c-f97e01aa7ab6" />

For comparison: the output with `s_useOpenAL 0` in the web version, and in the native version:

<img width="359" height="125" alt="image" src="https://github.com/user-attachments/assets/17b982ca-4fb3-43ec-8bf3-526d642a98e7" />
<img width="466" height="169" alt="image" src="https://github.com/user-attachments/assets/692d639f-ae1f-438c-b942-d6817a83558a" />
