### PR TITLE
refactor: rename `*_HEIGHT` -> `*_MAXS_Z`

### DIFF
--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1275,7 +1275,7 @@ static void PM_CheckDuck (void)
 
 	if (pm->ps->pm_type == PM_DEAD)
 	{
-		pm->maxs[2] = DEAD_HEIGHT;
+		pm->maxs[2] = DEAD_MAXS_Z;
 		pm->ps->viewheight = DEAD_VIEWHEIGHT;
 		return;
 	}
@@ -1289,7 +1289,7 @@ static void PM_CheckDuck (void)
 		if (pm->ps->pm_flags & PMF_DUCKED)
 		{
 			// try to stand up
-			pm->maxs[2] = DEFAULT_HEIGHT;
+			pm->maxs[2] = MAXS_Z;
 			pm->trace (&trace, pm->ps->origin, pm->mins, pm->maxs, pm->ps->origin, pm->ps->clientNum, pm->tracemask );
 			if (!trace.allsolid)
 				pm->ps->pm_flags &= ~PMF_DUCKED;
@@ -1298,12 +1298,12 @@ static void PM_CheckDuck (void)
 
 	if (pm->ps->pm_flags & PMF_DUCKED)
 	{
-		pm->maxs[2] = CROUCH_HEIGHT;
+		pm->maxs[2] = CROUCH_MAXS_Z;
 		pm->ps->viewheight = CROUCH_VIEWHEIGHT;
 	}
 	else
 	{
-		pm->maxs[2] = DEFAULT_HEIGHT;
+		pm->maxs[2] = MAXS_Z;
 		pm->ps->viewheight = DEFAULT_VIEWHEIGHT;
 	}
 }

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -48,11 +48,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define PLAYER_WIDTH		15
 #define	MINS_Z				-24
-#define DEFAULT_HEIGHT		32
+#define MAXS_Z				32
 #define	DEFAULT_VIEWHEIGHT	26
-#define CROUCH_HEIGHT		16
+#define CROUCH_MAXS_Z		16
 #define CROUCH_VIEWHEIGHT	12
-#define DEAD_HEIGHT			-8
+#define DEAD_MAXS_Z			-8
 #define	DEAD_VIEWHEIGHT		-16
 #define INVUL_RADIUS		42
 

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -601,7 +601,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 
 	self->s.loopSound = 0;
 
-	self->r.maxs[2] = DEAD_HEIGHT;
+	self->r.maxs[2] = DEAD_MAXS_Z;
 
 	// don't allow respawn until the death anim is done
 	// g_forcerespawn may force spawning at some later time


### PR DESCRIPTION
This is a follow-up to 38c41807405aaac8e99b1200e74059e2e2ea05bb
(https://github.com/ioquake/ioq3/pull/828).

This is not really "height" because height is constituted by
`maxs[2] - mins[2]`.
So the new name should be in line with the existing variable
named `MINS_Z`.
