### PR TITLE
Read and write CD key in lowercase

### DIFF
--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2485,6 +2485,8 @@ void Com_ReadCDKey( const char *filename ) {
 	FS_Read( buffer, 16, f );
 	FS_FCloseFile( f );
 
+	Q_strlwr(buffer);
+
 	if (CL_CDKeyValidate(buffer, NULL)) {
 		Q_strncpyz( cl_cdkey, buffer, 17 );
 	} else {
@@ -2554,6 +2556,8 @@ static void Com_WriteCDKey( const char *filename, const char *ikey ) {
 		Com_Printf ("Couldn't write CD key to %s.\n", fbuffer );
 		goto out;
 	}
+
+	Q_strlwr(key);
 
 	FS_Write( key, 16, f );
 


### PR DESCRIPTION
#877 again

#880 doesn't solve the problem when connecting to a server, since official servers use the 1999 .pak vm code. Reading and writing the key in lowercase to the q3key path in ioq3 should just solve it completely.