### PR TITLE
fix: \cl_shownet may print invalid entity number

### DIFF
--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2016 Eugene
 
 This file is part of Quake III Arena source code.
 
@@ -974,6 +975,8 @@ void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to,
 		Com_Error( ERR_DROP, "invalid entityState field count" );
 	}
 
+	to->number = number;
+
 	// shownet 2/3 will interleave with other printed info, -1 will
 	// just print the delta records`
 	if ( cl_shownet && ( cl_shownet->integer >= 2 || cl_shownet->integer == -1 ) ) {
@@ -982,8 +985,6 @@ void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to,
 	} else {
 		print = 0;
 	}
-
-	to->number = number;
 
 	for ( i = 0, field = entityStateFields ; i < lc ; i++, field++ ) {
 		fromF = (int *)( (byte *)from + field->offset );


### PR DESCRIPTION
Cherry-picked from
https://github.com/ec-/Quake3e/commit/76da681398c030bfe3db5fb76411a07b0b20ab9b.
