### PR TITLE
Fix: properly check disabled items against segfaults

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -318,7 +318,7 @@ void Cmd_Give_f (gentity_t *ent)
 		it_ent = G_Spawn();
 		VectorCopy( ent->r.currentOrigin, it_ent->s.origin );
 		it_ent->classname = it->classname;
-		G_SpawnItem (it_ent, it);
+		G_SpawnItem (it_ent, it, qtrue);
 		FinishSpawningItem(it_ent );
 		memset( &trace, 0, sizeof( trace ) );
 		Touch_Item (it_ent, ent, &trace);

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -363,15 +363,33 @@ void RespawnItem( gentity_t *ent ) {
 		}
 		master = ent->teammaster;
 
-		for (count = 0, ent = master; ent; ent = ent->teamchain, count++)
-			;
+		for (count = 0, ent = master; ent; ent = ent->teamchain) {
+			// Skip disabled (possibly through a disable_%s cvar) items
+			if ( !ent->item ) {
+				continue;
+			}
+
+			count++;
+		}
+
+		// No valid items to spawn
+		if ( count == 0 ) {
+			return;
+		}
 
 		choice = rand() % count;
 
-		for (count = 0, ent = master; ent && count < choice; ent = ent->teamchain, count++)
-			;
+		for (count = 0, ent = master; ent && count < choice; ent = ent->teamchain) {
+			// Skip disabled (possibly through a disable_%s cvar) items
+			if ( !ent->item ) {
+				continue;
+			}
+
+			count++;
+		}
 	}
 
+	// ent->item should not be nullish to this time
 	if (!ent) {
 		return;
 	}
@@ -883,14 +901,18 @@ Sets the clipping size and plants the object on the floor.
 
 Items can't be immediately dropped to floor, because they might
 be on an entity that hasn't spawned yet.
+
+forceSpawn lets to bypass check for disabled through disable_%s
+cvar items and spawn them anyway. Used for spawning items through
+third party sources like give command.
 ============
 */
-void G_SpawnItem (gentity_t *ent, gitem_t *item) {
+void G_SpawnItem (gentity_t *ent, gitem_t *item, qboolean forceSpawn) {
 	G_SpawnFloat( "random", "0", &ent->random );
 	G_SpawnFloat( "wait", "0", &ent->wait );
 
 	RegisterItem( item );
-	if ( G_ItemDisabled(item) )
+	if ( !forceSpawn && G_ItemDisabled(item) )
 		return;
 
 	ent->item = item;

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -442,7 +442,7 @@ void PrecacheItem (gitem_t *it);
 gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle );
 gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity );
 void SetRespawn (gentity_t *ent, float delay);
-void G_SpawnItem (gentity_t *ent, gitem_t *item);
+void G_SpawnItem (gentity_t *ent, gitem_t *item, qboolean forceSpawn);
 void FinishSpawningItem( gentity_t *ent );
 void Think_Weapon (gentity_t *ent);
 int ArmorIndex (gentity_t *ent);

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -277,7 +277,7 @@ qboolean G_CallSpawn( gentity_t *ent ) {
 	// check item spawn functions
 	for ( item=bg_itemlist+1 ; item->classname ; item++ ) {
 		if ( !strcmp(item->classname, ent->classname) ) {
-			G_SpawnItem( ent, item );
+			G_SpawnItem( ent, item, qfalse );
 			return qtrue;
 		}
 	}


### PR DESCRIPTION
### The issue
I'm using native libraries. On some maps that have _"teamed"_ items, where some of them are disabled through `disable_<item>` cvar, there's always a chance of the server crashing with `SIGSEGV`. Using `give` command to obtain disabled item also leads to segmentation violation.

Qvm on that matter just spawns nothing until the end of the match, but using `give` command will still crash the game.

### Reliable way to reproduce
Build native libraries and copy them into `baseq3`.

Map `q3ctf3` has _"teamed"_ items at the center of the map ( quad, regeneration and invisibility, which are chosen randomly on powerup respawn ). Disable _regeneration_ and _invisibility_.

Here's command to start such server:
```bash
./ioquake3 +set sv_pure 0 +set vm_game 0 +devmap q3ctf3 +set disable_item_regen 1 +set disable_item_invis 1
```

Restart the map with `map_restart`, go to the center of the map, where powerups are spawned, and pickup quad until the server crashes. I sped up the game with `sv_fps 250` and `timescale 100`, so I can observe crash within 10 seconds after standing at one place.

### The fix

When an item is disabled, any entity of that item will have nullish `ent->item`. Currently, I check for this as another spawning condition ( until `forceSpawn` is set ). Making it so requires user to restart the map each time they disable/enable items on the server, which is vanilla behaviour, but I would personally suggest against requiring map restart to apply the changes. As I see, it can be done by checking every couple of ticks whether an item has been enabled to spawn it or to prevent it from spawning if it has been disabled. It would also make code cleaner, as `G_ItemDisabled` says more to the reader than `!ent->item` check.

But still, waiting for your opinions and review. Would be glad to get any!