### PR TITLE
docs: `cl_autoRecordDemo`: mention `cg_autoAction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ the above locations, if desired.
 
 ```
   cl_autoRecordDemo                 - record a new demo on each map change
+                                      (similar to cg_autoAction in other
+                                      id Tech 3 games)
   cl_aviFrameRate                   - the framerate to use when capturing video
   cl_aviMotionJpeg                  - use the mjpeg codec when capturing video
   cl_guidServerUniq                 - makes cl_guid unique for each server

--- a/code/q3_ui/ui_demo2.c
+++ b/code/q3_ui/ui_demo2.c
@@ -216,6 +216,7 @@ static void Demos_MenuInit( void ) {
 	protocolLegacy = trap_Cvar_VariableValue("com_legacyprotocol");
 	protocol = trap_Cvar_VariableValue("com_protocol");
 
+	Com_Printf("\n\n\n\n!protocol: %i\n\n\n\n", !protocol);
 	if(!protocol)
 		protocol = trap_Cvar_VariableValue("protocol");
 	if(protocolLegacy == protocol)

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -2883,6 +2883,8 @@ static void UI_LoadDemos( void ) {
 	protocolLegacy = trap_Cvar_VariableValue("com_legacyprotocol");
 	protocol = trap_Cvar_VariableValue("com_protocol");
 
+	Com_Printf("\n\n\n\n!protocol: %i\n\n\n\n", !protocol);
+
 	if(!protocol)
 		protocol = trap_Cvar_VariableValue("protocol");
 	if(protocolLegacy == protocol)


### PR DESCRIPTION
This makes it easier to find the presence of such option
and how exactly it's spelled.
Not just with search inside the README file
but also with search engines.

"Other games" refers to Quake Live, ET: Legacy, and maybe more.
https://etlegacy.readthedocs.io/en/latest/cvars.html#cg-autoaction
