### PR TITLE
refactor: name `waterlevel` magic consts

### DIFF
--- a/code/botlib/be_aas_move.c
+++ b/code/botlib/be_aas_move.c
@@ -840,9 +840,9 @@ int AAS_ClientMovementPrediction(struct aas_clientmove_s *move,
 							if (swimming) delta = 0;
 							// never take falling damage if completely underwater
 							/*
-							if (ent->waterlevel == 3) return;
-							if (ent->waterlevel == 2) delta *= 0.25;
-							if (ent->waterlevel == 1) delta *= 0.5;
+							if (ent->waterlevel == WATERLEVEL_SUBMERGED) return;
+							if (ent->waterlevel == WATERLEVEL_HALFWAY) delta *= 0.25;
+							if (ent->waterlevel == WATERLEVEL_FEET) delta *= 0.5;
 							*/
 							if (delta > 40)
 							{

--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -441,7 +441,7 @@ int CG_WaterLevel(centity_t *cent) {
 	//
 	// get waterlevel, accounting for ducking
 	//
-	waterlevel = 0;
+	waterlevel = WATERLEVEL_NONE;
 
 	point[0] = cent->lerpOrigin[0];
 	point[1] = cent->lerpOrigin[1];
@@ -451,17 +451,17 @@ int CG_WaterLevel(centity_t *cent) {
 	if (contents & MASK_WATER) {
 		sample2 = viewheight - MINS_Z;
 		sample1 = sample2 / 2;
-		waterlevel = 1;
+		waterlevel = WATERLEVEL_FEET;
 		point[2] = cent->lerpOrigin[2] + MINS_Z + sample1;
 		contents = CG_PointContents(point, -1);
 
 		if (contents & MASK_WATER) {
-			waterlevel = 2;
+			waterlevel = WATERLEVEL_HALFWAY;
 			point[2] = cent->lerpOrigin[2] + MINS_Z + sample2;
 			contents = CG_PointContents(point, -1);
 
 			if (contents & MASK_WATER) {
-				waterlevel = 3;
+				waterlevel = WATERLEVEL_SUBMERGED;
 			}
 		}
 	}
@@ -494,7 +494,7 @@ void CG_PainEvent( centity_t *cent, int health ) {
 		snd = "*pain100_1.wav";
 	}
 	// play a gurp sound instead of a normal pain sound
-	if (CG_WaterLevel(cent) == 3) {
+	if (CG_WaterLevel(cent) == WATERLEVEL_SUBMERGED) {
 		if (rand()&1) {
 			trap_S_StartSound(NULL, cent->currentState.number, CHAN_VOICE, CG_CustomSound(cent->currentState.number, "sound/player/gurp1.wav"));
 		} else {
@@ -1169,7 +1169,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	case EV_DEATH3:
 		DEBUGNAME("EV_DEATHx");
 
-		if (CG_WaterLevel(cent) == 3) {
+		if (CG_WaterLevel(cent) == WATERLEVEL_SUBMERGED) {
 			trap_S_StartSound(NULL, es->number, CHAN_VOICE, CG_CustomSound(es->number, "*drown.wav"));
 		} else {
 			trap_S_StartSound(NULL, es->number, CHAN_VOICE, CG_CustomSound(es->number, va("*death%i.wav", event - EV_DEATH1 + 1)));

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -161,6 +161,12 @@ typedef enum {
 
 #define	PMF_ALL_TIMES	(PMF_TIME_WATERJUMP|PMF_TIME_LAND|PMF_TIME_KNOCKBACK)
 
+// pmove->waterlevel
+#define WATERLEVEL_NONE 0		// no water at all
+#define WATERLEVEL_FEET 1		// just the feet are under water
+#define WATERLEVEL_HALFWAY 2 	// wading / swimming at surface
+#define WATERLEVEL_SUBMERGED 3 	// fully underwater (max possible waterlevel)
+
 #define	MAXTOUCH	32
 typedef struct {
 	// state (in / out)

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -112,7 +112,7 @@ void P_WorldEffects( gentity_t *ent ) {
 	//
 	// check for drowning
 	//
-	if ( waterlevel == 3 ) {
+	if ( waterlevel == WATERLEVEL_SUBMERGED ) {
 		// envirosuit give air
 		if ( envirosuit ) {
 			ent->client->airOutTime = level.time + 10000;

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1155,7 +1155,7 @@ void ClientSpawn(gentity_t *ent) {
 	ent->r.contents = CONTENTS_BODY;
 	ent->clipmask = MASK_PLAYERSOLID;
 	ent->die = player_die;
-	ent->waterlevel = 0;
+	ent->waterlevel = WATERLEVEL_NONE;
 	ent->watertype = 0;
 	ent->flags = 0;
 	


### PR DESCRIPTION
Follow-up to
- a3e1552c0d9f7f0c31f66191214351737e1cf2eb
- 39bd020933690f0e27f2791afadecb4678b825a9

I did the replacement as such `(waterlevel.*)1` -> `$1WATERLEVEL_FEET`, manually reviewing each replacement.