### PR TITLE
Improve CD key prevalidation

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -4719,26 +4719,23 @@ qboolean CL_CDKeyValidate( const char *key, const char *checksum ) {
 	// for loop gets rid of conditional assignment warning
 	for (i = 0; i < len; i++) {
 		ch = *key++;
-		if (ch>='a' && ch<='z') {
-			ch -= 32;
-		}
-		switch( ch ) {
+		switch(tolower(ch)) {
 		case '2':
 		case '3':
 		case '7':
-		case 'A':
-		case 'B':
-		case 'C':
-		case 'D':
-		case 'G':
-		case 'H':
-		case 'J':
-		case 'L':
-		case 'P':
-		case 'R':
-		case 'S':
-		case 'T':
-		case 'W':
+		case 'a':
+		case 'b':
+		case 'c':
+		case 'd':
+		case 'g':
+		case 'h':
+		case 'j':
+		case 'l':
+		case 'p':
+		case 'r':
+		case 's':
+		case 't':
+		case 'w':
 			sum += ch;
 			continue;
 		default:

--- a/code/q3_ui/ui_cdkey.c
+++ b/code/q3_ui/ui_cdkey.c
@@ -96,26 +96,23 @@ static int UI_CDKeyMenu_PreValidateKey( const char *key ) {
 	}
 
 	while( ( ch = *key++ ) ) {
-			if (ch>='a' && ch<='z') {
-			ch -= 32;
-		}
-		switch( ch ) {
+		switch(tolower(ch)) {
 		case '2':
 		case '3':
 		case '7':
-		case 'A':
-		case 'B':
-		case 'C':
-		case 'D':
-		case 'G':
-		case 'H':
-		case 'J':
-		case 'L':
-		case 'P':
-		case 'R':
-		case 'S':
-		case 'T':
-		case 'W':
+		case 'a':
+		case 'b':
+		case 'c':
+		case 'd':
+		case 'g':
+		case 'h':
+		case 'j':
+		case 'l':
+		case 'p':
+		case 'r':
+		case 's':
+		case 't':
+		case 'w':
 			continue;
 		default:
 			return -1;

--- a/code/q3_ui/ui_cdkey.c
+++ b/code/q3_ui/ui_cdkey.c
@@ -96,23 +96,26 @@ static int UI_CDKeyMenu_PreValidateKey( const char *key ) {
 	}
 
 	while( ( ch = *key++ ) ) {
+			if (ch>='a' && ch<='z') {
+			ch -= 32;
+		}
 		switch( ch ) {
 		case '2':
 		case '3':
 		case '7':
-		case 'a':
-		case 'b':
-		case 'c':
-		case 'd':
-		case 'g':
-		case 'h':
-		case 'j':
-		case 'l':
-		case 'p':
-		case 'r':
-		case 's':
-		case 't':
-		case 'w':
+		case 'A':
+		case 'B':
+		case 'C':
+		case 'D':
+		case 'G':
+		case 'H':
+		case 'J':
+		case 'L':
+		case 'P':
+		case 'R':
+		case 'S':
+		case 'T':
+		case 'W':
 			continue;
 		default:
 			return -1;


### PR DESCRIPTION
Fix #877 

https://github.com/ioquake/ioq3/blob/5d810e50d2b682981dd1cdadd35f755037e0947b/code/client/cl_main.c#L4720-L4747

This snippet in cl_main.c already includes code to ignore case when validating CD key. The issue was that the UI_CDKeyMenu_PreValidateKey function diverged from this and prematurely failed. 